### PR TITLE
[server][ItemTablePtr] Remove unused methods

### DIFF
--- a/server/src/ItemTablePtr.cc
+++ b/server/src/ItemTablePtr.cc
@@ -30,9 +30,3 @@ template<> ItemTablePtr::UsedCountablePtr(void)
 {
 	m_data = new ItemTable();
 }
-
-ItemTablePtr
-crossJoin(const ItemTablePtr &tablePtr0, const ItemTablePtr &tablePtr1)
-{
-	return ItemTablePtr(tablePtr0->crossJoin(tablePtr1), false);
-}

--- a/server/src/ItemTablePtr.h
+++ b/server/src/ItemTablePtr.h
@@ -32,9 +32,6 @@ typedef std::list<ItemTablePtr>                 ItemTablePtrList;
 typedef std::list<ItemTablePtr>::iterator       ItemTablePtrListIterator;
 typedef std::list<ItemTablePtr>::const_iterator ItemTablePtrListConstIterator;
 
-ItemTablePtr
-crossJoin     (const ItemTablePtr &tablePtr0, const ItemTablePtr &tablePtr1);
-
 template<> VariableItemTablePtr::UsedCountablePtr(void);
 template<> ItemTablePtr::UsedCountablePtr(void);
 


### PR DESCRIPTION
This change removes the following unused methods:
- `ItemTablePtr::innerJoin`
- `ItemTablePtr::leftOuterJoin`
- `ItemTablePtr::rightOuterJoin`
- `ItemTablePtr::fullOuterJoin`
- `ItemTablePtr::crossJoin`
