### PR TITLE
 [HatoholAddActionDialog] Remove unexpected "Select" item for the default state of the trigger selector

### DIFF
--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -94,8 +94,9 @@ var HatoholAddActionDialog = function(addSucceededCb) {
       new HatoholHostSelector(self.selectedId[IDX_SELECTED_SERVER],
                               self.selectedId[IDX_SELECTED_HOST_GROUP],
                               hostSelectedCb);
-    } else
+    } else {
       setSelectedHostId(val);
+    }
   })
 
   $("#selectTriggerId").change(function() {
@@ -104,8 +105,9 @@ var HatoholAddActionDialog = function(addSucceededCb) {
       new HatoholTriggerSelector(self.selectedId[IDX_SELECTED_SERVER],
                                  self.selectedId[IDX_SELECTED_HOST],
                                  triggerSelectedCb);
-    } else
+    } else {
       setSelectedTriggerId(val);
+    }
   })
 
   function serverSelectedCb(serverInfo) {


### PR DESCRIPTION
It shouldn't be shown until a host is selected.
