### PR TITLE
[ActionsView] Fix the regression that doesn't show 'No limit'.

### DIFF
--- a/client/static/js/actions_view.js
+++ b/client/static/js/actions_view.js
@@ -229,9 +229,10 @@ var ActionsView = function(userProfile) {
 
       var timeout = actionDef.timeout;
       if (timeout == 0)
-        timeout = gettext("No limit");
-      timeoutSec = timeout / 1000;
-      s += "<td>" + escapeHTML(timeoutSec) + "</td>";
+        timeoutLabel = gettext("No limit");
+      else
+        timeoutLabel = timeout / 1000;
+      s += "<td>" + escapeHTML(timeoutLabel) + "</td>";
 
       s += "</tr>";
     }


### PR DESCRIPTION
With The previous commit: 68d58288c2a3, the timeout value is shown
as number even if the timeout is unlimited. This changed the behavior and
the regression. This patch resolves it.
