### PR TITLE
[server] Remove unused variable

### DIFF
--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -448,8 +448,6 @@ string HostResourceQueryOption::getFromClauseForOneTable(void) const
 string HostResourceQueryOption::getFromClauseWithHostgroup(void) const
 {
 	const Synapse &synapse = m_impl->synapse;
-	const ColumnDef *hgrpColumnDefs =
-	  synapse.hostgroupMapTableProfile.columnDefs;
 
 	return StringUtils::sprintf(
 	  "%s %s",


### PR DESCRIPTION
This change suppresses the following warning:

```
HostResourceQueryOption.cc: In member function 'virtual std::string HostResourceQueryOption::getFromClauseWithHostgroup() const':
HostResourceQueryOption.cc:451:19: warning: unused variable 'hgrpColumnDefs' [-Wunused-variable]
  const ColumnDef *hgrpColumnDefs =
                   ^
```
