### PR TITLE
Use upsert 2

### DIFF
--- a/server/src/DBClientHatohol.cc
+++ b/server/src/DBClientHatohol.cc
@@ -2293,6 +2293,7 @@ void DBClientHatohol::addHostInfoWithoutTransaction(const HostInfo &hostInfo)
 	arg.add(hostInfo.serverId);
 	arg.add(hostInfo.id);
 	arg.add(hostInfo.hostName);
+	arg.upsertOnDuplicate = true;
 	insert(arg);
 }
 


### PR DESCRIPTION
These patches clean up DBClientHatohol by using upsert feature of insert(),
which is recently introduced.
