### PR TITLE
[HatoholDialog] Fix a problem that accepts enter key even if the button is disabled

### DIFF
--- a/client/static/js/hatohol_dialog.js
+++ b/client/static/js/hatohol_dialog.js
@@ -65,7 +65,9 @@ var HatoholDialog = function(id, dialogTitle, buttons, dialogAttr) {
       $(".ui-dialog-titlebar-close").hide();
       $(self.dialogId).keypress(function(event) {
         if (event.keyCode == $.ui.keyCode.ENTER)
-          $(this).parent().find('.ui-dialog-buttonset button:first').click();
+          var button = $(this).parent().find('.ui-dialog-buttonset button:first');
+          if (button && !button.is(':disabled'))
+            button.click();
       });
     }
   });


### PR DESCRIPTION
In the previous version, HatoholDialog catches an ENTER key event and
run the event handler of the primary button even if its state is disabled.
This version only accept the button event only when the button is enabled.
