### PR TITLE
[hatohol-server-type-util] Add some missing default values for Nagios

### DIFF
--- a/server/tools/hatohol-server-type-util
+++ b/server/tools/hatohol-server-type-util
@@ -87,9 +87,11 @@ class NagiosParamGenerator(ParamGenerator):
                     'label':'Password',
                     'inputStyle':'password'});
         obj.append({'id':'pollingInterval',
-                    'label':'Polling interval (sec)'});
+                    'label':'Polling interval (sec)',
+                    'default':'30'});
         obj.append({'label':'Retry interval (sec)',
-                    'id':'retryInterval'});
+                    'id':'retryInterval',
+                    'default':'10'});
         return obj
 
 


### PR DESCRIPTION
Use same values with Zabbix:
- polling interval: 30
- retry interval: 10
