### PR TITLE
Split test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
   - gcc
   - clang
 env:
-  - RUN_TEST="MLPL_LOGGER_LEVEL=WARN ./server/mlpl/test/run-test.sh"
+  - RUN_TEST="env MLPL_LOGGER_LEVEL=WARN ./server/mlpl/test/run-test.sh"
   - RUN_TEST="cd server/test && MLPL_LOGGER_LEVEL=WARN ./run-test.sh"
   - RUN_TEST="cd server/tools/test && MLPL_LOGGER_LEVEL=WARN ./run-test.sh"
   - RUN_TEST="cd client/test/python && ./run-test.sh"


### PR DESCRIPTION
There are five test suites in Hatohol. If one of them is failed, Travis CI reports Hatohol's test is failed.

Then we need to find what test is failed from all test suites. It is hard.

This change splits Travis CI tasks. One task runs only one test suite. Is is not changed that "if one of them is failed, Travis CI reports Hatohol's test is failed". But the next step is changed. We can find the failed test from one test suite not all test suites. It is easy to find the failed test.
