### PR TITLE
[HatoholException] Make it easy to understand the reason of an build err...

### DIFF
--- a/server/src/HatoholException.h
+++ b/server/src/HatoholException.h
@@ -82,7 +82,7 @@ do { \
 /*
  * HATOHOL_BUILD_EXPECT(exp,val) emits build failure if
  * compile-time constant expression exp is not equal to val.
- * Otherwise, it returns val.
+ * Otherwise, it just returns exp itself.
  */
 template<typename T>
 struct _BuildError; // The body is not defined to cause an build error


### PR DESCRIPTION
...or.

For example, the follwoing error message is shown when the exp != val.

HatoholException.h: In instantiation of 'T _buildExpect(T) [with T = long unsigned int; bool COND = false]':
DBClientConfig.cc:116:3:   required from here
HatoholException.h:92:2: error: invalid use of incomplete type 'struct _BuildError'
  _BuildError("The used value is invalid (unexpected) or the matched specialized template method is not defined.");
  ^
HatoholException.h:87:8: error: forward declaration of 'struct _BuildError'
 struct _BuildError; // The body is not defined to cause an build error
