### PR TITLE
[WebUI][Servers] Remove code to load non existing file.

### DIFF
--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -76,7 +76,6 @@
 {% endblock %}
 
 {% block option %}
-  <script src="{{ STATIC_URL }}js/hatohol_server_edit_dialog.js"></script>
   <script src="{{ STATIC_URL }}js/hatohol_server_edit_dialog_parameterized.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
hatohol_server_edit_dialog.js has been removed from the repository.
Although the line causes an error, many browsers seem to ignore it.
So any problem has appeared since the file was deleted.
