### PR TITLE
[HatoholArmPluginBase] Add a new method getTimeOfLastEvent().

### DIFF
--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -60,6 +60,7 @@ enum HapiCommandCode {
 	HAPI_CMD_GET_MONITORING_SERVER_INFO,
 	HAPI_CMD_GET_TIMESTAMP_OF_LAST_TRIGGER,
 	HAPI_CMD_GET_LAST_EVENT_ID,
+	HAPI_CMD_GET_TIME_OF_LAST_EVENT,
 	HAPI_CMD_SEND_UPDATED_TRIGGERS,
 	HAPI_CMD_SEND_HOSTS,
 	HAPI_CMD_SEND_HOST_GROUP_ELEMENTS,
@@ -164,6 +165,10 @@ struct HapiArmInfo {
 	uint64_t numFailure;
 } __attribute__((__packed__));
 
+struct HapiParamTimeOfLastEvent {
+	uint64_t triggerId;
+} __attribute__((__packed__));
+
 struct HapiResponseHeader {
 	uint16_t type;
 	uint16_t code;
@@ -204,6 +209,12 @@ struct HapiResTimestampOfLastTrigger {
 struct HapiResLastEventId {
 	uint64_t lastEventId;
 } __attribute__((__packed__));
+
+struct HapiResTimeOfLastEvent {
+	uint64_t sec;
+	uint32_t nsec;
+} __attribute__((__packed__));
+
 
 class HatoholArmPluginInterface :
   public HatoholThreadBase, public EndianConverter {

--- a/server/hap/HatoholArmPluginBase.h
+++ b/server/hap/HatoholArmPluginBase.h
@@ -52,6 +52,18 @@ public:
 	 */
 	EventIdType getLastEventId(void);
 
+	/**
+	 * Get the time of the last event.
+	 *
+	 * @param triggerId An ID of the tareget trigger.
+	 *
+	 * @return
+	 * The time of the last event is returned. If no events found,
+	 * hasValidTime() of the retruned value is false.
+	 */
+	mlpl::SmartTime getTimeOfLastEvent(
+	  const TriggerIdType &triggerId = ALL_TRIGGERS);
+
 protected:
 	static const size_t WAIT_INFINITE;
 

--- a/server/src/HatoholArmPluginGate.h
+++ b/server/src/HatoholArmPluginGate.h
@@ -94,6 +94,7 @@ protected:
 	void cmdHandlerGetTimestampOfLastTrigger(
 	  const HapiCommandHeader *header);
 	void cmdHandlerGetLastEventId(const HapiCommandHeader *header);
+	void cmdHandlerGetTimeOfLastEvent(const HapiCommandHeader *header);
 	void cmdHandlerSendUpdatedTriggers(const HapiCommandHeader *header);
 	void cmdHandlerSendHosts(const HapiCommandHeader *header);
 	void cmdHandlerSendHostgroupElements(const HapiCommandHeader *header);

--- a/server/test/testHatoholArmPluginBase.cc
+++ b/server/test/testHatoholArmPluginBase.cc
@@ -97,6 +97,16 @@ void test_getLastEventId(void)
 	cppcut_assert_equal(expect, actual);
 }
 
+void test_getTimeOfLastEvent(void)
+{
+	loadTestDBEvents();
+	HatoholArmPluginTestPairArg arg(MONITORING_SYSTEM_HAPI_TEST_PASSIVE);
+	TestPair pair(arg);
+	const SmartTime expect(findTimeOfLastEvent(arg.serverId));
+	const SmartTime actual = pair.plugin->getTimeOfLastEvent();
+	cppcut_assert_equal(expect, actual);
+}
+
 void test_sendArmInfo(void)
 {
 	ArmInfo armInfo;


### PR DESCRIPTION
Getting monitoring data from OpenStack's ceilometer is done
by each trigger. So we needs the last event information by triggers.
