### PR TITLE
[DBTablesMonitoring] Change the table name: servers to avoid a confilict.

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -37,7 +37,7 @@ const char *DBTablesMonitoring::TABLE_NAME_HOSTS      = "hosts";
 const char *DBTablesMonitoring::TABLE_NAME_HOSTGROUPS = "hostgroups";
 const char *DBTablesMonitoring::TABLE_NAME_MAP_HOSTS_HOSTGROUPS
                                                    = "map_hosts_hostgroups";
-const char *DBTablesMonitoring::TABLE_NAME_SERVERS    = "servers";
+const char *DBTablesMonitoring::TABLE_NAME_SERVER_STATUS = "server_status";
 const char *DBTablesMonitoring::TABLE_NAME_INCIDENTS  = "incidents";
 
 const int   DBTablesMonitoring::HATOHOL_DB_VERSION = 5;
@@ -678,7 +678,7 @@ static const DBAgent::TableProfile tableProfileMapHostsHostgroups =
 			    indexDefsMapHostsHostgroups);
 
 // ----------------------------------------------------------------------------
-// Table: servers
+// Table: server_status
 // ----------------------------------------------------------------------------
 static const ColumnDef COLUMN_DEF_SERVERS[] = {
 {
@@ -711,7 +711,7 @@ enum {
 };
 
 static const DBAgent::TableProfile tableProfileServers =
-  DBAGENT_TABLEPROFILE_INIT(DBTablesMonitoring::TABLE_NAME_SERVERS,
+  DBAGENT_TABLEPROFILE_INIT(DBTablesMonitoring::TABLE_NAME_SERVER_STATUS,
 			    COLUMN_DEF_SERVERS,
 			    NUM_IDX_SERVERS);
 

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -283,7 +283,7 @@ public:
 	static const char *TABLE_NAME_HOSTS;
 	static const char *TABLE_NAME_HOSTGROUPS;
 	static const char *TABLE_NAME_MAP_HOSTS_HOSTGROUPS;
-	static const char *TABLE_NAME_SERVERS;
+	static const char *TABLE_NAME_SERVER_STATUS;
 	static const char *TABLE_NAME_INCIDENTS;
 
 	DBTablesMonitoring(void);


### PR DESCRIPTION
Now there are the tables that have the same name.
One is owned by DBTablesConfig and the other is owned by
DBTablesMonitoring. Since they are currently in different DBs (MySQL and
SQLite3), it doesn't conflict.

However, we are fixing the architecture of DB access. The final design
will have all tables in one DB in order to join each other and make it easy to
realize an HA system. In that case, the same table name cannot be allowed.
