### PR TITLE
[Params] Change a constsnat name: DB_DOMAIN_ID_HATOHOL.

### DIFF
--- a/server/src/CacheServiceDBClient.cc
+++ b/server/src/CacheServiceDBClient.cc
@@ -89,7 +89,7 @@ struct CacheServiceDBClient::Impl {
 		if (it != clientMap->end())
 			return it->second;
 		DBClient *dbClient = NULL;
-		if (domainId == DB_TABLES_ID_MONITOR)
+		if (domainId == DB_TABLES_ID_MONITORING)
 			dbClient = new DBClientHatohol();
 		else if (domainId == DB_TABLES_ID_USER)
 			dbClient = new DBTablesUser();
@@ -183,7 +183,7 @@ CacheServiceDBClient::~CacheServiceDBClient()
 
 DBClientHatohol *CacheServiceDBClient::getHatohol(void)
 {
-	return get<DBClientHatohol>(DB_TABLES_ID_MONITOR);
+	return get<DBClientHatohol>(DB_TABLES_ID_MONITORING);
 }
 
 DBTablesUser *CacheServiceDBClient::getUser(void)

--- a/server/src/DBClientHatohol.cc
+++ b/server/src/DBClientHatohol.cc
@@ -1412,11 +1412,11 @@ IncidentsQueryOption::IncidentsQueryOption(DataQueryContext *dataQueryContext)
 void DBClientHatohol::init(void)
 {
 	registerSetupInfo(
-	  DB_TABLES_ID_MONITOR, DEFAULT_DB_NAME, &DB_SETUP_FUNC_ARG);
+	  DB_TABLES_ID_MONITORING, DEFAULT_DB_NAME, &DB_SETUP_FUNC_ARG);
 }
 
 DBClientHatohol::DBClientHatohol(void)
-: DBClient(DB_TABLES_ID_MONITOR),
+: DBClient(DB_TABLES_ID_MONITORING),
   m_impl(new Impl())
 {
 }

--- a/server/src/Params.h
+++ b/server/src/Params.h
@@ -34,12 +34,12 @@
 typedef int DBDomainId; // TODO: remove after all the DBClient and the sub classes are removed.
 typedef int DBTablesId;
 
-static const DBDomainId DB_DOMAIN_ID_CONFIG  = 0x0010;
-static const DBTablesId DB_TABLES_ID_ACTION  = 0x0018;
-static const DBTablesId DB_TABLES_ID_MONITOR = 0x0020;
-static const DBTablesId DB_TABLES_ID_USER    = 0x0030;
-static const DBDomainId DB_DOMAIN_ID_HOST    = 0x0040;
-static const DBDomainId DB_DOMAIN_ID_NONE    = -1;
+static const DBDomainId DB_DOMAIN_ID_CONFIG     = 0x0010;
+static const DBTablesId DB_TABLES_ID_ACTION     = 0x0018;
+static const DBTablesId DB_TABLES_ID_MONITORING = 0x0020;
+static const DBTablesId DB_TABLES_ID_USER       = 0x0030;
+static const DBDomainId DB_DOMAIN_ID_HOST       = 0x0040;
+static const DBDomainId DB_DOMAIN_ID_NONE       = -1;
 
 typedef int ServerIdType;
 #define FMT_SERVER_ID "d"

--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -63,7 +63,7 @@ void startFaceRest(void)
 	bool dbRecreate = true, loadTestData = true;
 	setupTestDBConfig(dbRecreate, loadTestData);
 
-	defineDBPath(DB_TABLES_ID_MONITOR, dbPathHatohol);
+	defineDBPath(DB_TABLES_ID_MONITORING, dbPathHatohol);
 
 	ConfigManager::getInstance()->setFaceRestPort(TEST_PORT);
 	g_faceRest = new FaceRest(&param);

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -1101,9 +1101,9 @@ void releaseDefaultContext(void)
 
 void defineDBPath(DBDomainId domainId, const string &dbPath)
 {
-	if (domainId != DB_TABLES_ID_MONITOR)
+	if (domainId != DB_TABLES_ID_MONITORING)
 		cut_fail("Cannot set a domain ID for %d\n", domainId);
-	DBAgentSQLite3::defineDBPath(DB_TABLES_ID_MONITOR, dbPath);
+	DBAgentSQLite3::defineDBPath(DB_TABLES_ID_MONITORING, dbPath);
 }
 
 UserIdType searchMaxTestUserId(void)

--- a/server/test/fixtures/mkTestDB.cc
+++ b/server/test/fixtures/mkTestDB.cc
@@ -12,7 +12,7 @@ typedef void (*DBMaker)(const string &dbName);
 
 static void makeDBHatohol(const string &dbName)
 {
-	DBAgentSQLite3::defineDBPath(DB_TABLES_ID_MONITOR, dbName);
+	DBAgentSQLite3::defineDBPath(DB_TABLES_ID_MONITORING, dbName);
 	DBClientHatohol dbHatohol;
 
 	// Triggers

--- a/server/test/testDBClientHatohol.cc
+++ b/server/test/testDBClientHatohol.cc
@@ -477,7 +477,7 @@ void test_createDB(void)
 	string statement = "select * from _dbclient_version";
 	string output = execSqlite3ForDBClientHatohol(statement);
 	string expectedOut = StringUtils::sprintf
-	                       ("%d|%d\n", DB_TABLES_ID_MONITOR,
+	                       ("%d|%d\n", DB_TABLES_ID_MONITORING,
 	                                   DBClientHatohol::HATOHOL_DB_VERSION);
 	cppcut_assert_equal(expectedOut, output);
 }

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -135,7 +135,7 @@ void cut_setup(void)
 	                                     "fixtures",
 	                                     "testDatabase-hatohol.db",
 	                                     NULL);
-	defineDBPath(DB_TABLES_ID_MONITOR, dbPath);
+	defineDBPath(DB_TABLES_ID_MONITORING, dbPath);
 	setupTestDBConfig(true, true);
 }
 


### PR DESCRIPTION
The main purpose of this pull request is to discuss
the new name of DBClientHatohol.

I will change it to DBTablesMonitor, because tables
managed by the class are monitored matters such as
events and triggers.
