### PR TITLE
[server][DBClientConfig] Make a build fail when 'new CacheServiceDBClien...

### DIFF
--- a/server/src/CacheServiceDBClient.h
+++ b/server/src/CacheServiceDBClient.h
@@ -42,6 +42,13 @@ public:
 	DBClientConfig  *getConfig(void);
 
 private:
+	/**
+	 * An instance of this class is designed only to used
+	 * as a stack variable. The following method as a private is to
+	 * prevent the dynamic allocation with a 'new' operator.
+	 */
+	static void *operator new(size_t) {return NULL;}
+
 	struct PrivateContext;
 
 	template <class T> T *get(DBDomainId domainId);

--- a/server/test/testCacheServiceDBClient.cc
+++ b/server/test/testCacheServiceDBClient.cc
@@ -217,4 +217,16 @@ void test_getUser(void)
 	assertType(DBClientUser, cache.getUser());
 }
 
+#if 0
+// The following statement makes a build fail. The behavior is correct,
+// because the new operator is defined as a private to avoid it from being
+// used. To check the effect, replace the above '#if 0' with '#if 1'.
+// Or should we do a test that tries to compile the following function and
+// expects a failure ?
+void test_new(void)
+{
+	CacheServiceDBClient *cache = new CacheServiceDBClient();
+}
+#endif
+
 } // namespace testCacheServiceDBClient


### PR DESCRIPTION
CacheServiceDBClient must be used as a stack variable. This patch makes a build fail if it is created with 'new'.
