### PR TITLE
[FaceRestTestUtils] Remove an unused paramter in _assertUpdateRecord().

### DIFF
--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -351,8 +351,7 @@ void _assertAddRecord(JSONParserAgent *parser,
 	assertValueInParser(parser, "id", expectedId);
 }
 
-void _assertUpdateRecord(JSONParserAgent *parser,
-                         const StringMap &params, const string &baseUrl,
+void _assertUpdateRecord(const StringMap &params, const string &baseUrl,
                          uint32_t targetId, const UserIdType &userId,
                          const HatoholErrorCode &expectCode)
 {
@@ -367,11 +366,11 @@ void _assertUpdateRecord(JSONParserAgent *parser,
 	arg.parameters = params;
 	arg.request = "PUT";
 	arg.userId = userId;
-	parser = getResponseAsJSONParser(arg);
-	assertErrorCode(parser, expectCode);
+	unique_ptr<JSONParserAgent> parserPtr(getResponseAsJSONParser(arg));
+	assertErrorCode(parserPtr.get(), expectCode);
 	if (expectCode != HTERR_OK)
 		return;
-	assertValueInParser(parser, "id", targetId);
+	assertValueInParser(parserPtr.get(), "id", targetId);
 }
 
 void assertServersIdNameHashInParser(JSONParserAgent *parser)

--- a/server/test/FaceRestTestUtils.h
+++ b/server/test/FaceRestTestUtils.h
@@ -102,8 +102,7 @@ void _assertAddRecord(JSONParserAgent *parser,
                       const UserIdType &userId = INVALID_USER_ID,
                       const HatoholErrorCode &expectCode = HTERR_OK,
                       uint32_t expectedId = 1);
-void _assertUpdateRecord(JSONParserAgent *parser,
-                         const StringMap &params, const std::string &baseUrl,
+void _assertUpdateRecord(const StringMap &params, const std::string &baseUrl,
                          uint32_t targetId = 1,
                          const UserIdType &userId = INVALID_USER_ID,
                          const HatoholErrorCode &expectCode = HTERR_OK);

--- a/server/test/testFaceRestIncidentTracker.cc
+++ b/server/test/testFaceRestIncidentTracker.cc
@@ -86,7 +86,7 @@ cut_trace(_assertIncidentTrackers(P,##__VA_ARGS__))
 cut_trace(_assertAddRecord(g_parser, P, "/incident-tracker", ##__VA_ARGS__))
 
 #define assertUpdateIncidentTracker(P, ...) \
-cut_trace(_assertUpdateRecord(g_parser, P, "/incident-tracker", ##__VA_ARGS__))
+cut_trace(_assertUpdateRecord(P, "/incident-tracker", ##__VA_ARGS__))
 
 static void _assertIncidentTrackerInDB(
   const IncidentTrackerInfo &expectedIncidentTracker,

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -117,7 +117,7 @@ void _assertAddUserWithSetup(const StringMap &params,
 #define assertAddUserWithSetup(P,C) cut_trace(_assertAddUserWithSetup(P,C))
 
 #define assertUpdateUser(P, ...) \
-cut_trace(_assertUpdateRecord(g_parser, P, "/user", ##__VA_ARGS__))
+cut_trace(_assertUpdateRecord(P, "/user", ##__VA_ARGS__))
 
 void _assertUpdateUserWithSetup(const StringMap &params,
                                 uint32_t targetUserId,
@@ -860,7 +860,7 @@ void test_addUserRoleWithInvalidFlags(void)
 }
 
 #define assertUpdateUserRole(P, ...) \
-cut_trace(_assertUpdateRecord(g_parser, P, "/user-role", ##__VA_ARGS__))
+cut_trace(_assertUpdateRecord(P, "/user-role", ##__VA_ARGS__))
 
 void _assertUpdateUserRoleWithSetup(const StringMap &params,
 				    uint32_t targetUserRoleId,


### PR DESCRIPTION
The 1st paramter: JSONParserAgent *parser is not used as both input
and output. In addition, this patch also fixes a leak of a JSONParserAgent instance
stored in the variable.
