### PR TITLE
[HatoholArmPluginGate] Fix a bug that causes an infinite loop.

### DIFF
--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -1015,12 +1015,12 @@ gboolean HatoholArmPluginGate::pipeRdErrCb(
   GIOChannel *source, GIOCondition condition, gpointer data)
 {
 	MLPL_INFO("Got callback (PIPE): %08x", condition);
-	return TRUE;
+	return G_SOURCE_REMOVE;
 }
 
 gboolean HatoholArmPluginGate::pipeWrErrCb(
   GIOChannel *source, GIOCondition condition, gpointer data)
 {
 	MLPL_INFO("Got callback (PIPE): %08x", condition);
-	return TRUE;
+	return G_SOURCE_REMOVE;
 }


### PR DESCRIPTION
The previous returns TRUE from the error callback of the PIPE.
As a result, the error state continues and call the error callback
repeatedly.
