### PR TITLE
[setup][ansible] Install missing gettext-devel

### DIFF
--- a/setup-with-ansible/centos.yml
+++ b/setup-with-ansible/centos.yml
@@ -14,6 +14,9 @@
   - name: install libtool
     yum: name=libtool
 
+  - name: install gettext-devel
+    yum: name=gettext-devel
+
   - name: install glib2-devel
     yum: name=glib2-devel
 


### PR DESCRIPTION
It is required by generating .mo in client/conf/locale/ja/LC_MESSAGE/.
