### PR TITLE
[Client][Makefile] Add missing file: hatohol_version.js

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -86,6 +86,7 @@ nobase_dist_hatohol_client_DATA = \
 	static/js/hatohol_actor_mail_dialog.js \
 	static/js/hatohol_hostgroup_selector.js \
 	static/js/hatohol_incident_trackers_editor.js \
+	static/js/hatohol_version.js \
 	viewer/urls.py \
 	viewer/__init__.py \
 	viewer/models.py \


### PR DESCRIPTION
I checked the hatohol_version.js is included in the directory which is created by "make dist" command.
Sorry, I didn't check making RPM and install it successfully...

This pull request is related issue #728.
