### PR TITLE
[DBTablesMonitoring] Fix a bug that getLastEventId() returns unexpected ...

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1515,7 +1515,7 @@ int DBTablesMonitoring::getLastChangeTimeOfTrigger(const ServerIdType &serverId)
 {
 	const DBTermCodec *dbTermCodec = getDBAgent()->getDBTermCodec();
 	DBAgent::SelectExArg arg(tableProfileTriggers);
-	string stmt = StringUtils::sprintf("max(%s)", 
+	string stmt = StringUtils::sprintf("coalesce(max(%s), 0)",
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_LAST_CHANGE_TIME_SEC].columnName);
 	arg.add(stmt, COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].type);
 	arg.condition = StringUtils::sprintf("%s=%s",
@@ -1525,10 +1525,6 @@ int DBTablesMonitoring::getLastChangeTimeOfTrigger(const ServerIdType &serverId)
 	DBCLIENT_TRANSACTION_BEGIN() {
 		select(arg);
 	} DBCLIENT_TRANSACTION_END();
-
-	// get the result
-	if (arg.dataTable->getNumberOfRows() == 0)
-		return 0;
 
 	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
 	ItemGroupStream itemGroupStream(*grpList.begin());
@@ -1734,7 +1730,7 @@ uint64_t DBTablesMonitoring::getLastEventId(const ServerIdType &serverId)
 {
 	const DBTermCodec *dbTermCodec = getDBAgent()->getDBTermCodec();
 	DBAgent::SelectExArg arg(tableProfileEvents);
-	string stmt = StringUtils::sprintf("max(%s)", 
+	string stmt = StringUtils::sprintf("coalesce(max(%s), -1)",
 	    COLUMN_DEF_EVENTS[IDX_EVENTS_ID].columnName);
 	arg.add(stmt, COLUMN_DEF_EVENTS[IDX_EVENTS_ID].type);
 	arg.condition = StringUtils::sprintf("%s=%s",
@@ -1744,10 +1740,6 @@ uint64_t DBTablesMonitoring::getLastEventId(const ServerIdType &serverId)
 	DBCLIENT_TRANSACTION_BEGIN() {
 		select(arg);
 	} DBCLIENT_TRANSACTION_END();
-
-	// get the result
-	if (arg.dataTable->getNumberOfRows() == 0)
-		return EVENT_NOT_FOUND;
 
 	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
 	ItemGroupStream itemGroupStream(*grpList.begin());

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -811,6 +811,14 @@ void test_getLastEventId(gconstpointer data)
 	                    dbMonitoring.getLastEventId(serverid));
 }
 
+void test_getLastEventIdWithNoEvent(void)
+{
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	const ServerIdType serverid = 3;
+	cppcut_assert_equal(EVENT_NOT_FOUND,
+	                    dbMonitoring.getLastEventId(serverid));
+}
+
 void data_getHostInfoList(void)
 {
 	prepareTestDataForFilterForDataOfDefunctServers();
@@ -999,6 +1007,14 @@ void test_getNumberOfTriggersBySeverityWithoutPriviledge(void)
 		cppcut_assert_equal(expected, actual,
 		                    cut_message("severity: %d", i));
 	}
+}
+
+void test_getLastChangeTimeOfTriggerWithNoTrigger(void)
+{
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	const ServerIdType serverid = 3;
+	cppcut_assert_equal(
+	  0, dbMonitoring.getLastChangeTimeOfTrigger(serverid));
 }
 
 void test_getNumberOfGoodHosts(void)


### PR DESCRIPTION
...value

When no event exists, getLastEventId() returns 0 in spite of
expecting EVENT_NOT_FOUND.

In this commit we use a SQL function coalesce to avoid this issue.

Since getLastChangeTimeOfTrigger() has similar code, I also fixed
this function although it doesn't have such problem (because the
expected value is 0 for this case).
