### PR TITLE
[server][tls] Add "lib/" sub directory to base directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,8 @@ fi
 expanded_localstatedir="`eval echo $localstatedir`"
 AC_DEFINE_UNQUOTED(LOCALSTATEDIR, "$expanded_localstatedir", "Local state directory.")
 
-expanded_pkglocalstatedir="$expanded_localstatedir/$PACKAGE"
-AC_SUBST(expanded_pkglocalstatedir)
+expanded_pkglocaldatadir="$expanded_localstatedir/lib/$PACKAGE"
+AC_SUBST(expanded_pkglocaldatadir)
 
 if test x"$exec_prefix" = x"NONE"; then
     exec_prefix=$prefix

--- a/server/data/tls/hatohol-ca-initialize.in
+++ b/server/data/tls/hatohol-ca-initialize.in
@@ -11,7 +11,7 @@ run()
     fi
 }
 
-base_directory="@expanded_pkglocalstatedir@"
+base_directory="@expanded_pkglocaldatadir@"
 
 show_usage()
 {

--- a/server/data/tls/hatohol-ca-sign-client-certificate.in
+++ b/server/data/tls/hatohol-ca-sign-client-certificate.in
@@ -11,7 +11,7 @@ run()
     fi
 }
 
-base_directory="@expanded_pkglocalstatedir@"
+base_directory="@expanded_pkglocaldatadir@"
 signed_certificate_file="client-cert.pem"
 
 show_usage()

--- a/server/data/tls/hatohol-ca-sign-server-certificate.in
+++ b/server/data/tls/hatohol-ca-sign-server-certificate.in
@@ -11,7 +11,7 @@ run()
     fi
 }
 
-base_directory="@expanded_pkglocalstatedir@"
+base_directory="@expanded_pkglocaldatadir@"
 signed_certificate_file="server-cert.pem"
 
 show_usage()


### PR DESCRIPTION
Before:

```
${localstatedir}/hatohol
e.g.:
  /var/hatohol
```

After:

```
${localstatedir}/lib/hatohol
e.g.:
  /var/lib/hatohol
```

Because /var/lib/${PACKAGE} is used as local data directory widely.
