### PR TITLE
[client] po: Consistent Japanese notations.

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/django.po
+++ b/client/conf/locale/ja/LC_MESSAGES/django.po
@@ -45,7 +45,7 @@ msgstr "ホストグループ"
 
 #: viewer/actions_ajax.html:58 viewer/incident_settings_ajax.html:61
 msgid "Trigger"
-msgstr "トリガー"
+msgstr "トリガ"
 
 #: viewer/actions_ajax.html:59 viewer/events_ajax.html:71
 #: viewer/incident_settings_ajax.html:62 viewer/triggers_ajax.html:68
@@ -331,7 +331,7 @@ msgstr "概要:アイテム"
 
 #: viewer/overview_triggers_ajax.html:24 viewer/overview_triggers_ajax.html:29
 msgid "Overview : Triggers"
-msgstr "概要:トリガー"
+msgstr "概要:トリガ"
 
 #: viewer/servers_ajax.html:24 viewer/servers_ajax.html.py:29
 msgid "Servers"
@@ -359,11 +359,11 @@ msgstr ""
 
 #: viewer/triggers_ajax.html:24 viewer/triggers_ajax.html.py:29
 msgid "Triggers"
-msgstr "トリガー"
+msgstr "トリガ"
 
 #: viewer/triggers_ajax.html:59
 msgid "# of triggers per page"
-msgstr "ページ毎のトリガー数"
+msgstr "ページ毎のトリガ数"
 
 #: viewer/triggers_ajax.html:69
 msgid "Last change"
@@ -429,7 +429,7 @@ msgstr "権限"
 #~ msgstr "アイテム数"
 
 #~ msgid "Number of triggers [with problem]"
-#~ msgstr "トリガー数 [障害あり]"
+#~ msgstr "トリガ数 [障害あり]"
 
 #~ msgid "Number of users [Online]"
 #~ msgstr "ユーザ数 [オンライン]"

--- a/client/conf/locale/ja/LC_MESSAGES/djangojs.po
+++ b/client/conf/locale/ja/LC_MESSAGES/djangojs.po
@@ -54,7 +54,7 @@ msgstr "アイテム数"
 
 #: static/js/dashboard_view.js:110
 msgid "Number of triggers [with problem]"
-msgstr "トリガー数 [障害あり]"
+msgstr "トリガ数 [障害あり]"
 
 #: static/js/dashboard_view.js:122
 msgid "New values per second"
@@ -220,7 +220,7 @@ msgstr "ホスト名"
 
 #: static/js/hatohol_add_action_dialog.js:396
 msgid "Trigger"
-msgstr "トリガー"
+msgstr "トリガ"
 
 #: static/js/hatohol_add_action_dialog.js:403
 msgid "Status"
@@ -287,7 +287,7 @@ msgstr "プロジェクト: "
 #: static/js/hatohol_add_action_dialog.js:504
 #: static/js/incident_settings_view.js:204
 msgid "Tracker: "
-msgstr "トラッカー: "
+msgstr "トラッカ: "
 
 #: static/js/hatohol_add_action_dialog.js:555
 msgid "The template script returned the invalid value."
@@ -327,7 +327,7 @@ msgstr "不正なユーザです。"
 
 #: static/js/hatohol_def.js:193
 msgid "Failed to parse JSON data."
-msgstr "JSONデータの解析に失敗しました."
+msgstr "JSONデータの解析に失敗しました。"
 
 #: static/js/hatohol_def.js:194
 msgid "Not found target record."
@@ -731,7 +731,7 @@ msgstr "ダッシュボード"
 #: static/js/hatohol_navi.js:29 test/browser/test_hatohol_navi.js:43
 #: test/browser/test_hatohol_navi.js:72
 msgid "Overview : Triggers"
-msgstr "概要:トリガー"
+msgstr "概要:トリガ"
 
 #: static/js/hatohol_navi.js:33 test/browser/test_hatohol_navi.js:45
 #: test/browser/test_hatohol_navi.js:74
@@ -746,7 +746,7 @@ msgstr "最新データ"
 #: static/js/hatohol_navi.js:41 test/browser/test_hatohol_navi.js:49
 #: test/browser/test_hatohol_navi.js:78
 msgid "Triggers"
-msgstr "トリガー"
+msgstr "トリガ"
 
 #: static/js/hatohol_navi.js:44 test/browser/test_events_view.js:62
 #: test/browser/test_hatohol_navi.js:51 test/browser/test_hatohol_navi.js:80
@@ -1001,7 +1001,7 @@ msgstr "サーバ選択"
 
 #: static/js/hatohol_trigger_selector.js:26
 msgid "Trigger selecion"
-msgstr "トリガー選択"
+msgstr "トリガ選択"
 
 #: static/js/hatohol_trigger_selector.js:49
 msgid "Brief"


### PR DESCRIPTION
- If the word with 3 or more vowels ends with prolonged sound,
  omit the last "-".
- Use Japanese period.

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
