### PR TITLE
[Autotools] Use "foreign" style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,8 @@
 *.in
 .deps/
 .libs/
-AUTHORS
-INSTALL
 Makefile
 Makefile.in
-NEWS
 aclocal.m4
 autom4te.cache/
 config.guess
@@ -38,4 +35,3 @@ test/fixtures/testDatabase-hatohol.db
 test/fixtures/*.o
 tools/hatohol-config-db-creator
 tools/hatohol-config-db-creator.o
-touch

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,13 +1,7 @@
 #!/bin/sh
 
-touch AUTHORS NEWS touch
 if [ ! -d m4 ]; then
   mkdir m4
-fi
-
-# autoreconf needs README
-if [ ! -f README ]; then
-  ln -s README.md README
 fi
 
 aclocal

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.63)
 
 AC_INIT(hatohol, 14.06)
-AM_INIT_AUTOMAKE([1.9 no-dist-gzip dist-bzip2 tar-pax])
+AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADER(config.h)
 


### PR DESCRIPTION
We don't use the GNU standards package style. For example, we don't have
AUTHORS, INSTALL and NEWS files.

See also: http://www.gnu.org/software/automake/manual/automake.html#Strictness
