### PR TITLE
[server] Move SQLUtils::getFullName() to DBAgent::TableProfile

### DIFF
--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -486,8 +486,7 @@ void ArmNagiosNDOUtils::makeSelectTriggerBuilder(void)
 	// contiditon
 	m_impl->selectTriggerBaseCondition = StringUtils::sprintf(
 	  "%s>=",
-	  SQLUtils::getFullName(COLUMN_DEF_SERVICESTATUS,
-	                        IDX_SERVICESTATUS_STATUS_UPDATE_TIME).c_str());
+	  tableProfileServiceStatus.getFullColumnName(IDX_SERVICESTATUS_STATUS_UPDATE_TIME).c_str());
 }
 
 void ArmNagiosNDOUtils::makeSelectEventBuilder(void)
@@ -513,11 +512,9 @@ void ArmNagiosNDOUtils::makeSelectEventBuilder(void)
 	// contiditon
 	m_impl->selectEventBaseCondition = StringUtils::sprintf(
 	  "%s=%d and %s>=",
-	  SQLUtils::getFullName(COLUMN_DEF_STATEHISTORY,
-	                        IDX_STATEHISTORY_STATE_TYPE).c_str(),
+	  tableProfileStateHistory.getFullColumnName(IDX_STATEHISTORY_STATE_TYPE).c_str(),
 	  HARD_STATE,
-	  SQLUtils::getFullName(COLUMN_DEF_STATEHISTORY,
-	                        IDX_STATEHISTORY_STATEHISTORY_ID).c_str());
+	  tableProfileStateHistory.getFullColumnName(IDX_STATEHISTORY_STATEHISTORY_ID).c_str());
 }
 
 void ArmNagiosNDOUtils::makeSelectItemBuilder(void)

--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -113,6 +113,15 @@ DBAgent::TableProfile::TableProfile(
 {
 }
 
+std::string DBAgent::TableProfile::getFullColumnName(const size_t &index) const
+{
+	const ColumnDef &def = columnDefs[index];
+	string fullName = name;
+	fullName += ".";
+	fullName += def.columnName;
+	return fullName;
+}
+
 // ---------------------------------------------------------------------------
 // DBAgent::RowElement
 // ---------------------------------------------------------------------------
@@ -231,8 +240,7 @@ void DBAgent::SelectExArg::add(const size_t &columnIndex)
 	string statement;
 	const ColumnDef &columnDef = tableProfile->columnDefs[columnIndex];
 	if (useFullName) {
-		statement = SQLUtils::getFullName(tableProfile->columnDefs,
-		                                  columnIndex);
+		statement = tableProfile->getFullColumnName(columnIndex);
 	} else {
 		statement = columnDef.columnName;
 	}
@@ -278,7 +286,7 @@ string DBAgent::SelectMultiTableArg::getFullName(const size_t &tableIndex,
 	               "tableIndex (%zd) >= numTables (%zd)",
 	               tableIndex, numTables);
 	const TableProfile *profile = profiles[tableIndex];
-	return SQLUtils::getFullName(profile->columnDefs, columnIndex);
+	return profile->getFullColumnName(columnIndex);
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -67,6 +67,18 @@ public:
 
 		TableProfile(const char *name,  const ColumnDef *columnDefs,
 		             const size_t &numIndexes);
+
+		/**
+		 * Get a full name of a column.
+		 *
+		 * E.g. If table name is 'tbl' and a column name is 'name',
+		 * 'tbl.name' is returned.
+		 *
+		 * @param index      An index of the target column.
+		 *
+		 * @return A full name of the specified column.
+		 */
+		std::string getFullColumnName(const size_t &index) const;
 	};
 
 	struct IndexDef {

--- a/server/src/DBClientConfig.cc
+++ b/server/src/DBClientConfig.cc
@@ -533,8 +533,8 @@ static string serverIdCondition(
 {
 	string columnNameStr;
 	if (needTableName) {
-		columnNameStr = SQLUtils::getFullName(COLUMN_DEF_SERVERS,
-		                                      IDX_SERVERS_ID);
+		columnNameStr =
+			tableProfileServers.getFullColumnName(IDX_SERVERS_ID);
 	}
 	const char *columnName = needTableName ?
 	                         columnNameStr.c_str() :

--- a/server/src/DBClientJoinBuilder.cc
+++ b/server/src/DBClientJoinBuilder.cc
@@ -83,8 +83,8 @@ void DBClientJoinBuilder::addTable(
 	addTableCommon(table, type, table0, index0, index1);
 	m_impl->selectExArg.tableField += StringUtils::sprintf(
 	  "%s=%s",
-	  SQLUtils::getFullName(table0.columnDefs, index0).c_str(),
-	  SQLUtils::getFullName(table.columnDefs, index1).c_str());
+	  table0.getFullColumnName(index0).c_str(),
+	  table.getFullColumnName(index1).c_str());
 }
 
 void DBClientJoinBuilder::addTable(
@@ -95,8 +95,8 @@ void DBClientJoinBuilder::addTable(
 	addTableCommon(table, type, tableC, indexL, indexR);
 	m_impl->selectExArg.tableField += StringUtils::sprintf(
 	  "%s=%s",
-	  SQLUtils::getFullName(tableC.columnDefs, indexL).c_str(),
-	  SQLUtils::getFullName(table.columnDefs, indexR).c_str());
+	  tableC.getFullColumnName(indexL).c_str(),
+	  table.getFullColumnName(indexR).c_str());
 }
 
 void DBClientJoinBuilder::addTable(
@@ -116,10 +116,10 @@ void DBClientJoinBuilder::addTable(
 	addTableCommon(table, type, tableC0, index0L, index0R);
 	m_impl->selectExArg.tableField += StringUtils::sprintf(
 	  "(%s=%s AND %s=%s)",
-	  SQLUtils::getFullName(tableC0.columnDefs, index0L).c_str(),
-	  SQLUtils::getFullName(table.columnDefs,   index0R).c_str(),
-	  SQLUtils::getFullName(tableC1.columnDefs, index1L).c_str(),
-	  SQLUtils::getFullName(table.columnDefs,   index1R).c_str());
+	  tableC0.getFullColumnName(index0L).c_str(),
+	  table.getFullColumnName(index0R).c_str(),
+	  tableC1.getFullColumnName(index1L).c_str(),
+	  table.getFullColumnName(index1R).c_str());
 }
 
 void DBClientJoinBuilder::add(const size_t &columnIndex)

--- a/server/src/SQLUtils.cc
+++ b/server/src/SQLUtils.cc
@@ -52,15 +52,6 @@ void SQLUtils::init(void)
 	}
 }
 
-string SQLUtils::getFullName(const ColumnDef *columnDefs, const size_t &index)
-{
-	const ColumnDef &def = columnDefs[index];
-	string fullName = def.tableName;
-	fullName += ".";
-	fullName += def.columnName;
-	return fullName;
-}
-
 ItemDataPtr SQLUtils::createFromString(const char *str, SQLColumnType type)
 {
 	ItemData *itemData = NULL;

--- a/server/src/SQLUtils.h
+++ b/server/src/SQLUtils.h
@@ -29,20 +29,6 @@ public:
 
 	static void init(void);
 
-	/**
-	 * Get a full name of a column.
-	 *
-	 * E.g. If table name is 'tbl' and a column name is 'name',
-	 * 'tbl.name' is returned.
-	 *
-	 * @param columnDefs A pointer of a ColumnDef array.
-	 * @param index      An index of the target column.
-	 *
-	 * @return A full name of the specified column.
-	 */
-	static std::string getFullName(const ColumnDef *columnDefs,
-	                               const size_t &index);
-
 	static ItemDataPtr createFromString(const char *str,
 	                                    SQLColumnType type);
 

--- a/server/test/testDBAgent.cc
+++ b/server/test/testDBAgent.cc
@@ -621,5 +621,20 @@ void test_transactionCatchException(void)
 	cppcut_assert_equal(true, caughtException);
 }
 
+namespace testTableProfile
+{
+	void test_getFullColumnName(void)
+	{
+		using StringUtils::sprintf;
+		size_t index = 1;
+		const char *tableName = TABLE_NAME_TEST;
+		const char *columnName = COLUMN_DEF_TEST[index].columnName;
+		DBAgent::TableProfile profile(tableName,
+					      COLUMN_DEF_TEST,
+					      tableProfileTest.numColumns);
+		cppcut_assert_equal(sprintf("%s.%s", tableName, columnName),
+				    profile.getFullColumnName(index));
+	}
+}
 
 } // namespace testDBAgent

--- a/server/test/testSQLUtils.cc
+++ b/server/test/testSQLUtils.cc
@@ -54,17 +54,6 @@ static ColumnDef testDefChar = {
 // ---------------------------------------------------------------------------
 // Test cases
 // ---------------------------------------------------------------------------
-void test_getFullName(void)
-{
-	const size_t index = 1;
-	string actual = SQLUtils::getFullName(COLUMN_DEF_TEST, index);
-
-	const ColumnDef &def = COLUMN_DEF_TEST[index];
-	string expect =
-	  StringUtils::sprintf("%s.%s", def.tableName, def.columnName);
-	cppcut_assert_equal(expect, actual);
-}
-
 void test_createFromStringInt(void)
 {
 	int val = 5;


### PR DESCRIPTION
`SQLUtils::getFullName(columnDefs, index)` finds `ColumnDef` at `index`
from `ColumnDefs` and generates name with table name.

In the current code base, `DBAgent::TableProfile` manages
`ColumnDefs`. So it is natural that the feature is provided by
`DBAgent::TableProfile`.

New method is `DBAgent::TableProfile::getFullColumnName(index)`.
