### PR TITLE
[HapProcessCeilometer] Fix the time conversion code.

### DIFF
--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -570,7 +570,7 @@ string  HapProcessCeilometer::getHistoryQueryOption(
 	tm tim;
 	const timespec &ts = lastTime.getAsTimespec();
 	HATOHOL_ASSERT(
-	  gmtime_r(&ts.tv_sec, &tim),
+	  localtime_r(&ts.tv_sec, &tim),
 	  "Failed to call gmtime_r(): %s\n", ((string)lastTime).c_str());
 	string query = StringUtils::sprintf(
 	  "?q.field=timestamp&q.op=gt&q.value="


### PR DESCRIPTION
When an alarm is received, it's treated as the localtime. However,
the previous code uses as GMT when the new alarm is required.
