### PR TITLE
Cleanup initial db check

### DIFF
--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -139,18 +139,18 @@ static bool daemonize(void)
 
 static bool checkDBConnection(void)
 {
-	void *dbObjAddr = NULL;
 	try {
 		ThreadLocalDBCache cache;
-		DBTablesConfig &config = cache.getConfig();
-		dbObjAddr = &config;
+		DBHatohol &dbHatohol = cache.getDBHatohol();
+		HATOHOL_ASSERT(&dbHatohol,
+		  "The reference of DBHatohol is unexpectedly NULL.");
 	} catch (const exception &e) {
 		MLPL_CRIT("Failed to create a database object. "
 		          "This program is aborted. Reason: %s\n",
 		          e.what());
 		return false;
 	}
-	return dbObjAddr;
+	return true;
 }
 
 int mainRoutine(int argc, char *argv[])


### PR DESCRIPTION
Previously checkDBConnection() returns true if the address of
the reference is not NULL. This logic is actually unnecessary.
It was just added to avoid a warning of 'unsed variable'.
