### PR TITLE
[mlpl][SmartTime] Delete a dynamic allocation to improve performance.

### DIFF
--- a/server/mlpl/src/SmartTime.h
+++ b/server/mlpl/src/SmartTime.h
@@ -71,8 +71,7 @@ public:
 	operator std::string () const;
 
 private:
-	struct PrivateContext;
-	PrivateContext *m_ctx;
+	timespec m_time;
 };
 
 } // namespace mlpl


### PR DESCRIPTION
This class is tend to be instantiated as a temprorary variable on
stack in order to calculate the time difference and so on.
So the memory allocation may degrades performace.
