### PR TITLE
[HostResourceQueryOption] Fix confusing treatment of table name alias

### DIFF
--- a/server/src/DBClientHatohol.h
+++ b/server/src/DBClientHatohol.h
@@ -158,7 +158,7 @@ public:
 	virtual ~HostResourceQueryOption();
 
 	// Overriding of virtual methods
-	virtual std::string getCondition(const std::string &varName = "") const;
+	virtual std::string getCondition(const std::string &tableAlias = "") const;
 
 	virtual ServerIdType getTargetServerId(void) const;
 	virtual void setTargetServerId(const ServerIdType &targetServerId);
@@ -167,20 +167,16 @@ public:
 	virtual uint64_t getTargetHostgroupId(void) const;
 	virtual void setTargetHostgroupId(uint64_t targetHostGroupId);
 
-	virtual std::string getTableNameForServerId(void) const;
-	virtual void setTableNameForServerId(const std::string &name);
-
-	virtual void enableTableVariable(const bool &enable = true) const;
-
 protected:
 	void setServerIdColumnName(const std::string &name) const;
-	std::string getServerIdColumnName(void) const;
+	std::string getServerIdColumnName(
+	  const std::string &tableAlias = "") const;
 	void setHostGroupIdColumnName(const std::string &name) const;
-	std::string getHostGroupIdColumnName(void) const;
+	std::string getHostGroupIdColumnName(
+	  const std::string &tableAlias = "") const;
 	void setHostIdColumnName(const std::string &name) const;
-	std::string getHostIdColumnName(void) const;
-	void setTableVariableName(const std::string &name) const;
-	std::string getTableVariableName(void) const;
+	std::string getHostIdColumnName(
+	  const std::string &tableAlias = "") const;
 	static void appendCondition(std::string &cond,
 	                            const std::string &newCond);
 	static std::string makeCondition(
@@ -285,7 +281,7 @@ public:
 	void addEventInfo(EventInfo *eventInfo);
 	void addEventInfoList(const EventInfoList &eventInfoList);
 	HatoholError getEventInfoList(EventInfoList &eventInfoList,
-	                              EventsQueryOption &option);
+	                              const EventsQueryOption &option);
 	void setEventInfoList(const EventInfoList &eventInfoList,
 	                      const ServerIdType &serverId);
 

--- a/server/test/testDBClientHatohol.cc
+++ b/server/test/testDBClientHatohol.cc
@@ -32,9 +32,9 @@ namespace testDBClientHatohol {
 
 class TestHostResourceQueryOption : public HostResourceQueryOption {
 public:
-	string callGetServerIdColumnName(void) const
+	string callGetServerIdColumnName(const string &tableAlias = "") const
 	{
-		return getServerIdColumnName();
+		return getServerIdColumnName(tableAlias);
 	}
 
 	static
@@ -1106,29 +1106,23 @@ void test_conditionForAdminWithTargetServerAndHost(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_eventQueryOptionDefaultTableName(void)
-{
-	HostResourceQueryOption option;
-	cppcut_assert_equal(string(""), option.getTableNameForServerId());
-}
-
-void test_eventQueryOptionSetTableName(void)
-{
-	HostResourceQueryOption option;
-	const string tableName = "test_event";
-	option.setTableNameForServerId(tableName);
-	cppcut_assert_equal(tableName, option.getTableNameForServerId());
-}
-
 void test_eventQueryOptionGetServerIdColumnName(void)
 {
-	TestHostResourceQueryOption option;
-	const string tableName = "test_event";
-	const string expectedServerIdColumnName
-	  = tableName + "." + serverIdColumnName;
-	option.setTableNameForServerId(tableName);
-	cppcut_assert_equal(expectedServerIdColumnName,
-			    option.callGetServerIdColumnName());
+	HostResourceQueryOption option(USER_ID_SYSTEM);
+	const string tableAlias = "test_event_table_alias";
+	option.setTargetServerId(26);
+	option.setTargetHostgroupId(48);
+	option.setTargetHostId(32);
+	string expect = StringUtils::sprintf(
+	                  "%s.%s=26 AND %s.%s=32 AND %s.%s=48",
+			  tableAlias.c_str(),
+			  serverIdColumnName.c_str(),
+			  tableAlias.c_str(),
+			  hostIdColumnName.c_str(),
+			  tableAlias.c_str(),
+			  hostGroupIdColumnName.c_str());
+	cppcut_assert_equal(expect, option.getCondition(tableAlias));
+
 }
 
 void test_makeConditionComplicated(void)


### PR DESCRIPTION
There are few issues in the previous implementation:
- enableTableVariable() was defined as const member function but
  it modifies its contents.
- getCondition() had an arugument "varName" but it never be used.
- There were 2 functions for a same purpose:
  - setTableNameForServerId()
  - setTableVariableName()

Now I think HostResourceQueryOption shouldn't hold table name
and a flag like "useTableVariable" because caller of
DBClientHatohol::getEventInfoList() or DBClientHatohol::
getTriggerInfoList() doesn't want that the content of
HostResourceQueryOption is modified.
