### PR TITLE
Split SQL set for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ compiler:
 install:
   - server/misc/setup-cutter.sh
   - sudo apt-get install -qq -y autotools-dev libglib2.0-dev libjson-glib-dev libsoup2.4-dev libmysqlclient-dev sqlite3 ndoutils-nagios3-mysql uuid-dev npm python-pip expect python-dev libqpidmessaging2-dev libqpidtypes1-dev libqpidcommon2-dev qpidd
-  - mysql -u root -e "GRANT all on ndoutils.* TO ndoutils@localhost IDENTIFIED BY 'admin';"
-  - mysql -u root -e "CREATE DATABASE hatohol_client;"
-  - mysql -u root -e "GRANT ALL PRIVILEGES ON hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';"
-  - mysql -u root -e "CREATE DATABASE test_hatohol_client;"
-  - mysql -u root -e "GRANT ALL PRIVILEGES ON test_hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';"
+  - mysql -u root < data/test/setup.sql
   - npm install -g mocha
   - npm install -g expect.js
   - npm install -g sinon

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = server client data/init.d
+SUBDIRS = server client data data/init.d
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 EXTRA_DIST = autogen.sh README.md hatohol.spec

--- a/configure.ac
+++ b/configure.ac
@@ -193,11 +193,13 @@ dnl **************************************************************
 AC_OUTPUT([
 Makefile
 hatohol.spec
+data/Makefile
 data/init.d/Makefile
 data/init.d/debian/hatohol.debian
 data/init.d/debian/Makefile
 data/init.d/centos/hatohol.centos
 data/init.d/centos/Makefile
+data/test/Makefile
 server/Makefile
 server/mlpl/Makefile
 server/mlpl/src/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = test

--- a/data/test/Makefile.am
+++ b/data/test/Makefile.am
@@ -1,0 +1,2 @@
+EXTRA_DIST = \
+	setup.sql

--- a/data/test/setup.sql
+++ b/data/test/setup.sql
@@ -1,0 +1,5 @@
+GRANT all on ndoutils.* TO ndoutils@localhost IDENTIFIED BY 'admin';
+CREATE DATABASE hatohol_client;
+GRANT ALL PRIVILEGES ON hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';
+CREATE DATABASE test_hatohol_client;
+GRANT ALL PRIVILEGES ON test_hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';


### PR DESCRIPTION
The SQL set is useful to create a local development environment. If the
SQL set is stored in a file, we don't need to copy & paste from
.travis.yml. We just run the following command:

```
% mysql -u root < data/test/setup.sql
```
