### PR TITLE
[server][HostResourceQueryOption] Use more readable name

### DIFF
--- a/server/src/DBClientHatohol.cc
+++ b/server/src/DBClientHatohol.cc
@@ -999,7 +999,7 @@ void initEventInfo(EventInfo &eventInfo)
 static const HostResourceQueryOption::Synapse synapseEventsQueryOption(
   tableProfileEvents,
   IDX_EVENTS_UNIFIED_ID, IDX_EVENTS_SERVER_ID, IDX_EVENTS_HOST_ID,
-  INVALID_COLUMN_IDX,
+  true,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);
@@ -1170,7 +1170,7 @@ TriggerStatusType EventsQueryOption::getTriggerStatus(void) const
 static const HostResourceQueryOption::Synapse synapseTriggersQueryOption(
   tableProfileTriggers,
   IDX_TRIGGERS_ID, IDX_TRIGGERS_SERVER_ID, IDX_TRIGGERS_HOST_ID,
-  INVALID_COLUMN_IDX,
+  true,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);
@@ -1287,7 +1287,7 @@ TriggerStatusType TriggersQueryOption::getTriggerStatus(void) const
 //
 static const HostResourceQueryOption::Synapse synapseItemsQueryOption(
   tableProfileItems, IDX_ITEMS_ID, IDX_ITEMS_SERVER_ID, IDX_ITEMS_HOST_ID,
-  INVALID_COLUMN_IDX,
+  true,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);
@@ -1383,7 +1383,7 @@ const string &ItemsQueryOption::getTargetItemGroupName(void)
 //
 static const HostResourceQueryOption::Synapse synapseHostsQueryOption(
   tableProfileHosts, IDX_HOSTS_ID, IDX_HOSTS_SERVER_ID, IDX_HOSTS_HOST_ID,
-  INVALID_COLUMN_IDX,
+  true,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);
@@ -1404,7 +1404,7 @@ HostsQueryOption::HostsQueryOption(DataQueryContext *dataQueryContext)
 static const HostResourceQueryOption::Synapse synapseHostgroupsQueryOption(
   tableProfileHostgroups,
   IDX_HOSTGROUPS_GROUP_ID, IDX_HOSTGROUPS_SERVER_ID, INVALID_COLUMN_IDX,
-  IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID,
+  false,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);
@@ -1425,7 +1425,7 @@ HostgroupsQueryOption::HostgroupsQueryOption(DataQueryContext *dataQueryContext)
 static const HostResourceQueryOption::Synapse synapseHostgroupElementQueryOption(
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_ID, IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID,
-  IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
+  IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID, false,
   tableProfileMapHostsHostgroups,
   IDX_MAP_HOSTS_HOSTGROUPS_SERVER_ID, IDX_MAP_HOSTS_HOSTGROUPS_HOST_ID,
   IDX_MAP_HOSTS_HOSTGROUPS_GROUP_ID);

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -34,7 +34,7 @@ HostResourceQueryOption::Synapse::Synapse(
   const size_t &_selfIdColumnIdx,
   const size_t &_serverIdColumnIdx,
   const size_t &_hostIdColumnIdx,
-  const size_t &_hostgroupIdColumnIdx,
+  const bool &_needToJoinHostgroup,
   const DBAgent::TableProfile &_hostgroupMapTableProfile,
   const size_t &_hostgroupMapServerIdColumnIdx,
   const size_t &_hostgroupMapHostIdColumnIdx,
@@ -43,7 +43,7 @@ HostResourceQueryOption::Synapse::Synapse(
   selfIdColumnIdx(_selfIdColumnIdx),
   serverIdColumnIdx(_serverIdColumnIdx),
   hostIdColumnIdx(_hostIdColumnIdx),
-  hostgroupIdColumnIdx(_hostgroupIdColumnIdx),
+  needToJoinHostgroup(_needToJoinHostgroup),
   hostgroupMapTableProfile(_hostgroupMapTableProfile),
   hostgroupMapServerIdColumnIdx(_hostgroupMapServerIdColumnIdx),
   hostgroupMapHostIdColumnIdx(_hostgroupMapHostIdColumnIdx),
@@ -198,7 +198,7 @@ string HostResourceQueryOption::getFromClause(void) const
 bool HostResourceQueryOption::isHostgroupUsed(void) const
 {
 	const Synapse &synapse = m_impl->synapse;
-	if (synapse.hostgroupIdColumnIdx != INVALID_COLUMN_IDX)
+	if (!synapse.needToJoinHostgroup)
 		return false;
 	if (isHostgroupEnumerationInCondition())
 		return true;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -32,7 +32,7 @@ public:
 		const size_t                 selfIdColumnIdx;
 		const size_t                 serverIdColumnIdx;
 		const size_t                 hostIdColumnIdx;
-		const size_t                 hostgroupIdColumnIdx;
+		const bool                   needToJoinHostgroup;
 
 		const DBAgent::TableProfile &hostgroupMapTableProfile;
 		const size_t                 hostgroupMapServerIdColumnIdx;
@@ -43,7 +43,7 @@ public:
 		     const size_t &selfIdColumnIdx,
 		     const size_t &serverIdColumnIdx,
 		     const size_t &hostIdColumnIdx,
-		     const size_t &hostgroupIdColumnIdx,
+		     const bool &needToJoinHostgroup,
 		     const DBAgent::TableProfile &hostgroupMapTableProfile,
 		     const size_t &hostgroupMapServerIdColumnIdx,
 		     const size_t &hostgroupMapHostIdColumnIdx,

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -164,7 +164,7 @@ const DBAgent::TableProfile tableProfileTestHGrp(
 static const HostResourceQueryOption::Synapse TEST_SYNAPSE(
   tableProfileTest,
   IDX_TEST_TABLE_ID, IDX_TEST_TABLE_SERVER_ID, IDX_TEST_TABLE_HOST_ID,
-  INVALID_COLUMN_IDX,
+  true,
   tableProfileTestHGrp,
   IDX_TEST_HGRP_TABLE_SERVER_ID, IDX_TEST_HGRP_TABLE_HOST_ID,
   IDX_TEST_HGRP_TABLE_HOST_GROUP_ID);
@@ -172,7 +172,7 @@ static const HostResourceQueryOption::Synapse TEST_SYNAPSE(
 static const HostResourceQueryOption::Synapse TEST_SYNAPSE_HGRP(
   tableProfileTestHGrp,
   IDX_TEST_HGRP_TABLE_ID, IDX_TEST_HGRP_TABLE_SERVER_ID,
-  IDX_TEST_HGRP_TABLE_HOST_ID, IDX_TEST_HGRP_TABLE_HOST_GROUP_ID,
+  IDX_TEST_HGRP_TABLE_HOST_ID, false,
   tableProfileTestHGrp,
   IDX_TEST_HGRP_TABLE_SERVER_ID, IDX_TEST_HGRP_TABLE_HOST_ID,
   IDX_TEST_HGRP_TABLE_HOST_GROUP_ID);


### PR DESCRIPTION
`HostResourceQueryOption::Synapse::hostgroupIdColumnIdx` was used for
determining whether the option needs to join with hostgroup table.

If `hostgroupIdColumnIdx` isn't `INVALID_COLUMN_IDX`, it doesn't need to
join with hostgroup table.

`hostgroupIdColumnIdx` wasn't straightforward name. So this change uses
straightforward name.

See also https://github.com/project-hatohol/hatohol/commit/e2fbebfc2b41fa48d5582a1c69529092be3d1768#commitcomment-7440124
