### PR TITLE
[client] servers: Remove unused 'add monitoring server (new version)' bu...

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/django.po
+++ b/client/conf/locale/ja/LC_MESSAGES/django.po
@@ -346,10 +346,6 @@ msgstr "監視サーバー"
 msgid "ADD MONITORING SERVER"
 msgstr "監視サーバー追加"
 
-#: viewer/servers_ajax.html:40
-msgid "ADD MONITORING SERVER (New version)"
-msgstr "監視サーバー追加(新バージョン)"
-
 #: viewer/servers_ajax.html:45
 msgid "DELETE MONITORING SERVER"
 msgstr "監視サーバー削除"

--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -35,11 +35,6 @@
         {% trans "ADD MONITORING SERVER" %}
       </button>
 
-      <button id="add-server-button-by-param" type="button" class="btn btn-default" style="display: none;">
-        <span class="glyphicon glyphicon-plus"></span>
-        {% trans "ADD MONITORING SERVER (New version)" %}
-      </button>
-
       <button id="delete-server-button" type="button" class="btn btn-default" disabled style="display: none;">
         <span class="glyphicon glyphicon-remove"></span>
         {% trans "DELETE MONITORING SERVER" %}


### PR DESCRIPTION
...tton for development.

The button was used during development phase and is not used any longer.
Remove it.

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
