### PR TITLE
[client] Disable "add/update" without selection monitoring server type.

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog_parameterized.js
+++ b/client/static/js/hatohol_server_edit_dialog_parameterized.js
@@ -148,6 +148,7 @@ HatoholServerEditDialogParameterized.prototype.createMainElement = function() {
       $('#selectServerType').append($('<option>').html(name).val(type));
       self.paramArray[type] = parameters;
     }
+    self.fixupApplyButtonState();
 
     if (self.server) {
       var selectElem = $("#selectServerType");


### PR DESCRIPTION
We should disable "add" or "update" button without selecting monitoring server type.

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
Closes: #751
