### PR TITLE
[SQLUtils] Remove an unused method: createItemData.

### DIFF
--- a/server/src/SQLUtils.h
+++ b/server/src/SQLUtils.h
@@ -43,18 +43,6 @@ public:
 	static std::string getFullName(const ColumnDef *columnDefs,
 	                               const size_t &index);
 
-	/**
-	 * create ItemDataPtr from a string.
-	 *
-	 * @columnDef A pointer of ColumnDef object.
-	 * @value A string of the value.
-	 * @return An ItemDataPtr that refers an ItemData object on success.
-	 *         When an error, the returned ItemDataPtr doesn't
-	 *         have a reference (i.e. hasData() returns falase).
-	 */
-	static ItemDataPtr createItemData(const ColumnDef *columnDef,
-	                                  const std::string &value);
-
 	static ItemDataPtr createFromString(const char *str,
 	                                    SQLColumnType type);
 

--- a/server/test/testSQLUtils.cc
+++ b/server/test/testSQLUtils.cc
@@ -51,24 +51,6 @@ static ColumnDef testDefChar = {
 	SQL_COLUMN_TYPE_CHAR, 8, 0
 };
 
-template<class ValueType, class ItemDataType>
-void _assertCreateItemData(const ColumnDef *columnDefinition,
-                           ValueType data)
-{
-	stringstream ss;
-	ss << data;
-	string value = ss.str();
-	ItemDataPtr dataPtr = SQLUtils::createItemData(columnDefinition, value);
-	const ItemDataType *createdItemData =
-	  dynamic_cast<const ItemDataType *>(&*dataPtr);
-	cppcut_assert_not_null(createdItemData);
-	cppcut_assert_equal(testItemId, createdItemData->getId());
-	ValueType actual = createdItemData->get();
-	cppcut_assert_equal(data, actual);
-}
-#define assertCreateItemData(VT, IDT, DEF, V) \
-cut_trace((_assertCreateItemData<VT,IDT>(DEF, V)))
-
 // ---------------------------------------------------------------------------
 // Test cases
 // ---------------------------------------------------------------------------
@@ -81,60 +63,6 @@ void test_getFullName(void)
 	string expect =
 	  StringUtils::sprintf("%s.%s", def.tableName, def.columnName);
 	cppcut_assert_equal(expect, actual);
-}
-
-void test_itemInt(void)
-{
-	int data = 10;
-	assertCreateItemData(int, ItemInt, &testDefInt, data);
-}
-
-void test_itemIntNegative(void)
-{
-	int data = -510;
-	assertCreateItemData(int, ItemInt, &testDefInt, data);
-}
-
-void test_itemBiguint32bitMax(void)
-{
-	uint64_t data = 0x00000000ffffffff;
-	assertCreateItemData(uint64_t, ItemUint64, &testDefBiguint, data);
-}
-
-void test_itemBiguint64bitMin(void)
-{
-	uint64_t data = 0x0000000100000000;
-	assertCreateItemData(uint64_t, ItemUint64, &testDefBiguint, data);
-}
-
-void test_itemBiguint64bitHalf7f(void)
-{
-	uint64_t data = 0x7fffffffffffffff;
-	assertCreateItemData(uint64_t, ItemUint64, &testDefBiguint, data);
-}
-
-void test_itemBiguint64bitHalf80(void)
-{
-	uint64_t data = 0x8000000000000000;
-	assertCreateItemData(uint64_t, ItemUint64, &testDefBiguint, data);
-}
-
-void test_itemBiguint64bitMax(void)
-{
-	uint64_t data = 0xffffffffffffffff;
-	assertCreateItemData(uint64_t, ItemUint64, &testDefBiguint, data);
-}
-
-void test_itemVarchar(void)
-{
-	string data = "foo";
-	assertCreateItemData(string, ItemString, &testDefVarchar, data);
-}
-
-void test_itemChar(void)
-{
-	string data = "foo";
-	assertCreateItemData(string, ItemString, &testDefChar, data);
 }
 
 void test_createFromStringInt(void)


### PR DESCRIPTION
Without this patch, the test fails by a missing symbol.
