### PR TITLE
[client] Use POST mehtod for login to avoid exposing user name/password.

### DIFF
--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -117,9 +117,14 @@ HatoholConnector.prototype.start = function(connectParams) {
 
   function loginReadyCallback(user, password) {
     $.ajax({
-      url: "/tunnel/login?user=" + encodeURI(user)
-           + "&password=" + encodeURI(password),
-      type: "GET",
+      url: "/tunnel/login",
+      data: { user: user, password: password, },
+      processData: true,
+      type: "POST",
+      beforeSend: function(xhr, settings) {
+        // For the Django's CSRF protection mechanism
+	xhr.setRequestHeader('X-CSRFToken', getCsrfToken());
+      },
       success: function(data) {
         parseLoginResult(data);
       },

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -69,6 +69,8 @@
       </div>
     </div>
 
+    <div style="display: none;"><form>{% csrf_token %}</form></div>
+
 {% block main %}
 {% endblock %}
 


### PR DESCRIPTION
It is very bad to expose user's password in access logs.
To avoid that, let's use POST method for login.

Note that we need to get a token from django middleware
to cope with CSRF.  So far, form is used to get that token
as a cookie.  Later, we could use ensure_csrf_cookie().

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
