### PR TITLE
Modified TriggerID and HostID failure of the monitoring server self.

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -72,16 +72,6 @@ typedef std::list<TriggerInfo>          TriggerInfoList;
 typedef TriggerInfoList::iterator       TriggerInfoListIterator;
 typedef TriggerInfoList::const_iterator TriggerInfoListConstIterator;
 
-static const TriggerIdType FAILED_CONNECT_ZABBIX_TRIGGERID = LONG_MAX - 1;
-static const TriggerIdType FAILED_CONNECT_MYSQL_TRIGGERID = LONG_MAX - 2;
-static const TriggerIdType FAILED_INTERNAL_ERROR_TRIGGERID = LONG_MAX - 3;
-static const TriggerIdType FAILED_PARSER_ERROR_TRIGGERID = LONG_MAX - 4;
-
-// Define a special ID By using the LONG_MAX.
-// Because, it does not overlap with the hostID set by the Zabbix.
-// There is a possibility that depends on Zabbix version of this.
-static const HostIdType MONITORING_SERVER_SELF_ID = LONG_MAX;
-
 enum EventType {
 	EVENT_TYPE_GOOD,
 	EVENT_TYPE_BAD,

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -82,6 +82,16 @@ static const HostIdType      ALL_HOSTS   = -1;
 static const HostgroupIdType ALL_HOST_GROUPS = -1;
 static const IncidentTrackerIdType ALL_INCIDENT_TRACKERS = -1;
 
+// Define a special ID By using the -2.
+// Because, it does not overlap with the hostID set by the Zabbix.
+// There is a possibility that depends on Zabbix version of this.
+static const HostIdType MONITORING_SERVER_SELF_ID = -2;
+
+static const TriggerIdType FAILED_CONNECT_ZABBIX_TRIGGERID = -1;
+static const TriggerIdType FAILED_CONNECT_MYSQL_TRIGGERID  = -2;
+static const TriggerIdType FAILED_INTERNAL_ERROR_TRIGGERID = -3;
+static const TriggerIdType FAILED_PARSER_ERROR_TRIGGERID   = -4;
+
 static const UserIdType INVALID_USER_ID = -1;
 static const UserIdType USER_ID_ANY     = -2;
 


### PR DESCRIPTION
ID is to use a value close to the maximum of ULONG_MAX(64bit).
Therefore, to set a negative number.
