### PR TITLE
[server][libdl] add libdl function symbol check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,14 @@ fi
 AM_CONDITIONAL([HAVE_LIBRABBITMQ], [test "$have_librabbitmq" = "yes"])
 
 dnl **************************************************************
+dnl Checks for libdl
+dnl **************************************************************
+
+DL_FUNCTIONS="[dlopen, dlclose, dlerror, dlsym]"
+AC_CHECK_LIB([dl], $DL_FUNCTIONS, [],
+  [AC_MSG_ERROR([Could not found '$DL_FUNCTIONS' in dlfcn.h.])])
+
+dnl **************************************************************
 dnl Checks for MySQL
 dnl **************************************************************
 AC_CHECK_PROGS(MYSQL_CONFIG, mysql_config)


### PR DESCRIPTION
I've got an linker error `undefined reference to symbol 'dlclose@@GLIBC_2.2.5'` when I compile hatohol/server.
#### My environment
- Ubuntu 14.04.1 LTS amd64
##### Solution 1 (just a workaround, I think.):

`make` execute with `LIBS=-ldl`.
It can compile hatohol/server.
##### Solution 2:

Add check macro to configure.ac.
This pull request selects this solution. 
#### build log

``` log
hatohol% ./autogen.sh
hatohol% make -j4
/bin/bash ./config.status --recheck
running CONFIG_SHELL=/bin/bash /bin/bash ./configure --no-create --no-recursion
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking how to create a pax tar archive... gnutar
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking how to print strings... printf
checking for style of include used by make... GNU
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 3458764513820540925
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... yes
checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for mt... mt
checking if mt is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking dependency style of g++... gcc3
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... yes
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether make supports nested variables... (cached) yes
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for GLIB... yes
checking for GIO... yes
checking for GTHREAD... yes
checking for LIBSOUP... yes
checking for JSON_GLIB... yes
checking for SQLITE3... yes
checking for UUID... yes
checking for LIBRABBITMQ... no
checking for mysql_config... mysql_config
checking for _init in -lqpidmessaging... yes
checking qpid/ImportExport.h usability... yes
checking qpid/ImportExport.h presence... yes
checking for qpid/ImportExport.h... yes
checking qpid/types/Exception.h usability... yes
checking qpid/types/Exception.h presence... yes
checking for qpid/types/Exception.h... yes
checking for CUTTER... yes
checking for GCUTTER... yes
checking for CPPCUTTER... yes
checking for sqlite3... yes
checking for enabling coverage... no
checking for mocha... no
checking for npm... yes
checking that generated files are newer than configure... done
configure: creating ./config.status

Configure Result:

  C Unit test (cutter) : yes
  JS Unit test         : no

 /bin/bash ./config.status
config.status: creating Makefile
config.status: creating hatohol.spec
config.status: creating data/Makefile
config.status: creating data/init.d/Makefile
config.status: creating data/init.d/debian/hatohol.debian
config.status: creating data/init.d/debian/Makefile
config.status: creating data/init.d/centos/hatohol.centos
config.status: creating data/init.d/centos/Makefile
config.status: creating data/test/Makefile
config.status: creating server/Makefile
config.status: creating server/mlpl/Makefile
config.status: creating server/mlpl/src/Makefile
config.status: creating server/mlpl/test/Makefile
config.status: creating server/mlpl/mlpl.pc
config.status: creating server/common/Makefile
config.status: creating server/src/Makefile
config.status: creating server/hap/Makefile
config.status: creating server/tools/Makefile
config.status: creating server/data/Makefile
config.status: creating server/data/tls/Makefile
config.status: creating server/data/tls/hatohol-ca-initialize
config.status: creating server/data/tls/hatohol-ca-sign-client-certificate
config.status: creating server/data/tls/hatohol-ca-sign-server-certificate
config.status: creating server/test/Makefile
config.status: creating server/test/fixtures/Makefile
config.status: creating server/benchmark/Makefile
config.status: creating client/Makefile
config.status: creating client/test/Makefile
config.status: creating config.h
config.status: config.h is unchanged
config.status: executing depfiles commands
config.status: executing libtool commands
make  all-recursive
make[1]: ディレクトリ `/media/Data2/Gitrepo/hatohol' に入ります
Making all in server
make[2]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server' に入ります
Making all in mlpl
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl' に入ります
Making all in src
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl/src' に入ります
  CXX      Mutex.lo
  CXX      ReadWriteLock.lo
  CXX      SimpleSemaphore.lo
  CXX      EventSemaphore.lo
  CXX      SeparatorInjector.lo
  CXX      SmartBuffer.lo
  CXX      Logger.lo
  CXX      StringUtils.lo
  CXX      ParsableString.lo
  CXX      SmartTime.lo
  CXXLD    libmlpl.la
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl/src' から出ます
Making all in test
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl/test' に入ります
  CXX      testMutex.lo
  CXX      testLogger.lo
  CXX      testReadWriteLock.lo
  CXX      testStringUtils.lo
  CXX      testParsableString.lo
  CXX      testSeparatorInjector.lo
  CXX      testSmartBuffer.lo
  CXX      testReaper.lo
  CXX      testSmartTime.lo
  CXX      testSmartQueue.lo
  CXX      testAtomicValue.lo
  CXX      testSimpleSemaphore.lo
  CXX      testEventSemaphore.lo
  CXX      loggerTestee.o
  CXXLD    loggerTestee
  CXXLD    testMLPL.la
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl/test' から出ます
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl' に入ります
make[4]: `all-am' に対して行うべき事はありません.
make[4]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl' から出ます
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/mlpl' から出ます
Making all in common
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/common' に入ります
  CXX      ArmStatus.lo
  CXX      DataStoreException.lo
  CXX      HatoholThreadBase.lo
  CXX      HatoholArmPluginInterface.lo
  CXX      HatoholException.lo
  CXX      HatoholError.lo
  CXX      ItemData.lo
  CXX      ItemDataUtils.lo
  CXX      ItemGroup.lo
  CXX      ItemGroupType.lo
  CXX      ItemGroupPtr.lo
  CXX      ItemTable.lo
  CXX      ItemTablePtr.lo
  CXX      JSONBuilder.lo
  CXX      JSONParser.lo
  CXX      JSONParserPositionStack.lo
  CXX      MonitoringServerInfo.lo
  CXX      UsedCountable.lo
  CXX      Utils.lo
  CXX      UsedCountablePtr.lo
  CXX      ZabbixAPI.lo
  CXXLD    libhatohol-common.la
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/common' から出ます
Making all in src
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/src' に入ります
  CXX      ActionExecArgMaker.lo
  CXX      ActorCollector.lo
  CXX      ArmBase.lo
  CXX      ActionManager.lo
  CXX      ArmFake.lo
  CXX      ArmIncidentTracker.lo
  CXX      ArmNagiosNDOUtils.lo
  CXX      ArmRedmine.lo
  CXX      ArmZabbixAPI.lo
  CXX      ArmCeilometer.lo
  CXX      ChildProcessManager.lo
  CXX      Closure.lo
  CXX      ThreadLocalDBCache.lo
  CXX      ConfigManager.lo
  CXX      DataQueryContext.lo
  CXX      DataQueryOption.lo
  CXX      DBAgent.lo
  CXX      DBAgentFactory.lo
  CXX      DBAgentMySQL.lo
  CXX      DBAgentSQLite3.lo
  CXX      DB.lo
  CXX      DBHatohol.lo
  CXX      DBTables.lo
  CXX      DBTablesAction.lo
  CXX      DBTablesConfig.lo
  CXX      DBTablesUser.lo
  CXX      DBTablesMonitoring.lo
  CXX      DBTablesHost.lo
  CXX      DBClientJoinBuilder.lo
  CXX      DBTermCodec.lo
  CXX      DataStore.lo
  CXX      DataStoreFactory.lo
  CXX      DataStoreManager.lo
  CXX      DataStoreFake.lo
  CXX      DataStoreNagios.lo
  CXX      DataStoreZabbix.lo
  CXX      FaceBase.lo
  CXX      FaceRest.lo
  CXX      Hatohol.lo
  CXX      HostResourceQueryOption.lo
  CXX      HatoholArmPluginGate.lo
  CXX      HatoholServer.lo
  CXX      HatoholDBUtils.lo
  CXX      HostInfoCache.lo
  CXX      IncidentSender.lo
  CXX      IncidentSenderManager.lo
  CXX      IncidentSenderRedmine.lo
  CXX      ItemFetchWorker.lo
  CXX      ItemGroupStream.lo
  CXX      LabelUtils.lo
  CXX      NamedPipe.lo
  CXX      OperationPrivilege.lo
  CXX      RedmineAPI.lo
  CXX      ResidentCommunicator.lo
  CXX      RestResourceAction.lo
  CXX      RestResourceHost.lo
  CXX      RestResourceIncidentTracker.lo
  CXX      RestResourceServer.lo
  CXX      RestResourceUser.lo
  CXX      SessionManager.lo
  CXX      SQLUtils.lo
  CXX      UnifiedDataStore.lo
  CXX      main.o
  CXX      hatoholResidentYard.o
  CXXLD    libhatohol.la
  CXXLD    hatohol
  CXXLD    hatohol-resident-yard
/usr/bin/ld: hatoholResidentYard.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[3]: *** [hatohol-resident-yard] エラー 1
make[3]: *** 未完了のジョブを待っています....
make[3]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server/src' から出ます
make[2]: *** [all-recursive] エラー 1
make[2]: ディレクトリ `/media/Data2/Gitrepo/hatohol/server' から出ます
make[1]: *** [all-recursive] エラー 1
make[1]: ディレクトリ `/media/Data2/Gitrepo/hatohol' から出ます
make: *** [all] エラー 2
```
