### PR TITLE
[FaceRestTestUtils] Remove the DB setting in the helper function.

### DIFF
--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -49,9 +49,6 @@ void startFaceRest(void)
 	} param;
 
 	string dbPathHatohol  = getFixturesDir() + TEST_DB_HATOHOL_NAME;
-	bool dbRecreate = true, loadTestData = true;
-	setupTestDBConfig(dbRecreate, loadTestData);
-
 	defineDBPath(DB_TABLES_ID_MONITORING, dbPathHatohol);
 
 	ConfigManager::getInstance()->setFaceRestPort(TEST_PORT);

--- a/server/test/testFaceRestAction.cc
+++ b/server/test/testFaceRestAction.cc
@@ -64,6 +64,7 @@ void cut_setup(void)
 {
 	hatoholInit();
 	setupTestDB();
+	loadTestDBTablesConfig();
 	loadTestDBTablesUser();
 }
 

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -478,6 +478,7 @@ void cut_setup(void)
 {
 	hatoholInit();
 	setupTestDB();
+	loadTestDBTablesConfig();
 	loadTestDBUser();
 }
 

--- a/server/test/testFaceRestIncidentTracker.cc
+++ b/server/test/testFaceRestIncidentTracker.cc
@@ -37,6 +37,7 @@ void cut_setup(void)
 {
 	hatoholInit();
 	setupTestDB();
+	loadTestDBTablesConfig();
 	loadTestDBTablesUser();
 }
 

--- a/server/test/testFaceRestServer.cc
+++ b/server/test/testFaceRestServer.cc
@@ -38,6 +38,7 @@ void cut_setup(void)
 {
 	hatoholInit();
 	setupTestDB();
+	loadTestDBTablesConfig();
 	loadTestDBUser();
 }
 


### PR DESCRIPTION
Calling a DB setup function in the middle much degrades readability
and may cause unexpected behaivor.

startFaceRest() still have a similar line that calls defineDBPath().
I will also remove this later.
