### PR TITLE
[DBClientJoinBuilder][HostResourceQueryOption] Fix a bug that hostgroup ...

### DIFF
--- a/server/src/DBClientJoinBuilder.cc
+++ b/server/src/DBClientJoinBuilder.cc
@@ -61,8 +61,10 @@ DBClientJoinBuilder::DBClientJoinBuilder(
 	const HostResourceQueryOption *hrqOption =
 	  dynamic_cast<const HostResourceQueryOption *>(option);
 	if (hrqOption) {
-		m_impl->selectExArg.tableField = hrqOption->getFromClause();
-		m_impl->selectExArg.useDistinct = hrqOption->isHostgroupUsed();
+		m_impl->selectExArg.tableField
+		  = hrqOption->getPrimaryTableName();
+		m_impl->selectExArg.useDistinct
+		  = hrqOption->isHostgroupUsed();
 	} else {
 		m_impl->selectExArg.tableField = table.name;
 	}
@@ -128,7 +130,17 @@ void DBClientJoinBuilder::add(const size_t &columnIndex)
 
 DBAgent::SelectExArg &DBClientJoinBuilder::getSelectExArg(void)
 {
+	const HostResourceQueryOption *hrqOption =
+	  dynamic_cast<const HostResourceQueryOption *>(m_impl->option);
+	if (hrqOption) {
+		m_impl->selectExArg.tableField += hrqOption->getJoinClause();
+	}
 	return m_impl->selectExArg;
+}
+
+DBAgent::SelectExArg &DBClientJoinBuilder::build(void)
+{
+	return getSelectExArg();
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/DBClientJoinBuilder.h
+++ b/server/src/DBClientJoinBuilder.h
@@ -104,6 +104,7 @@ public:
 	void add(const size_t &columnIndex);
 
 	DBAgent::SelectExArg &getSelectExArg(void);
+	DBAgent::SelectExArg &build(void);
 
 protected:
 	static const char *getJoinOperatorString(const JoinType &type);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1653,7 +1653,7 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	}
 
 	// Condition
-	DBAgent::SelectExArg &arg = builder.getSelectExArg();
+	DBAgent::SelectExArg &arg = builder.build();
 
 	string optCond;
 	arg.condition.swap(optCond); // option.getCondition() must be set.

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -201,6 +201,28 @@ string HostResourceQueryOption::getFromClause(void) const
 		return getFromClauseForOneTable();
 }
 
+string HostResourceQueryOption::getJoinClause(void) const
+{
+	if (!isHostgroupUsed())
+		return string();
+
+	const Synapse &synapse = m_impl->synapse;
+	const ColumnDef *hgrpColumnDefs =
+	  synapse.hostgroupMapTableProfile.columnDefs;
+
+	return StringUtils::sprintf(
+	  " INNER JOIN %s ON ((%s=%s.%s) AND (%s=%s.%s))",
+	  synapse.hostgroupMapTableProfile.name,
+
+	  getServerIdColumnName().c_str(),
+	  synapse.hostgroupMapTableProfile.name,
+	  hgrpColumnDefs[synapse.hostgroupMapServerIdColumnIdx].columnName,
+
+	  getHostIdColumnName().c_str(),
+	  synapse.hostgroupMapTableProfile.name,
+	  hgrpColumnDefs[synapse.hostgroupMapHostIdColumnIdx].columnName);
+}
+
 bool HostResourceQueryOption::isHostgroupUsed(void) const
 {
 	const Synapse &synapse = m_impl->synapse;
@@ -430,17 +452,9 @@ string HostResourceQueryOption::getFromClauseWithHostgroup(void) const
 	  synapse.hostgroupMapTableProfile.columnDefs;
 
 	return StringUtils::sprintf(
-	  "%s INNER JOIN %s ON ((%s=%s.%s) AND (%s=%s.%s))",
+	  "%s %s",
 	  synapse.tableProfile.name,
-	  synapse.hostgroupMapTableProfile.name,
-
-	  getColumnName(synapse.serverIdColumnIdx).c_str(),
-	  synapse.hostgroupMapTableProfile.name,
-	  hgrpColumnDefs[synapse.hostgroupMapServerIdColumnIdx].columnName,
-
-	  getColumnName(synapse.hostIdColumnIdx).c_str(),
-	  synapse.hostgroupMapTableProfile.name,
-	  hgrpColumnDefs[synapse.hostgroupMapHostIdColumnIdx].columnName);
+	  getJoinClause().c_str());
 }
 
 string HostResourceQueryOption::getColumnNameCommon(

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -136,6 +136,8 @@ public:
 
 	virtual const DBTermCodec *getDBTermCodec(void) const override;
 
+	std::string getJoinClause(void) const;
+
 protected:
 	std::string getServerIdColumnName(void) const;
 	std::string getHostgroupIdColumnName(void) const;


### PR DESCRIPTION
...filter doesn't work for events

There are two reasons:
- A wrong table is used on generating a column name at
  HostResourceQueryOption::getFromClauseWithHostgroup()
- Can't resolve triggers.host_id on joining map_hosts_hostgroups
  table because MySQL try to join it before triggers table:
  ERROR 1054 (42S22): Unknown column 'triggers.host_id' in 'on clause'

To resolve later one, I moved "JOIN" clause of map_hosts_hostgroups
to the last of "FROM" clause. But it just a quick hack. I think we
should refactor generating SQL query to resolve it formally.

issue #561
