### PR TITLE
[server][HAPI JSON] Remove needless "hatohol." prefix from queue name

### DIFF
--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -160,7 +160,7 @@ struct HatoholArmPluginGateJSON::Impl
 private:
 	string generateBrokerAddress(const MonitoringServerInfo &serverInfo)
 	{
-		return StringUtils::sprintf("hatohol.gate.%" FMT_SERVER_ID,
+		return StringUtils::sprintf("gate.%" FMT_SERVER_ID,
 					    serverInfo.id);
 	}
 };


### PR DESCRIPTION
We should use vhost for separating name space instead of queue name.
