### PR TITLE
[DBTablesMonitoring] Revive host names of events

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1722,7 +1722,7 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 		} else {
 			eventInfo.severity = triggerSeverity;
 		}
-		if (eventHostId != INVALID_HOST_ID) {
+		if (eventHostId != 0 && eventHostId != INVALID_HOST_ID) {
 			eventInfo.hostId = eventHostId;
 			eventInfo.hostName = eventHostName;
 		} else {


### PR DESCRIPTION
Host names are accidentaly removed by f9ca5c7aeb0ed935cd5babc894f1bdf701f0dab2
because default hostId in events table is 0, not INVLID_HOST_ID.

TODO: Should we fill it by INVALID_HOST_ID?
