### PR TITLE
[IncidentSenderRedmine] Don't share a SoupSession among multiple Inciden...

### DIFF
--- a/server/src/IncidentSenderRedmine.cc
+++ b/server/src/IncidentSenderRedmine.cc
@@ -30,25 +30,14 @@ using namespace mlpl;
 
 static const guint DEFAULT_TIMEOUT_SECONDS = 60;
 static const char *MIME_JSON = "application/json";
-static Mutex soupSessionMutex;
-
-static SoupSession *getSoupSession(void)
-{
-	static SoupSession *session = NULL;
-	soupSessionMutex.lock();
-	if (!session) {
-		session = soup_session_sync_new_with_options(
-			SOUP_SESSION_TIMEOUT, DEFAULT_TIMEOUT_SECONDS, NULL);
-	}
-	soupSessionMutex.unlock();
-	return session;
-}
 
 struct IncidentSenderRedmine::Impl
 {
 	Impl(IncidentSenderRedmine &sender)
-	: m_sender(sender), m_session(getSoupSession())
+	: m_sender(sender), m_session(NULL)
 	{
+		m_session = soup_session_sync_new_with_options(
+			SOUP_SESSION_TIMEOUT, DEFAULT_TIMEOUT_SECONDS, NULL);
 		connectSessionSignals();
 	}
 	virtual ~Impl()


### PR DESCRIPTION
...tSenderRedmine

Because it's possible to use different users against a same
Redmine server.

In addition, I expect that this approach will fix issue #290
(sometimes soup_auth_authenticate() crashes when it's called from
multiple threads simultaneously). When a SoupSession is separated,
SoupAuthManager is also separated and they will not use same
SoupAuth.
