### PR TITLE
[DBClientHatohol] Fix an inappropriate index for hostgroups

### DIFF
--- a/server/src/DBClientHatohol.cc
+++ b/server/src/DBClientHatohol.cc
@@ -879,7 +879,7 @@ static const DBAgent::IndexDef indexDefsHosts[] = {
 
 // Hostgroups
 static const int columnIndexesHostgroupsUniqId[] = {
-  IDX_HOSTGROUPS_SERVER_ID, IDX_HOSTGROUPS_ID, DBAgent::IndexDef::END,
+  IDX_HOSTGROUPS_SERVER_ID, IDX_HOSTGROUPS_GROUP_ID, DBAgent::IndexDef::END,
 };
 
 static const DBAgent::IndexDef indexDefsHostgroups[] = {


### PR DESCRIPTION
Without this fix, hostgroups will always be inserted even if
updating an existing record is expected.

It's same issue with 851d3ba878ed72ddf957444039dfbffaa8e70d94.

You have to clear cache DB after applying this fix because DB
migration code isn't prepared (851d3ba has a same issue).
