### PR TITLE
[hatohol_server_edit_dialog] Remove a meaningless statement.

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog.js
+++ b/client/static/js/hatohol_server_edit_dialog.js
@@ -51,7 +51,6 @@ var HatoholServerEditDialog = function(params) {
   //
   function addButtonClickedCb() {
     if (validateParameters()) {
-      makeQueryData();
       if (self.server)
         hatoholInfoMsgBox(gettext("Now updating the server ..."));
       else


### PR DESCRIPTION
makeQueryData() makes an object for POST/PUT and returns it.
However, the line never uses the returned object and has
no effect.

Actually, the function is called in postAddServer() and used.
