### PR TITLE
issue13: Fix style

### DIFF
--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -106,7 +106,7 @@ static bool daemonize(void)
 	if (daemon(0, 0) == 0) {
 		pid = getpid();
 		pid_file = fopen(pid_file_path, "w+");
-		
+
 		if (pid_file != NULL) {
 			fprintf(pid_file, "%d\n", pid);
 			fclose(pid_file);


### PR DESCRIPTION
There are two style fixes
- Add a missing space between "if" and "(".
- Remove trailing spaces.
