### PR TITLE
Test dbtables action declare

### DIFF
--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -39,13 +39,6 @@ namespace testDBTablesAction {
 	DBTablesAction &VAR_NAME = _dbHatohol.getAction();
 	***/
 
-struct TestDBTablesAction : public DBTablesAction {
-	uint64_t callGetLastInsertId(void)
-	{
-		return getLastInsertId();
-	}
-};
-
 static string makeExpectedString(const ActionDef &actDef, int expectedId)
 {
 	const ActionCondition &cond = actDef.condition;


### PR DESCRIPTION
After DBTablesMonitoring inherits DBTables, we will have to change the
way to make an instance for the test. This macro helps to reduce
lines to be changed when the time comes.
