### PR TITLE
Simplify return expression

### DIFF
--- a/server/test/testMain.cc
+++ b/server/test/testMain.cc
@@ -50,9 +50,7 @@ bool checkMagicNumber(string& actualEnvironment)
 	stringstream ssMagicNumberString;
 	ssMagicNumberString << "MAGICNUMBER=" << randomNumber;
 	string MagicNumber = ssMagicNumberString.str();
-	if(actualEnvironment == MagicNumber)
-		return true;
-	return false;
+	return actualEnvironment == MagicNumber;
 }
 
 void endChildProcess(GPid child_pid, gint status, gpointer data)


### PR DESCRIPTION
The following style return expressions are verbose:

```
if (XXX)
    return true;
return false;
```

You can write the above expressions by the following simple
return expression:

```
return XXX;
```
