### PR TITLE
[configure] Add --enable-debug option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,20 @@ AC_DEFINE_UNQUOTED(LIBEXECDIR, "`eval echo $libexecdir`", "Prefix for libexec di
 dnl **************************************************************
 dnl Optional C++ compiler flags
 dnl **************************************************************
-OPT_CXXFLAGS="-Wall -g3 -O2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+OPT_CXXFLAGS="-Wall -g3 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+
+enable_debug_default=no
+AC_ARG_ENABLE([debug],
+  [AS_HELP_STRING([--enable-debug],
+                  [Enable debug build (default is $enable_debug_default)])],
+  [],
+  [enable_debug=$enable_debug_default])
+
+if test "$enable_debug" = "yes"; then
+  OPT_CXXFLAGS="$OPT_CXXFLAGS -O0"
+else
+  OPT_CXXFLAGS="$OPT_CXXFLAGS -O2"
+fi
 
 dnl **************************************************************
 dnl Checks for GLib


### PR DESCRIPTION
No compiler optimization build is easy to debug with debugger. It is
useful for developers.

If --enable-debug option is used on configure, we can build Hatohol
with no compiler optimization. The default behavior isn't changed.
(= -O2 build)
