### PR TITLE
[mlpl] Rename va_list version of StringUtils::sprintf() to StringUtils::...

### DIFF
--- a/server/mlpl/src/Logger.cc
+++ b/server/mlpl/src/Logger.cc
@@ -50,7 +50,7 @@ void Logger::log(LogLevel level, const char *fileName, int lineNumber,
 	                                     lineNumber);
 	va_list ap;
 	va_start(ap, fmt);
-	string body = StringUtils::sprintf(fmt, ap);
+	string body = StringUtils::vsprintf(fmt, ap);
 	va_end(ap);
 
 	fprintf(stderr, "%s%s", header.c_str(), body.c_str());

--- a/server/mlpl/src/StringUtils.cc
+++ b/server/mlpl/src/StringUtils.cc
@@ -107,12 +107,12 @@ string StringUtils::sprintf(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	string str = sprintf(fmt, ap);
+	string str = vsprintf(fmt, ap);
 	va_end(ap);
 	return str;
 }
 
-string StringUtils::sprintf(const char *fmt, va_list ap)
+string StringUtils::vsprintf(const char *fmt, va_list ap)
 {
 	char bufOnStack[SPRINTF_BUF_ON_STACK_LENGTH];
 

--- a/server/mlpl/src/StringUtils.h
+++ b/server/mlpl/src/StringUtils.h
@@ -50,7 +50,7 @@ public:
 	static bool casecmp(const char *str1, string &str2);
 	static bool casecmp(string &str1, string &str2);
 	static string sprintf(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
-	static string sprintf(const char *fmt, va_list ap);
+	static string vsprintf(const char *fmt, va_list ap);
 	static bool isNumber(const char *str, bool *isFloat = NULL);
 	static bool isNumber(const string &str, bool *isFloat = NULL);
 	static string toString(int number);


### PR DESCRIPTION
[mlpl] Rename va_list version of StringUtils::sprintf() to StringUtils::vsprintf().

Because many compile time warnings are occured on my environment:

```
ActionManager.cc:190:3: warning: deprecated conversion from string constant to 'va_list {aka char*}' [-Wwrite-strings]
```

and they cause crash at runtime.
