### PR TITLE
[Utils] Define missing functions in old libsoup as macros

### DIFF
--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -28,10 +28,16 @@
 #include <glib.h>
 #include <StringUtils.h>
 #include <execinfo.h>
+#include <libsoup/soup.h>
 #include "Params.h"
 
 #ifndef GLIB_VERSION_2_32
 #define G_SOURCE_REMOVE FALSE
+#endif
+
+#ifndef SOUP_VERSION_2_32
+#define soup_uri_get_host(uri) (uri->host)
+#define soup_uri_get_port(uri) (uri->port)
 #endif
 
 class FormulaElement;

--- a/server/src/ArmIncidentTracker.cc
+++ b/server/src/ArmIncidentTracker.cc
@@ -19,6 +19,7 @@
 
 #include "ArmIncidentTracker.h"
 #include "ArmRedmine.h"
+#include <Utils.h>
 #include <libsoup/soup.h>
 
 using namespace std;
@@ -31,8 +32,8 @@ static MonitoringServerInfo toMonitoringServerInfo(
 	SoupURI *uri = soup_uri_new(trackerInfo.baseURL.c_str());
 	monitoringServer.type = MONITORING_SYSTEM_INCIDENT_TRACKER;
 	monitoringServer.nickname = trackerInfo.nickname;
-	monitoringServer.hostName = uri->host;
-	monitoringServer.port = uri->port;
+	monitoringServer.hostName = soup_uri_get_host(uri);
+	monitoringServer.port = soup_uri_get_port(uri);
 	//TODO: should be customizable
 	monitoringServer.pollingIntervalSec = 60;
 	monitoringServer.retryIntervalSec = 30;


### PR DESCRIPTION
- soup_uri_get_host()
- soup_uri_get_port()
