### PR TITLE
[Utils] Define missing SOUP_URI_IS_VALID()

### DIFF
--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -40,6 +40,10 @@
 #define soup_uri_get_port(uri) (uri->port)
 #endif
 
+#ifndef SOUP_URI_IS_VALID
+#define SOUP_URI_IS_VALID(uri) ((uri) && (uri)->scheme && (uri)->path)
+#endif
+
 class FormulaElement;
 
 static const guint INVALID_EVENT_ID = -1;


### PR DESCRIPTION
It's available on libsoup-2.38 or later.
