### PR TITLE
[server][CacheServiceDBClinet] Disable `new CacheServiceDBClinet`

### DIFF
--- a/server/src/CacheServiceDBClient.h
+++ b/server/src/CacheServiceDBClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Project Hatohol
+ * Copyright (C) 2013-2014 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -49,7 +49,7 @@ private:
 	 * only as a stack variable. The following as a private makes it
 	 * impossible to allocate an instance with a 'new' operator.
 	 */
-	static void *operator new(size_t) {return NULL;}
+	static void *operator new(size_t);
 
 	struct Impl;
 


### PR DESCRIPTION
fix #239

The current implementation causes build warning on CentOS 6:

```
  CXX    CacheServiceDBClient.lo
In file included from CacheServiceDBClient.cc:25:
CacheServiceDBClient.h: In static member function 'static void* CacheServiceDBClient::operator new(size_t)':
CacheServiceDBClient.h:52: warning: 'operator new' must not return NULL unless it is declared 'throw()' (or -fcheck-new is in effect)
```

We can just remove implementation of `operator new()` to disable `new
CacheServiceDBClient`. If someone use `new CacheServiceDBClient`,
compiler reports the following error:

```
error: ‘static void* CacheServiceDBClient::operator new(size_t)’ is private
```

So we can detect `new CacheServiceDBClient` on build time.
