### PR TITLE
[server][hap] Fix misleading function & struct names concerned with self...

### DIFF
--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -235,8 +235,9 @@ struct HapiResTimeOfLastEvent {
 	uint32_t nsec;
 } __attribute__((__packed__));
 
-struct HapiAvailableTrigger {
+struct HapiHapSelfTriggers {
 	uint64_t numTriggers;
+	// Traling data is an array of HatoholArmPluginWatchType.
 } __attribute__((__packed__));
 
 

--- a/server/hap/HapProcessZabbixAPI.cc
+++ b/server/hap/HapProcessZabbixAPI.cc
@@ -179,5 +179,5 @@ void HapProcessZabbixAPI::onGotNewEvents(ItemTablePtr eventsTablePtr)
 void HapProcessZabbixAPI::onInitiated(void)
 {
 	HapProcessStandard::onInitiated();
-	sendAvailableTrigger(numHapZabbixSelfError, hapiZabbixErrorList);
+	sendHapSelfTriggers(numHapZabbixSelfError, hapiZabbixErrorList);
 }

--- a/server/hap/HatoholArmPluginBase.cc
+++ b/server/hap/HatoholArmPluginBase.cc
@@ -415,15 +415,15 @@ void HatoholArmPluginBase::sendArmInfo(const ArmInfo &armInfo,
 	send(cmdBuf);
 }
 
-void HatoholArmPluginBase::sendAvailableTrigger(const int numTriggerList,
-						const HatoholArmPluginWatchType *TriggerList)
+void HatoholArmPluginBase::sendHapSelfTriggers(const int numTriggerList,
+					       const HatoholArmPluginWatchType *TriggerList)
 {
 	SmartBuffer cmdBuf;
 	const size_t additionalSize = sizeof(uint64_t)*numTriggerList;
 
-	HapiAvailableTrigger *body = 
-		setupCommandHeader<HapiAvailableTrigger>(cmdBuf, HAPI_CMD_SEND_HAP_SELF_TRIGGERS,
-							 additionalSize);
+	HapiHapSelfTriggers *body =
+	  setupCommandHeader<HapiHapSelfTriggers>(
+	    cmdBuf, HAPI_CMD_SEND_HAP_SELF_TRIGGERS, additionalSize);
 	body->numTriggers= NtoL(numTriggerList);
 	uint64_t *buf = reinterpret_cast<uint64_t *>(body + 1);
 	for (int i=0 ; i < numTriggerList ; i++) {

--- a/server/hap/HatoholArmPluginBase.h
+++ b/server/hap/HatoholArmPluginBase.h
@@ -84,8 +84,8 @@ protected:
 	               const ItemTablePtr &tablePtr);
 	void sendArmInfo(const ArmInfo &armInfo,
 			 const HatoholArmPluginWatchType &type = COLLECT_OK);
-	void sendAvailableTrigger(const int TriggerNum,
-				  const HatoholArmPluginWatchType *TriggerList);
+	void sendHapSelfTriggers(const int TriggerNum,
+				 const HatoholArmPluginWatchType *TriggerList);
 	void cmdHandlerFetchItems(const HapiCommandHeader *header);
 	void cmdHandlerTerminate(const HapiCommandHeader *header);
 

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -207,7 +207,7 @@ HatoholArmPluginGate::HatoholArmPluginGate(
 	registerCommandHandler(
 	  HAPI_CMD_SEND_HAP_SELF_TRIGGERS,
 	  (CommandHandler)
-	  &HatoholArmPluginGate::cmdHandlerAvailableTrigger);
+	  &HatoholArmPluginGate::cmdHandlerSendHapSelfTriggers);
 }
 
 void HatoholArmPluginGate::start(void)
@@ -964,13 +964,13 @@ void HatoholArmPluginGate::addInitialTrigger(HatoholArmPluginWatchType addtrigge
 	}
 }
 
-void HatoholArmPluginGate::cmdHandlerAvailableTrigger(
+void HatoholArmPluginGate::cmdHandlerSendHapSelfTriggers(
   const HapiCommandHeader *header)
 {
 	SmartBuffer *cmdBuf = getCurrBuffer();
 	HATOHOL_ASSERT(cmdBuf, "Current buffer: NULL");
 
-	HapiAvailableTrigger *body = getCommandBody<HapiAvailableTrigger>(*cmdBuf);
+	HapiHapSelfTriggers *body = getCommandBody<HapiHapSelfTriggers>(*cmdBuf);
 
 	int numTriggerList = LtoN(body->numTriggers);
 	uint64_t *buf = reinterpret_cast<uint64_t *>(body + 1);

--- a/server/src/HatoholArmPluginGate.h
+++ b/server/src/HatoholArmPluginGate.h
@@ -127,7 +127,7 @@ protected:
 	void cmdHandlerSendHostgroups(const HapiCommandHeader *header);
 	void cmdHandlerSendUpdatedEvents(const HapiCommandHeader *header);
 	void cmdHandlerSendArmInfo(const HapiCommandHeader *header);
-	void cmdHandlerAvailableTrigger(const HapiCommandHeader *header);
+	void cmdHandlerSendHapSelfTriggers(const HapiCommandHeader *header);
 
 	void addInitialTrigger(HatoholArmPluginWatchType addtrigger);
 


### PR DESCRIPTION
... monitoring triggers

The name "AvailableTrigger" can't be ditinguished from normal
triggers, and it's not matched with the command name
"HAPI_CMD_SEND_HAP_SELF_TRIGGERS".
