### PR TITLE
Fix MLPL_LIBS path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ dnl **************************************************************
 dnl Flag setting for MLPL
 dnl **************************************************************
 MLPL_CFLAGS=-I\${abs_top_srcdir}/server/mlpl/src
-MLPL_LIBS=\${abs_top_srcdir}/server/mlpl/src/libmlpl.la
+MLPL_LIBS=\${top_builddir}/server/mlpl/src/libmlpl.la
 
 AC_SUBST(MLPL_CFLAGS)
 AC_SUBST(MLPL_LIBS)


### PR DESCRIPTION
It should be build directory not source directory. Because .la is a
built file.

And it should be relative path to be recognized as internal library.
