### PR TITLE
[hatohol-db-initiator] Fix a problem in which libhatohol cannot be loaded

### DIFF
--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -26,7 +26,7 @@ def create_db_if_needed(cursor, args):
     cursor.execute('USE %s' % args.db_name)
 
 def create_hatohol_tables(args):
-    hatohol = cdll.LoadLibrary('libhatohol.so')
+    hatohol = cdll.LoadLibrary('libhatohol.so.0')
     ret = hatohol.createDBHatohol(c_char_p(args.db_name),
                                   c_char_p(args.db_user),
                                   c_char_p(args.db_password))


### PR DESCRIPTION
libhatohol.so is a synbolic link to libhatohol.so.0.
However, the link is typically provided by the 'dev' package.
I.e. 'libhatohol.so' does not exist on machine for operation.
