### PR TITLE
[Utils] Fix a problem in which the callback function is invoked synchronously in a condition.

### DIFF
--- a/server/common/Utils.cc
+++ b/server/common/Utils.cc
@@ -299,7 +299,7 @@ void Utils::executeOnGLibEventLoop(
 
 	// just call the function if the caller has the ownership
 	// of the context.
-	if (g_main_context_acquire(context)) {
+	if (syncType == SYNC && g_main_context_acquire(context)) {
 		(*func)(data);
 		g_main_context_release(context);
 		return;


### PR DESCRIPTION
This patch also fixes the test that is depending on the wrong behaivor.
