### PR TITLE
[Server] implement check another server process running

### DIFF
--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -174,7 +174,7 @@ int mainRoutine(int argc, char *argv[])
 #endif // GLIB_VERSION_2_36
 #ifndef GLIB_VERSION_2_32
 	g_thread_init(NULL);
-#endif // GLIB_VERSION_2_32 
+#endif // GLIB_VERSION_2_32
 
 	// parse command line argument
 	ExecContext ctx;


### PR DESCRIPTION
This implementation for daemonized hatohol server process. #40 
- add `checkAnotherServerProcess()` function to check another hatohol server process running
- `checkAnotherServerProcess()` checks existence of hatohol's pidfile.
- When another daemonized hatohol server process running, it will be automatically exit.

Does it need implementation for given `--foreground` option case?
