### PR TITLE
[client][utils] Check existence of hostId at getHostName()

### DIFF
--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -160,7 +160,7 @@ function getServerName(server, serverId) {
 }
 
 function getHostName(server, hostId) {
-  if (!server)
+  if (!server || !server["hosts"] || !(hostId in server["hosts"]))
     return "Unknown:" + hostId;
   return server["hosts"][hostId]["name"];
 }


### PR DESCRIPTION
An error is occured on my broken environment (old data are remained
and cannot connect to a host):

  [http://localhost:8000/static/js/utils.js:165]
  TypeError: server.hosts[hostId] is undefined

Although it's not happend on usual cases (maybe), we should check
existence of the element before accessing to it.
