### PR TITLE
[hatohol_server_edit_dialog_parameterized] Request to turn off auto completion of parameters.

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog_parameterized.js
+++ b/client/static/js/hatohol_server_edit_dialog_parameterized.js
@@ -162,7 +162,7 @@ HatoholServerEditDialogParameterized.prototype.createMainElement = function() {
     form.append($('<label>').text(gettext('Monitoring server type')));
     var select = $('<select id="selectServerType">').appendTo(form);
     select.append($('<option>').html(gettext('Please select')).val('_header'));
-    mainDiv.append('<form id="add-server-param-form" class="form-horizontal" role="form">');
+    mainDiv.append('<form id="add-server-param-form" class="form-horizontal" role="form" autocomplete="off">');
     return mainDiv;
   }
 };


### PR DESCRIPTION
Automatic completion of paramters sometimes makes input worng.
So this patch add autocomplete="off" attribute to the form.

However, some browser ignore this attibute for the password form,
such as Chrome 34 and IE11.
