### PR TITLE
[HapProcessZabbixAPI] Fix a bug that fetching items doesn't work

### DIFF
--- a/server/hap/HapProcessZabbixAPI.cc
+++ b/server/hap/HapProcessZabbixAPI.cc
@@ -148,10 +148,10 @@ HatoholError HapProcessZabbixAPI::fetchItem(const MessagingContext &msgCtx)
 	ItemTablePtr applications = getApplications(items);
 
 	SmartBuffer resBuf;
-	setupResponseBuffer<void>(resBuf, 0, HAPI_RES_ITEMS);
+	setupResponseBuffer<void>(resBuf, 0, HAPI_RES_ITEMS, &msgCtx);
 	appendItemTable(resBuf, items);
 	appendItemTable(resBuf, applications);
-	reply(resBuf);
+	reply(msgCtx, resBuf);
 
 	return HTERR_OK;
 }


### PR DESCRIPTION
In the previous implementation fetchItem() doesn't work and it
causes stall with following debug message:

[DBG] HatoholException.cc:48 HatoholException: HatoholArmPluginInterface.cc:298 ASSERTION failed: [m_impl->currMessage] : This object doesn't have a current message.

The cause is that it doesn't use MessagingContext passed via
argument.
