### PR TITLE
[UnifiedDataStore] Use pre-increment of an iterator to improve performance.

### DIFF
--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -135,7 +135,7 @@ struct UnifiedDataStore::PrivateContext
 			itemFetchedSignal.connect(closure);
 		remainingArmsCount = arms.size();
 		ArmBaseVectorIterator arms_it = arms.begin();
-		for (size_t i = 0; arms_it != arms.end(); i++, arms_it++) {
+		for (size_t i = 0; arms_it != arms.end(); i++, ++arms_it) {
 			ArmBase *arm = *arms_it;
 
 			if (targetServerId != ALL_SERVERS) {


### PR DESCRIPTION
In general, a post-increment operation of an iterator creates a temporary
object. Since it is often a class, its constructor is executed. As a result,
a post-increment operation is slightly slower than the pre-increment.
