### PR TITLE
Move a process to base_ajax.html from dashboard_ajax.html in a case to turn off JavaScript of web browser.

### DIFF
--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -23,6 +23,9 @@
 
 <html>
   <head>
+    <noscript>
+      <meta http-equiv="Refresh" content="0; URL=disable_js">
+    </noscript>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="{{ STATIC_URL }}images/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <link href="{{ STATIC_URL }}css.external/bootstrap.css" rel="stylesheet" media="screen">

--- a/client/viewer/dashboard_ajax.html
+++ b/client/viewer/dashboard_ajax.html
@@ -98,8 +98,4 @@
       var view = new DashboardView(userProfile);
     });
   </script>
-
-  <noscript>
-     <meta http-equiv="Refresh" content="0; URL=disable_js">
-  </noscript>
 {% endblock %}


### PR DESCRIPTION
Currently, the process is applied only to hatohol
dashboard. But this state allows direct access to the other pages which hatohol
generates.

When this patch is applied, the process is applied to all pages. When hatohol
users direct access to all pages, this process redirects to disable_js.html.

FYI:
We announce to use the web browser with HTML5. If Hatohol users do not use HTML5,
we do not ensure correct behaviors. In general, 'noscript' tag in header is not
supported in HTML4.
