### PR TITLE
[FaceRestTestutils.cc] Remove an unused paramter in _assertAddRecord().

### DIFF
--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -333,8 +333,7 @@ void _assertErrorCode(JSONParserAgent *parser,
 	cppcut_assert_equal((int64_t)expectCode, actualCode);
 }
 
-void _assertAddRecord(JSONParserAgent *parser,
-                      const StringMap &params, const string &url,
+void _assertAddRecord(const StringMap &params, const string &url,
                       const UserIdType &userId,
                       const HatoholErrorCode &expectCode,
                       uint32_t expectedId)
@@ -344,11 +343,11 @@ void _assertAddRecord(JSONParserAgent *parser,
 	arg.parameters = params;
 	arg.request = "POST";
 	arg.userId = userId;
-	parser = getResponseAsJSONParser(arg);
-	assertErrorCode(parser, expectCode);
+	unique_ptr<JSONParserAgent> parserPtr(getResponseAsJSONParser(arg));
+	assertErrorCode(parserPtr.get(), expectCode);
 	if (expectCode != HTERR_OK)
 		return;
-	assertValueInParser(parser, "id", expectedId);
+	assertValueInParser(parserPtr.get(), "id", expectedId);
 }
 
 void _assertUpdateRecord(JSONParserAgent *parser,

--- a/server/test/FaceRestTestUtils.h
+++ b/server/test/FaceRestTestUtils.h
@@ -97,8 +97,7 @@ void _assertErrorCode(JSONParserAgent *parser,
 		      const HatoholErrorCode &expectCode = HTERR_OK);
 #define assertErrorCode(P, ...) cut_trace(_assertErrorCode(P, ##__VA_ARGS__))
 
-void _assertAddRecord(JSONParserAgent *parser,
-                      const StringMap &params, const std::string &url,
+void _assertAddRecord(const StringMap &params, const std::string &url,
                       const UserIdType &userId = INVALID_USER_ID,
                       const HatoholErrorCode &expectCode = HTERR_OK,
                       uint32_t expectedId = 1);

--- a/server/test/testFaceRestAction.cc
+++ b/server/test/testFaceRestAction.cc
@@ -173,7 +173,7 @@ static void _assertActions(const string &path, const string &callbackName = "",
 #define assertActions(P,...) cut_trace(_assertActions(P,##__VA_ARGS__))
 
 #define assertAddAction(P, ...) \
-cut_trace(_assertAddRecord(g_parser, P, "/action", ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, "/action", ##__VA_ARGS__))
 
 void data_actionsJSONP(void)
 {

--- a/server/test/testFaceRestIncidentTracker.cc
+++ b/server/test/testFaceRestIncidentTracker.cc
@@ -83,7 +83,7 @@ static void _assertIncidentTrackers(
 cut_trace(_assertIncidentTrackers(P,##__VA_ARGS__))
 
 #define assertAddIncidentTracker(P, ...) \
-cut_trace(_assertAddRecord(g_parser, P, "/incident-tracker", ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, "/incident-tracker", ##__VA_ARGS__))
 
 #define assertUpdateIncidentTracker(P, ...) \
 cut_trace(_assertUpdateRecord(g_parser, P, "/incident-tracker", ##__VA_ARGS__))

--- a/server/test/testFaceRestServer.cc
+++ b/server/test/testFaceRestServer.cc
@@ -108,7 +108,7 @@ static void _assertServers(const string &path, const string &callbackName = "")
 #define assertServers(P,...) cut_trace(_assertServers(P,##__VA_ARGS__))
 
 #define assertAddServer(P, ...) \
-cut_trace(_assertAddRecord(g_parser, P, "/server", ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, "/server", ##__VA_ARGS__))
 
 void _assertAddServerWithSetup(const StringMap &params,
 			       const HatoholErrorCode &expectCode)

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -103,7 +103,7 @@ static void _assertUsers(const string &path, const UserIdType &userId,
 #define assertUsers(P, U, ...) cut_trace(_assertUsers(P, U, ##__VA_ARGS__))
 
 #define assertAddUser(P, ...) \
-cut_trace(_assertAddRecord(g_parser, P, "/user", ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, "/user", ##__VA_ARGS__))
 
 void _assertAddUserWithSetup(const StringMap &params,
                              const HatoholErrorCode &expectCode)
@@ -231,7 +231,7 @@ static void _assertAllowedServers(const string &path, const UserIdType &userId,
 #define assertAllowedServers(P,...) cut_trace(_assertAllowedServers(P,##__VA_ARGS__))
 
 #define assertAddAccessInfo(U, P, USER_ID, ...) \
-cut_trace(_assertAddRecord(g_parser, P, U, USER_ID, ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, U, USER_ID, ##__VA_ARGS__))
 
 void _assertAddAccessInfoWithCond(
   const string &serverId, const string &hostgroupId,
@@ -771,7 +771,7 @@ void test_getUserRole(void)
 }
 
 #define assertAddUserRole(P, ...) \
-cut_trace(_assertAddRecord(g_parser, P, "/user-role", ##__VA_ARGS__))
+cut_trace(_assertAddRecord(P, "/user-role", ##__VA_ARGS__))
 
 void _assertAddUserRoleWithSetup(const StringMap &params,
 				 const HatoholErrorCode &expectCode,


### PR DESCRIPTION
The 1st paramter: JSONParserAgent *parser is not used as both input
and output. In addition, this patch also fixes a leak of a JSONParserAgent
instance stored in the variable.
