### PR TITLE
[HatoholServerEditDialogParameterized] Arrange JSON paramters.

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog_parameterized.js
+++ b/client/static/js/hatohol_server_edit_dialog_parameterized.js
@@ -72,14 +72,11 @@ var HatoholServerEditDialogParameterized = function(params) {
       if (param.hidden)
         val = param.default;
       else if (param.inputStyle == 'checkBox')
-        val = $('#' + param.id).prop('checked');
+        val = $('#' + param.elementId).prop('checked');
       else
-        val = $('#' + param.id).val();
+        val = $('#' + param.elementId).val();
 
-      if (param.class)
-        queryData[param.class] = val;
-      else
-        queryData['_extra'][param.name] = val;
+      queryData[param.id] = val;
     }
     return queryData;
   }
@@ -199,7 +196,7 @@ HatoholServerEditDialogParameterized.prototype.onAppendMainElement = function ()
 
     // set events to fix up state of 'apply' button
     for (var i = 0; i < paramObj.length; i++) {
-      $('#' + paramObj[i].id).keyup(function() {
+      $('#' + paramObj[i].elementId).keyup(function() {
         self.fixupApplyButtonState();
       });
     }
@@ -210,7 +207,11 @@ HatoholServerEditDialogParameterized.prototype.onAppendMainElement = function ()
     if (param.hidden)
       return null;
 
-    var label = param.name;
+    var label;
+    if (param.label)
+      label = param.label;
+    else
+      label = param.id;
 
     var defaultValue = '';
     if (param.default != undefined)
@@ -224,13 +225,13 @@ HatoholServerEditDialogParameterized.prototype.onAppendMainElement = function ()
     if (param.hint != undefined)
       hint = param.hint;
 
-    var id = 'server-edit-dialog-param-form-' + index;
-    param.id = id;
+    var elementId = 'server-edit-dialog-param-form-' + index;
+    param.elementId = elementId;
     var div = $('<div class="form-group">');
     if (inputStyle == 'text') {
-      div.append(makeTextInput(id, label, defaultValue, hint));
+      div.append(makeTextInput(elementId, label, defaultValue, hint));
     } else if (inputStyle == 'checkBox') {
-      div.append(makeCheckboxInput(id, label, hint));
+      div.append(makeCheckboxInput(elementId, label, hint));
     } else {
       hatoholErrorMsgBox("[Malformed reply] unknown input style: " +
                          inputStyle);
@@ -291,7 +292,7 @@ HatoholServerEditDialogParameterized.prototype.fixupApplyButtonState = function(
        continue;
      if (param.hidden)
        continue;
-     if (!$('#' + param.id).val())
+     if (!$('#' + param.elementId).val())
        break;
   }
   var state = (i == paramObj.length);

--- a/server/data/mk-server-type-sql
+++ b/server/data/mk-server-type-sql
@@ -5,39 +5,39 @@ import json
 
 def get_zabbix_params():
     obj = []
-    obj.append({'name':'Nickname',
-                'class':'nickname'});
-    obj.append({'name':'Host name',
-                'class':'hostName'});
-    obj.append({'name':'IP address',
-                'class':'ipAddress'});
-    obj.append({'name':'Port',
-                'class':'port',
+    obj.append({'id':'nickname',
+                'label':'Nickname'});
+    obj.append({'id':'hostName',
+                'label':'Host name'});
+    obj.append({'id':'ipAddress',
+                'label':'IP address'});
+    obj.append({'id':'port',
+                'label':'Port',
                 'default':'80'});
-    obj.append({'name':'User name',
-                'class':'userName'});
-    obj.append({'name':'Password',
-                'class':'password'});
-    obj.append({'name':'Polling interval (sec)',
-                'class':'pollingInterval',
+    obj.append({'id':'userName',
+                'label':'User name'});
+    obj.append({'id':'password',
+                'label':'Password'});
+    obj.append({'id':'pollingInterval',
+                'label':'Polling interval (sec)',
                 'default':'30'});
-    obj.append({'name':'Retry interval (sec)',
-                'class':'retryInterval',
+    obj.append({'id':'retryInterval',
+                'label':'Retry interval (sec)',
                 'default':'10'});
     return obj;
 
 
 def get_hapi_params():
     obj = []
-    obj.append({'name':'Passive mode',
-                'class':'passiveMode',
+    obj.append({'id':'passiveMode',
+                'label':'Passive mode',
                 'inputStyle':'checkBox'});
-    obj.append({'name':'Broker URL',
-                'class':'brokerUrl',
+    obj.append({'id':'brokerUrl',
+                'label':'Broker URL',
                 'allowEmpty':True,
                 'hint':'(empty: Default)'});
-    obj.append({'name':'Static queue address',
-                'class':'staticQueueAddress',
+    obj.append({'id':'staticQueueAddress',
+                'label':'Static queue address',
                 'allowEmpty':True,
                 'hint':'(empty: Default)'});
     return obj;
@@ -51,25 +51,25 @@ class ZabbixParamGenerator:
 class NagiosParamGenerator:
     def __call__(self):
         obj = []
-        obj.append({'name':'Nickname',
-                    'class':'nickname'});
-        obj.append({'name':'Host name',
-                    'class':'hostName'});
-        obj.append({'name':'IP address',
-                    'class':'ipAddress'});
-        obj.append({'name':'Port',
-                    'class':'port',
+        obj.append({'id':'nickname',
+                    'label':'Nickname'});
+        obj.append({'id':'hostName',
+                    'label':'Host name'});
+        obj.append({'id':'ipAddress',
+                    'label':'IP address'});
+        obj.append({'id':'port',
+                    'label':'Port',
                     'default':'0'});
-        obj.append({'name':'DB name',
-                    'class':'dbName'});
-        obj.append({'name':'User name',
-                    'class':'userName'});
-        obj.append({'name':'Password',
-                    'class':'password'});
-        obj.append({'name':'Polling interval (sec)',
-                    'class':'pollingInterval'});
-        obj.append({'name':'Retry interval (sec)',
-                    'class':'retryInterval'});
+        obj.append({'id':'dbName',
+                    'label':'DB name'});
+        obj.append({'id':'userName',
+                    'label':'User name'});
+        obj.append({'id':'password',
+                    'label':'Password'});
+        obj.append({'id':'pollingInterval',
+                    'label':'Polling interval (sec)'});
+        obj.append({'label':'Retry interval (sec)',
+                    'id':'retryInterval'});
         return json.dumps(obj)
 
 
@@ -89,30 +89,30 @@ class HapiJSONParamGenerator:
 class HapiCeilometerGenerator:
     def __call__(self):
         obj = []
-        obj.append({'name':'Nickname',
-                    'class':'nickname'});
-        obj.append({'name':'Keystone URL',
-                    'class':'hostName',
+        obj.append({'id':'nickname',
+                    'label':'Nickname'});
+        obj.append({'id':'hostName',
+                    'label':'Keystone URL',
                     'hint':'Example: http://controller:5000/v2.0'});
-        obj.append({'name':'IP address',
-                    'class':'ipAddress',
+        obj.append({'id':'ipAddress',
+                    'label':'IP address',
                     'hidden':True,
                     'default':'127.0.0.1'});
-        obj.append({'name':'Port',
-                    'class':'port',
+        obj.append({'id':'port',
+                    'label':'Port',
                     'hidden':True,
                     'default':'0'});
-        obj.append({'name':'Tenant name',
-                    'class':'dbName'});
-        obj.append({'name':'User name',
-                    'class':'userName'});
-        obj.append({'name':'Password',
-                    'class':'password'});
-        obj.append({'name':'Polling interval (sec)',
-                    'class':'pollingInterval',
+        obj.append({'id':'dbName',
+                    'label':'Tenant name'});
+        obj.append({'id':'userName',
+                    'label':'User name'});
+        obj.append({'id':'password',
+                    'label':'Password'});
+        obj.append({'id':'pollingInterval',
+                    'label':'Polling interval (sec)',
                     'default':'30'});
-        obj.append({'name':'Retry interval (sec)',
-                    'class':'retryInterval',
+        obj.append({'id':'retryInterval',
+                    'label':'Retry interval (sec)',
                     'default':'10'});
         obj.extend(get_hapi_params())
         return json.dumps(obj)


### PR DESCRIPTION
This patch arrange paramter names and to improve readability and simplicity.

The new rules are following.
- Each paramter must have 'id' which is uniqueue.
- The paramter 'label' is used for the label field of UI.
- The WebUI use 'id' as key of returned parameters.

NOTE:
Currently REST service POST/PUT on '/server' saves conventional paramters only.
We will add a mechanism to save other paramters in the one column as a (probably JSON)
string, which is directly passed to Arm Plugins.
