### PR TITLE
[DBClientAction] Add a workaround for broken isIncidentSenderEnabled()

### DIFF
--- a/server/src/DBClientAction.cc
+++ b/server/src/DBClientAction.cc
@@ -859,9 +859,12 @@ bool DBClientAction::isIncidentSenderEnabled(void)
 	ActionDefList actionDefList;
 	ActionsQueryOption option(USER_ID_SYSTEM);
 	option.setActionType(ACTION_INCIDENT_SENDER);
-	option.setMaximumNumber(1);
+	// TODO: We have to fix the validator in getActionList() to re-enable
+	//       the following line because the validator may drop the action
+	//       after fetching it from DB.
+	//option.setMaximumNumber(1);
 	getActionList(actionDefList, option);
-	return (actionDefList.size() == 1);
+	return (actionDefList.size() > 0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
It always returns false when the first action in DB is invalid
(the corresponding incident tracker doesn't exist).

The root cause is the validator in getActionList(). It may drop
fetched records, so it conflicts with "LIMIT" clause of SQL.
We should fix getActionList() side to resolve this issue completely.
