### PR TITLE
[HapProcessCeilometer] Accept timestamp without usec part.

### DIFF
--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -239,7 +239,9 @@ SmartTime HapProcessCeilometer::parseStateTimestamp(
 	                          "%04d-%02d-%02dT%02d:%02d:%02d.%06d",
 	                          &year, &month, &day, &hour, &min, &sec, &us);
 	const size_t NUM_EXPECT_ELEM = 7;
-	if (num != NUM_EXPECT_ELEM)
+	// We sometimes get the timestamp without the usec part.
+	// So we also accept the result with NUM_EXPECT_ELEM-1.
+	if (num != NUM_EXPECT_ELEM-1 && num != NUM_EXPECT_ELEM)
 		MLPL_ERR("Failed to parser time: %s\n", stateTimestamp.c_str());
 
 	tm tm;

--- a/server/test/testHapProcessCeilometer.cc
+++ b/server/test/testHapProcessCeilometer.cc
@@ -83,4 +83,16 @@ void test_parseStateTimestamp()
 	cppcut_assert_equal(expect, actual);
 }
 
+void test_parseStateTimestampWithoutUSec()
+{
+	TestHapProcessCeilometer hap;
+	const string ts = "2014-09-10T09:54:03";
+	SmartTime actual = hap.callParseStateTimestamp(ts);
+	timespec _expect;
+	_expect.tv_sec = 1410342843;
+	_expect.tv_nsec = 0;
+	SmartTime expect(_expect);
+	cppcut_assert_equal(expect, actual);
+}
+
 } // namespace testHapProcessCeilometer


### PR DESCRIPTION
Now we can accept both the following timestamp.

|  tate transition | 2014-09-09T23:38:09.926000 | state: alarm                                                         |
| state transition | 2014-09-09T23:48:10        | state: ok
