### PR TITLE
[HatoholException] Show a debug message on a creation of a HatoholExcept...

### DIFF
--- a/server/src/HatoholException.cc
+++ b/server/src/HatoholException.cc
@@ -44,6 +44,8 @@ HatoholException::HatoholException(
   m_sourceFileName(sourceFileName),
   m_lineNumber(lineNumber)
 {
+	MLPL_DBG("HatoholException: <%s:%d> %s\n", sourceFileName.c_str(), lineNumber,
+	         brief.c_str());
 	if (m_saveStackTrace)
 		saveStackTrace();
 }


### PR DESCRIPTION
...ion object.

This is useful, for example, when an exception happens during an exception.
The current implementation cann't show information about the first exception.
