### PR TITLE
[DBClientHatohol] Fix wrong count of triggers

### DIFF
--- a/server/src/DBClientHatohol.cc
+++ b/server/src/DBClientHatohol.cc
@@ -1775,9 +1775,7 @@ size_t DBClientHatohol::getNumberOfTriggers(const TriggersQueryOption &option,
                                             TriggerSeverityType severity)
 {
 	DBAgent::SelectExArg arg(tableProfileTriggers);
-	string stmt =
-	  StringUtils::sprintf("count(distinct %s)",
-	    option.getColumnName(IDX_TRIGGERS_HOST_ID).c_str());
+	string stmt = "count(*)";
 	arg.add(stmt, SQL_COLUMN_TYPE_INT);
 
 	// from

--- a/server/test/DBClientTest.cc
+++ b/server/test/DBClientTest.cc
@@ -109,6 +109,15 @@ TriggerInfo testTriggerInfo[] =
 	"hostX2",                 // hostName,
 	"TEST Trigger 1b",        // brief,
 },{
+	1,                        // serverId
+	4,                        // id
+	TRIGGER_STATUS_PROBLEM,   // status
+	TRIGGER_SEVERITY_INFO,    // severity
+	{1362957197,0},           // lastChangeTime
+	235012,                   // hostId,
+	"hostX1",                 // hostName,
+	"TEST Trigger 1c",        // brief,
+},{
 	3,                        // serverId
 	2,                        // id
 	TRIGGER_STATUS_PROBLEM,   // status


### PR DESCRIPTION
The previous implementation of getNumberOfTriggers() counts number of
hosts instead of triggers!
