### PR TITLE
Fix a bug that multiple incidents can be created for one event

### DIFF
--- a/server/test/DBClientTest.cc
+++ b/server/test/DBClientTest.cc
@@ -435,23 +435,6 @@ ActionDef testActionDef[] = {
 	"3",                    // command
 	0,                      // timeout
 	0,                      // ownerUserId
-}, {
-	0,                      // id (this field is ignored)
-	ActionCondition(
-	  0,                        // enableBits
-	  0,                        // serverId
-	  0,                        // hostId
-	  0,                        // hostgroupId
-	  0,                        // triggerId
-	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
-	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
-	  CMP_EQ_GT                 // triggerSeverityCompType;
-	), // condition
-	ACTION_INCIDENT_SENDER, // type
-	"",                     // working dir
-	"3",                    // command
-	0,                      // timeout
-	0,                      // ownerUserId
 },
 };
 

--- a/server/test/testActionManager.cc
+++ b/server/test/testActionManager.cc
@@ -1362,9 +1362,26 @@ void test_checkEventsWithMultipleIncidentSender(void)
 {
 	// prepare two incident sender actions
 	setupTestDBAction();
+	ActionDef actDef = {
+	  0,                      // id (this field is ignored)
+	  ActionCondition(
+	    ACTCOND_TRIGGER_STATUS | ACTCOND_TRIGGER_SEVERITY, // enableBits
+	    0,                        // serverId
+	    0,                        // hostId
+	    0,                        // hostgroupId
+	    0,                        // triggerId
+	    TRIGGER_STATUS_PROBLEM,   // triggerStatus
+	    TRIGGER_SEVERITY_INFO,    // triggerSeverity
+	    CMP_EQ_GT                 // triggerSeverityCompType;
+	  ), // condition
+	  ACTION_INCIDENT_SENDER, // type
+	  "",                     // working dir
+	  "3",                    // command
+	  0,                      // timeout
+	  0,                      // ownerUserId
+	};
 	ActionIdType expectedActionId = 1;
 	DBClientAction dbAction;
-	ActionDef &actDef = testActionDef[NumTestActionDef - 1];
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	dbAction.addAction(actDef, privilege);
 	dbAction.addAction(actDef, privilege);


### PR DESCRIPTION
Because previous implementation of shouldSkipIncidenSender() never returns true.
