### PR TITLE
[server] common/HatoholException: Make HATOHOL_BUILD_ASSERT() work.

### DIFF
--- a/server/common/HatoholException.h
+++ b/server/common/HatoholException.h
@@ -109,6 +109,13 @@ _buildExpect<size_t, true>(size_t exp)
 	return exp;
 }
 
+template<>
+inline bool
+_buildExpect<bool, true>(bool exp)
+{
+	return exp;
+}
+
 #define HATOHOL_BUILD_EXPECT(exp,val)	\
 	_buildExpect<__typeof__(exp), (exp == val)>(exp)
 


### PR DESCRIPTION
HATOHOL_BUILD_ASSERT() did not work because we did not have _buildExpect for bool.
