### PR TITLE
Support aclocal flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = server client data/init.d
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 EXTRA_DIST = autogen.sh README.md hatohol.spec
 


### PR DESCRIPTION
We can't create Cutter supported configure.in when Cutter isn't
installed with --prefix=/usr.

With this change, we can use Cutter installed by --prefix=/tmp/local
by the following command line:

```
% export ACLOCAL_FLAGS="-I /tmp/local/share/aclocal"
% ./autogen.sh
% ./configure --help | grep cutter
  --with-cutter           Use Cutter (default: auto)
```
