### PR TITLE
[server][ConfigManager] Fix build error on CentOS 6

### DIFF
--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -148,7 +148,7 @@ struct ConfigManager::Impl {
 			MLPL_CRIT("Failed to call g_key_file_new().\n");
 			return false;
 		}
-		Reaper<GKeyFile> keyFileReaper(keyFile, g_key_file_unref);
+		Reaper<GKeyFile> keyFileReaper(keyFile, g_key_file_free);
 
 		GError *error = NULL;
 		gboolean succeeded =


### PR DESCRIPTION
GLib on CentOS 6 is 2.12. It doesn't have
`g_key_file_unref()`. `g_key_file_unref()` is available since 2.32.

See also: https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html#g-key-file-unref

This change fixes the following build error:

```
ConfigManager.cc:151: error: 'g_key_file_unref' was not declared in this scope
```
