### PR TITLE
[Helpers] Read a file again if the read size is zero.

### DIFF
--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -1201,7 +1201,7 @@ void _assertFileContent(const string &expect, const string &path)
 		// reason is unknown, we try to read repeatedly in order to
 		// avoid the failure.
 		g_free(contents);
-		usleep(10 * 1000 * 1000); // 10ms
+		usleep(10 * 1000); // 10ms
 		SmartTime elapsed(SmartTime::INIT_CURR_TIME);
 		elapsed -= startTime;
 		cppcut_assert_equal(true, elapsed.getAsSec() < TIMEOUT_SEC);


### PR DESCRIPTION
Some tests such as testChildProcessManager::test_createWithEnv()
sometimes fails due to empty of file contents. Although the clear
reason is unknown, we try to read repeatedly in order to avoid
the failure.

An example of the failure:
https://travis-ci.org/project-hatohol/hatohol/jobs/33042226
