### PR TITLE
[HatoholArmPluginInterface] Add a new methods: set/getGLibMainContext().

### DIFF
--- a/server/common/HatoholArmPluginInterface.cc
+++ b/server/common/HatoholArmPluginInterface.cc
@@ -84,6 +84,7 @@ struct HatoholArmPluginInterface::Impl {
 	uint32_t   sequenceId;
 	uint32_t   sequenceIdOfCurrCmd;
 	SmartQueue<ReplyWaiter *> replyWaiterQueue;
+	GMainContext *glibMainContext;
 
 	Impl(HatoholArmPluginInterface *_hapi,
 	               const bool &_workInServer)
@@ -95,6 +96,7 @@ struct HatoholArmPluginInterface::Impl {
 	  currBuffer(NULL),
 	  sequenceId(0),
 	  sequenceIdOfCurrCmd(SEQ_ID_UNKNOWN),
+	  glibMainContext(NULL),
 	  connected(false),
 	  brokerUrl(DEFAULT_BROKER_URL)
 	{
@@ -104,6 +106,8 @@ struct HatoholArmPluginInterface::Impl {
 	{
 		disconnect();
 		freeReplyWaiters();
+		if (glibMainContext)
+			g_main_context_unref(glibMainContext);
 	}
 
 	void connect(void)
@@ -655,6 +659,19 @@ string HatoholArmPluginInterface::getQueueAddress(void) const
 void HatoholArmPluginInterface::setQueueAddress(const string &queueAddr)
 {
 	return m_impl->setQueueAddress(queueAddr);
+}
+
+void HatoholArmPluginInterface::setGLibMainContext(GMainContext *context)
+{
+	if (m_impl->glibMainContext)
+		g_main_context_unref(m_impl->glibMainContext);
+	m_impl->glibMainContext = context;
+	g_main_context_ref(m_impl->glibMainContext);
+}
+
+GMainContext *HatoholArmPluginInterface::getGLibMainContext(void) const
+{
+	return m_impl->glibMainContext;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -489,6 +489,28 @@ public:
 	std::string getQueueAddress(void) const;
 	void setQueueAddress(const std::string &queueAddr);
 
+	/**
+	 * Set the GLibMainContext.
+	 *
+	 * @param context A GLib's main context.
+	 * This method internally calls g_main_context_ref() to this object.
+	 * If any context is already set, it is replaced and
+	 * g_main_context_unref() is called for it.
+	 */
+	void setGLibMainContext(GMainContext *context);
+
+	/**
+	 * Get the GLibMainContext set by setGLibMainContext().
+	 *
+	 * By default, none of GLib's main context is not set to this object.
+	 * I.e. this method returns NULL.
+	 * This method doesn't change the reference count of the returned
+	 * object.
+	 *
+	 * @return A GLib's main context.
+	 */
+	GMainContext *getGLibMainContext(void) const;
+
 protected:
 	typedef std::map<uint16_t, CommandHandler> CommandHandlerMap;
 	typedef CommandHandlerMap::iterator        CommandHandlerMapIterator;

--- a/server/test/testHatoholArmPluginInterface.cc
+++ b/server/test/testHatoholArmPluginInterface.cc
@@ -20,6 +20,7 @@
 #include <gcutter.h>
 #include <cppcutter.h>
 #include <SimpleSemaphore.h>
+#include <Reaper.h>
 #include "DataSamples.h"
 #include "Helpers.h"
 #include "HatoholArmPluginInterface.h"
@@ -629,6 +630,18 @@ void test_setGetBrokerUrl(void)
 	  hapi.getBrokerUrl());
 	hapi.setBrokerUrl(brokerUrl);
 	cppcut_assert_equal(brokerUrl, hapi.getBrokerUrl());
+}
+
+void test_setGetGLibMainContext(void)
+{
+	HatoholArmPluginInterface hapi;
+	cppcut_assert_equal((GMainContext *)NULL, hapi.getGLibMainContext());
+
+	GMainContext *ctx = g_main_context_new();
+	Reaper<GMainContext> reaper(ctx, g_main_context_unref);
+
+	hapi.setGLibMainContext(ctx);
+	cppcut_assert_equal(ctx, hapi.getGLibMainContext());
 }
 
 } // namespace testHatoholArmPluginInterface


### PR DESCRIPTION
Currently only one GLib Main context is used for timer, GIOChannel
(mainly for pipe) except for libsoup's handling. However, when the
number of the GLib's event loop's user increase, this architecture
doesn't take care of that.
