### PR TITLE
Fix a broken Makefile.

### DIFF
--- a/server/tools/Makefile.am
+++ b/server/tools/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = hatohol-def-src-file-generator
-dist_bin_SCRIPTS = hatohol-voyager
+dist_bin_SCRIPTS = hatohol-voyager \
                    hatohol-inspect-info-collector
 actiondir = $(libexecdir)/$(PACKAGE)/action
 dist_action_SCRIPTS = hatohol-actor-mail


### PR DESCRIPTION
The Makefile was broken in the branch: backup-tool-2 due to
missing of backslash.
And it was merged to master at 3d8f9c5.
