### PR TITLE
Fix warning message on CentOS environ.

### DIFF
--- a/server/src/CacheServiceDBClient.h
+++ b/server/src/CacheServiceDBClient.h
@@ -46,6 +46,9 @@ private:
 	 * An instance of this class is designed to be defined
 	 * only as a stack variable. The following as a private makes it
 	 * impossible to allocate an instance with a 'new' operator.
+	 *
+	 * 'new' operator must not return NULL unless it is declared 'throw()'.
+	 * So, this operator returns 1 of void * type.
 	 */
 	static void *operator new(size_t) {return (void *)1;}
 


### PR DESCRIPTION
When I try to build hatohol on CentOS environ, following messages are
occured (I'm using Japanese environment):

CacheServiceDBClient.h: In static member function ‘static void*
CacheServiceDBClient::operator new(size_t)’:
CacheServiceDBClient.h:50: 警告: ‘operator new’ must not return NULL
unless it is declared ‘throw()’ (or -fcheck-new is in effect)
