### PR TITLE
[ConfigManager] Simplify the command line option.

### DIFF
--- a/client/HowToTest.md
+++ b/client/HowToTest.md
@@ -56,7 +56,7 @@ run Hatohol with a debug mode
 run Hatohol server with --test-mode  
 Ex.)
 
-    $ LD_LIBRARY_PATH=mlpl/src/.libs:src/.libs HATOHOL_DB_DIR=~/tmp src/.libs/hatohol --pid-file-path ~/tmp/hatohol.pid --foreground --test-mode
+    $ LD_LIBRARY_PATH=mlpl/src/.libs:src/.libs HATOHOL_DB_DIR=~/tmp src/.libs/hatohol --pid-file ~/tmp/hatohol.pid --foreground --test-mode
 
 run djang with debug mode (set an environment variable: HATOHOL_DEBUG=1)
 

--- a/server/QUICK-REF.md
+++ b/server/QUICK-REF.md
@@ -10,7 +10,7 @@ specify the data base server (and optionally port number) for config data.
 --foreground  
 run hatohol as a foreground process.
 
---pid-file-path  
+--pid-file
 specify the path of the pid file.
 
 --enable-copy-on-demand  
@@ -18,6 +18,6 @@ enable the copy on demand.
 
 Examples
 --------
-start hatohol as a foreground process without installing. The option: --pid-file-path enables non-root users to execute it.
+start hatohol as a foreground process without installing. The option: --pid-file enables non-root users to execute it.
 
-    server $ PATH=hap/.libs:$PATH LD_LIBRARY_PATH=mlpl/src/.libs:src/.libs:common/.libs:hap/.libs src/.libs/hatohol --pid-file-path ~/tmp/hatohol.pid --foreground
+    server $ PATH=hap/.libs:$PATH LD_LIBRARY_PATH=mlpl/src/.libs:src/.libs:common/.libs:hap/.libs src/.libs/hatohol --pid-file ~/tmp/hatohol.pid --foreground

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -227,7 +227,7 @@ bool ConfigManager::parseCommandLine(gint *argc, gchar ***argv,
                                      CommandLineOptions *cmdLineOpts)
 {
 	GOptionEntry entries[] = {
-		{"pid-file-path",
+		{"pid-file",
 		 'p', 0, G_OPTION_ARG_STRING,
 		 &cmdLineOpts->pidFilePath, "Pid file path", NULL},
 		{"foreground",

--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -184,7 +184,7 @@ void test_parsePidFilePathDefault(void)
 void test_parsePidFilePath(void)
 {
 	CommandArgHelper cmds;
-	cmds << "--pid-file-path";
+	cmds << "--pid-file";
 	cmds << "/tmp/hoge/foo.x";
 	cmds.activate();
 	cppcut_assert_equal(

--- a/server/test/testMain.cc
+++ b/server/test/testMain.cc
@@ -323,7 +323,7 @@ bool spawnChildProcess(string magicNumber, GPid &childPid, const string &pidFile
 	  "--db-name", TEST_DB_NAME,
 	  "--db-user", TEST_DB_USER,
 	  "--db-password", TEST_DB_PASSWORD,
-	  "--pid-file-path", pidFilePath.c_str(), NULL};
+	  "--pid-file", pidFilePath.c_str(), NULL};
 	const gchar *envp[] = {"LD_LIBRARY_PATH=../src/.libs/", magicNumber.c_str(), NULL};
 	GError *error;
 	gboolean succeeded;

--- a/test/launch-hatohol-for-test.sh
+++ b/test/launch-hatohol-for-test.sh
@@ -11,7 +11,7 @@ if [ $error_code -ne 0 ]; then
   exit $error_code
 fi
 
-HATOHOL_DB_DIR=/tmp $server_dir/src/.libs/hatohol --pid-file-path /tmp/hatohol.pid --foreground --test-mode &
+HATOHOL_DB_DIR=/tmp $server_dir/src/.libs/hatohol --pid-file /tmp/hatohol.pid --foreground --test-mode &
 server_pid=$!
 
 cd $client_dir


### PR DESCRIPTION
--pid-file-path ->
--pid-file

The previous name is a little redundant and long to input by hand.
