### PR TITLE
Fix deadlock at exit (#709)

### DIFF
--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -71,35 +71,35 @@ static void setupSignalHandlerForExit(int signo)
 	             "Failed to set SIGNAL: %d, errno: %d\n", signo, errno);
 }
 
-static void exitFuncOnWaitThread(ExecContext *impl)
+static void exitFuncOnWaitThread(ExecContext *ctx)
 {
 	MLPL_INFO("start exit process on the dedicated thread.\n");
 
-	impl->unifiedDataStore->stop();
+	ctx->unifiedDataStore->stop();
 	DBTablesAction::stop();
 
 	// TODO: implement
 	// ChildProcessManager::getInstance()->quit();
 
-	// Because this function is beeing called, impl->loop must have valid
-	// value even if a signal is received before impl->loop is created.
-	g_main_loop_quit(impl->loop);
+	// Because this function is beeing called, ctx->loop must have valid
+	// value even if a signal is received before ctx->loop is created.
+	g_main_loop_quit(ctx->loop);
 }
 
 gboolean exitFunc(GIOChannel *source, GIOCondition condition, gpointer data)
 {
 	struct ExitFuncThread : public HatoholThreadBase {
-		ExecContext *impl;
+		ExecContext *ctx;
 		virtual gpointer mainThread(HatoholThreadArg *arg) override
 		{
-			exitFuncOnWaitThread(impl);
+			exitFuncOnWaitThread(ctx);
 			return NULL;
 		}
 	};
 	ExitFuncThread *exitFuncThread = new ExitFuncThread();
 
 	MLPL_INFO("recieved stop request.\n");
-	exitFuncThread->impl = static_cast<ExecContext *>(data);
+	exitFuncThread->ctx = static_cast<ExecContext *>(data);
 	const bool autoDeleteObject = true;
 	exitFuncThread->start(autoDeleteObject);
 


### PR DESCRIPTION
Some synchronous stop procedures use a GLib's main loop on the main
thread. Therefore, calling it (typically stop()) on the main thread
may causes the dead-lock.

This patch avoids the situation by calling a stop procedure on a
dedicated thread.
