### PR TITLE
[server] Support db config in config file

### DIFF
--- a/server/data/Makefile.am
+++ b/server/data/Makefile.am
@@ -3,3 +3,7 @@ SUBDIRS = tls
 sql_DATA = \
 	create-db.sql
 sqldir = $(pkgdatadir)/sql
+
+pkgsysconf_DATA = \
+	hatohol.conf
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)

--- a/server/data/hatohol.conf
+++ b/server/data/hatohol.conf
@@ -1,0 +1,4 @@
+[mysql]
+database=hatohol
+user=hatohol
+password=hatohol

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -167,6 +167,8 @@ struct ConfigManager::Impl {
 			return false;
 		}
 
+		loadConfigFileMySQLGroup(keyFile);
+
 		return true;
 	}
 
@@ -186,6 +188,26 @@ struct ConfigManager::Impl {
 			faceRestPort = cmdLineOpts.faceRestPort;
 		if (cmdLineOpts.pidFilePath)
 			pidFilePath = cmdLineOpts.pidFilePath;
+	}
+
+private:
+	void loadConfigFileMySQLGroup(GKeyFile *keyFile)
+	{
+		const gchar *group = "mysql";
+
+		if (!g_key_file_has_group(keyFile, group))
+			return;
+
+		gchar *database =
+			g_key_file_get_string(keyFile, group, "database", NULL);
+		gchar *user =
+			g_key_file_get_string(keyFile, group, "user", NULL);
+		gchar *password =
+			g_key_file_get_string(keyFile, group, "password", NULL);
+		DBHatohol::setDefaultDBParams(database, user, password);
+		g_free(database);
+		g_free(user);
+		g_free(password);
 	}
 };
 

--- a/server/src/Hatohol.cc
+++ b/server/src/Hatohol.cc
@@ -65,10 +65,9 @@ static void reset(const CommandLineOptions *cmdLineOpts)
 	ChildProcessManager::getInstance()->reset();
 	ActorCollector::reset();
 	SessionManager::reset();
-	ConfigManager::reset(cmdLineOpts);
 
 	DBHatohol::reset();
-	
+
 	// These should be place after DBHatohol::reset()
 	DBTablesConfig::reset();
 	DBTablesUser::reset();
@@ -80,6 +79,8 @@ static void reset(const CommandLineOptions *cmdLineOpts)
 	ThreadLocalDBCache::reset();
 
 	UnifiedDataStore::getInstance()->reset();
+
+	ConfigManager::reset(cmdLineOpts);
 }
 
 void hatoholInit(const CommandLineOptions *cmdLineOpts)


### PR DESCRIPTION
Here is a sample config file to custom MySQL authentication information:

```
[mysql]
database=hatohol-db1
user=me
password=secret
```
