### PR TITLE
[server] Suppress an uninitialized value is used warning

### DIFF
--- a/server/mlpl/src/AtomicValue.h
+++ b/server/mlpl/src/AtomicValue.h
@@ -31,6 +31,7 @@ public:
 	}
 
 	AtomicValue(void)
+	: m_value()
 	{
 	}
 


### PR DESCRIPTION
It is reported on CentOS 6.5 like the following:

```
../src/AtomicValue.h: In function 'void testAtomicValue::test_setAndGet()':
../src/AtomicValue.h:44: warning: 'val' is used uninitialized in this function
testAtomicValue.cc:49: note: 'val' was declared here
```

By the way, should we support AtomicValue constructor without initial
value?
