### PR TITLE
[client] Remove duplicated file

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -80,7 +80,6 @@ nobase_dist_hatohol_client_DATA = \
 	static/js/hatohol_selector_dialog.js \
 	static/js/hatohol_trigger_selector.js \
 	static/js/hatohol_actor_mail_dialog.js \
-	static/js/hatohol_user_roles_editor.js \
 	viewer/urls.py \
 	viewer/__init__.py \
 	viewer/models.py \


### PR DESCRIPTION
It causes installation failure.

  /usr/bin/install: will not overwrite just-created `/usr/local/libexec/hatohol/client/static/js/hatohol_user_roles_editor.js' with`static/js/hatohol_user_roles_editor.js'
  make[3]: **\* [install-nobase_dist_hatohol_clientDATA] Error 1
