### PR TITLE
[Parmas] Remove an unused constant.

### DIFF
--- a/server/src/Params.h
+++ b/server/src/Params.h
@@ -38,10 +38,6 @@ static const DBDomainId DB_DOMAIN_ID_ACTION  = 0x0018;
 static const DBDomainId DB_DOMAIN_ID_HATOHOL = 0x0020;
 static const DBDomainId DB_DOMAIN_ID_USERS   = 0x0030;
 static const DBDomainId DB_DOMAIN_ID_HOST    = 0x0040;
-static const DBDomainId DB_DOMAIN_ID_ZABBIX  = 0x00100000;
-// DBClintZabbix uses the number of domains by NUM_MAX_ZABBIX_SERVERS 
-// So the domain ID is occupied
-//   from DB_DOMAIN_ID_ZABBIX to 0xffffffff
 static const DBDomainId DB_DOMAIN_ID_NONE    = -1;
 
 typedef int ServerIdType;


### PR DESCRIPTION
We removed DBClientZabbix before. So the constant is no longer ued.
