### PR TITLE
[HapProcessCeilometer] Fix the problem in which re-authentification is not performed

### DIFF
--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -882,12 +882,16 @@ HatoholError HapProcessCeilometer::fetchItem(void)
 HatoholError HapProcessCeilometer::fetchItemsOfInstance(
   VariableItemTablePtr &tablePtr, const string &instanceId)
 {
+	HatoholError err = updateAuthTokenIfNeeded();
+	if (err != HTERR_OK)
+		return err;
+
 	string url = StringUtils::sprintf(
 	               "%s/v2/resources/%s",
 	               m_impl->ceilometerEP.publicURL.c_str(),
 	               instanceId.c_str());
 	HttpRequestArg arg(SOUP_METHOD_GET, url);
-	HatoholError err = sendHttpRequest(arg);
+	err = sendHttpRequest(arg);
 	if (err != HTERR_OK)
 		return err;
 


### PR DESCRIPTION
When only fetching item is repeated, the key is expired, because
the update is not performed.
