### PR TITLE
Add targets to delete merged branches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,3 +6,19 @@ EXTRA_DIST = autogen.sh README.md hatohol.spec
 rpm:    dist hatohol.spec
 	rpmbuild -ta $(distdir).tar.bz2
 
+remove-merged-branches: remove-local-merged-branches
+remove-merged-branches: remove-remote-merged-branches
+
+remove-local-merged-branches:
+	git branch --merged | \
+	  grep -v '^* ' | \
+	  grep -v ' master' | \
+	  xargs -I BRANCH git branch --delete BRANCH
+
+remove-remote-merged-branches:
+	git branch --remote --merged | \
+	  grep '^  origin/' | \
+	  sed -e 's,^  origin/,,' | \
+	  grep -v ' -> ' | \
+	  grep -v '^master$$' | \
+	  xargs -I BRANCH git push origin :BRANCH


### PR DESCRIPTION
How to use:

```
% make remove-local-merged-branches
```

Normally, we don't need to use `remove-remote-merged-branches` if we remove a branch when the branch is merged.
