### PR TITLE
[testDBClientAction] Remove a print statement for debugging.

### DIFF
--- a/server/test/testDBClientAction.cc
+++ b/server/test/testDBClientAction.cc
@@ -753,7 +753,6 @@ static void _assertGetActionWithSeverity(const TriggerSeverityType &severity,
 		cppcut_assert_equal((size_t)1, actionDefList.size());
 		// check the content
 		const ActionDef &actual = *actionDefList.begin();
-		g_print("\nexpect: %d, action id: %d\n", expectedActionIdx, actual.id);
 		assertEqual(testActionDef[expectedActionIdx], actual);
 	}
 }


### PR DESCRIPTION
This was probably written to debug and has been forgetten to be
removed.
