### PR TITLE
[ActionManager] Ignore unused "_actorInfo" arguments of execCommandAction()

### DIFF
--- a/server/src/ActionManager.cc
+++ b/server/src/ActionManager.cc
@@ -731,7 +731,8 @@ void ActionManager::execCommandAction(const ActionDef &actionDef,
 	// WaitingCommandActionInfo. In the case, the action is queued
 	// and will be executed later.
 	if (waitCmdInfo) {
-		_actorInfo->logId = waitCmdInfo->logId;
+		if (_actorInfo)
+			_actorInfo->logId = waitCmdInfo->logId;
 		return;
 	}
 


### PR DESCRIPTION
The arugument is used only by test code and it's always NULL in
the actual code. So it will cause crash on the actual environment!
