### PR TITLE
[server][HAPI JSON] Support host information in event

### DIFF
--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -87,7 +87,7 @@ private:
 
 		HostInfoListIterator it = hostInfoList.begin();
 		for (; it != hostInfoList.end(); ++it) {
-			HostInfo &hostInfo = *it;
+			const HostInfo &hostInfo = *it;
 			m_hosts[hostInfo.hostName] = hostInfo.id;
 			if (hostInfo.id > m_largestHostID) {
 				m_largestHostID = hostInfo.id;


### PR DESCRIPTION
This change is for Hatohol 14.12. Please keep it open until 14.09 is released.

TODO: This implementation doesn't work on multi-master architecture
because new host ID is emitted on each Hatohol server.
