### PR TITLE
[hatohol-db-initiator] Add a new command to setup database.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -146,22 +146,21 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
-  $ mysql -uroot -p < /usr/local/share/hatohol/sql/create-db.sql
+  $ hatohol-db-initiator database_name mysql_user mysql_password
+
+Example:
+
+  $ hatohol-db-initiator hatohol root rootpass
 
 Tips:
-- If the root password of the MySQL server is not set, -p option is not needed.
-- The default create-db.sql sets 'hatohol'/'hatohol' as user/password of
-the DB. If you change them, copy create-db.sql to any directory,
-replace them in the GRANT line of the copied file, and use it
-as an input of the mysql command.
-- If Hatohol server and MySQL server are executed on different machines.
-You have to replace 'localhost' in the GRANT line with the machine name or
-the IP address that runs Hatohol server.
+- If the root password of the MySQL server is not set, just pass ''.
+- You can change password of the created DB by --hatohol-db-user and --hatohol-db-passowrd options.
+- If Hatohol server and MySQL server are executed on different machines, you have to input GRANT statement manually with the mysql command line tool.
 
 For example, user/password are 'myuser'/'mypasswd' and the IP address of
 Hatohol server is 192.168.10.50.
 
-    GRANT ALL PRIVILEGES ON hatohol.* TO myuser@"192.168.10.50" IDENTIFIED BY 'mypasswd';
+    mysql> GRANT ALL PRIVILEGES ON hatohol.* TO myuser@"192.168.10.50" IDENTIFIED BY 'mypasswd';
 
 (2) Prepare the data base directory
 

--- a/server/src/DBHatohol.cc
+++ b/server/src/DBHatohol.cc
@@ -53,6 +53,22 @@ struct DBHatohol::Impl {
 DB::SetupContext DBHatohol::Impl::setupCtx(typeid(DBHatohol));
 
 // ---------------------------------------------------------------------------
+// This function is intended to call from hatohol-db-initiator
+// ---------------------------------------------------------------------------
+extern "C"
+int createDBHatohol(
+  const char *dbName, const char *user, const char *password)
+{
+	try {
+		DBHatohol::setDefaultDBParams(dbName, user, password);
+		DBHatohol db; // Create all DBTables instances to create tables
+	} catch (...) {
+		return -1;
+	}
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
 // Public methods
 // ---------------------------------------------------------------------------
 void DBHatohol::reset(void)

--- a/server/tools/Makefile.am
+++ b/server/tools/Makefile.am
@@ -1,5 +1,6 @@
 bin_PROGRAMS = hatohol-def-src-file-generator
 dist_bin_SCRIPTS = hatohol-voyager \
+                   hatohol-db-initiator \
                    hatohol-inspect-info-collector \
                    hatohol-server-type-util
 

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+import sys
+import os
+import argparse
+import MySQLdb
+from ctypes import *
+
+def create_db_if_needed(cursor, args):
+    cursor.execute('SHOW DATABASES')
+    found = False
+    for row in cursor.fetchall():
+        if args.db_name in row:
+            found = True
+            break
+    if found:
+        print 'DB already exists: %s' % args.db_name
+    else:
+        cursor.execute('CREATE DATABASE %s' % args.db_name)
+        cursor.execute('GRANT ALL PRIVILEGES ON %s.* TO %s@localhost IDENTIFIED BY \'%s\'' % args.db_name, args.hatohol_db_user, args.hatohol_db_password)
+        print 'Created DB: %s' % args.db_name
+    cursor.execute('USE %s' % args.db_name)
+
+def create_hatohol_tables(args):
+    hatohol = cdll.LoadLibrary('libhatohol.so')
+    ret = hatohol.createDBHatohol(c_char_p(args.db_name),
+                                  c_char_p(args.db_user),
+                                  c_char_p(args.db_password))
+    if ret == -1:
+        print 'Failed to create DBHatohol object'
+        sys.exit(-1)
+
+def execute_sql_statements_from_file(cursor, path):
+    with open(path, 'r') as sql_file:
+        for statement in sql_file:
+            cursor.execute(statement)
+    print 'Succeessfully loaded: %s' % path
+
+
+def load_data_from_file(cursor, args, table_name, file_name):
+    cursor.execute('SELECT COUNT(*) FROM %s;' % table_name)
+    num_rows = cursor.fetchall()[0][0]
+    if num_rows > 0 and not args.force:
+        print 'The number of rows in table: %s ' \
+              'is not zero (%d)' % (table_name, num_rows)
+        print 'Skip loading data: %s' % file_name
+        print 'If you want to drop the existing table ' \
+              'and load data, use -f or --force option.'
+        return
+
+    if num_rows > 0:
+        cursor.execute('DELETE FROM %s' % table_name)
+        print 'Deleted all rows in table: %s' % table_name
+
+    execute_sql_statements_from_file(cursor, args.sql_dir + '/' + file_name)
+
+
+def start(args):
+    db = MySQLdb.connect(host=args.host,
+                           user=args.db_user, passwd=args.db_password)
+    cursor = db.cursor()
+    create_db_if_needed(cursor, args)
+    create_hatohol_tables(args)
+
+    try:
+        load_data_from_file(cursor, args, 'server_types', 'server-type.sql')
+        db.commit()
+    except:
+        db.rollback()
+
+    cursor.close()
+    db.close()
+
+
+def get_default_sql_dir():
+    return os.path.dirname(__file__) + '/../share/hatohol/sql'
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Hatohol DB Initiator')
+    parser.add_argument('db_name', type=str)
+    parser.add_argument('db_user', type=str)
+    parser.add_argument('db_password', default='', type=str)
+    parser.add_argument('--host', default='localhost', type=str)
+    parser.add_argument('--sql-dir', default=get_default_sql_dir(), type=str)
+    parser.add_argument('--hatohol-db-name', default='hatohol', type=str)
+    parser.add_argument('--hatohol-db-password', default='hatohol', type=str)
+    parser.add_argument('-f', '--force', action='store_true')
+    args = parser.parse_args()
+    start(args)

--- a/server/tools/hatohol-server-type-util
+++ b/server/tools/hatohol-server-type-util
@@ -168,7 +168,6 @@ def generate_one_type(table_name, server_type, server_label, parameters, plugin_
 
 def generate_mysql(generators):
     TABLE_NAME = 'server_types'
-    print 'DELETE FROM %s;' % TABLE_NAME
     for gen in generators:
         generate_one_type(TABLE_NAME, gen.get_server_type(),
                           gen.get_server_type_name(),


### PR DESCRIPTION
This utility performs the following things
- create database if needed
- load default data to sever_types table if the table is empty
  (can forcely update data by the option)
