### PR TITLE
[Server] suppress warning when hatohol terminates in foreground mode

### DIFF
--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -179,6 +179,8 @@ int mainRoutine(int argc, char *argv[])
 			MLPL_ERR("Can't start daemon process\n");
 			return EXIT_FAILURE;
 		}
+	} else {
+		pidFilePath.clear();
 	}
 
 	// setup signal handlers for exit


### PR DESCRIPTION
Because following error displayed when hatohol server terminates in foreground mode:

``` log
[ERR] <main.cc:108> Failed to remove pid file: /tmp/hatohol.pid
```

In foreground mode, hatohol server doesn't create pidfile.
I've selected following strategy suggested by kz0817:
- Call pidFilePath.clear() when the case that doesn't call daemonize().
