### PR TITLE
Fix path to the top directory

### DIFF
--- a/server/mlpl/test/run-test.sh
+++ b/server/mlpl/test/run-test.sh
@@ -3,7 +3,7 @@
 unset LANG
 
 export BASE_DIR="`dirname $0`"
-top_dir="$BASE_DIR/.."
+top_dir="$BASE_DIR/../../.."
 top_dir="`cd $top_dir; pwd`"
 
 if test x"$NO_MAKE" != x"yes"; then

--- a/server/test/run-test.sh
+++ b/server/test/run-test.sh
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH=../src/.libs:../mlpl/src/.libs:$LD_LIBRARY_PATH
 export HATOHOL_ACTION_LD_LIBRARY_PATH=../src/.libs:../mlpl/src/.libs
 
 export BASE_DIR="`dirname $0`"
-top_dir="$BASE_DIR/.."
+top_dir="$BASE_DIR/../.."
 top_dir="`cd $top_dir; pwd`"
 
 if test x"$NO_MAKE" != x"yes"; then


### PR DESCRIPTION
It enables debugging tests on GDB like:

```
% CUTTER_DEBUG=yes server/mlpl/test/run-test.sh
```
