### PR TITLE
[server][benchmark] Remove reserving memory from fast_join

### DIFF
--- a/server/benchmark/bench-string-join.cc
+++ b/server/benchmark/bench-string-join.cc
@@ -248,7 +248,6 @@ main(int argc, char **argv)
 
 		virtual void run(void) {
 			string all;
-			all.reserve(3 * lookupTotalLength(", ", m_elements));
 			all += join(", ", m_elements);
 			all += join(", ", m_elements);
 			all += join(", ", m_elements);


### PR DESCRIPTION
It is unfair.
We should reserve memory for all cases or don't reserve.

Before:

```
% make -s -C server/benchmark run-bench-string-join
            Label:     Total   Average    Median
     string::join: (0.011s)  (0.001ms) (0.001ms)
string::fast_join: (0.005s)  (0.500us) (0.000us)
SeparatorInjector: (0.005s)  (0.529us) (0.001ms)
```

After:

```
% make -s -C server/benchmark run-bench-string-join
            Label:     Total   Average    Median
     string::join: (0.008s)  (0.816us) (0.001ms)
string::fast_join: (0.006s)  (0.577us) (0.001ms)
SeparatorInjector: (0.006s)  (0.576us) (0.001ms)
```

With this result, we know that we can get the similar performance with
fast_join or SeparatorInjector.

I will send a propose that replacing SeparatorInjector with
fast_join. Because user code of fast_join approach is simpler rather
than SeparatorInjector approach and no performance difference.
