### PR TITLE
[DBTables] Fix a problem in which a DB updater is not invoked.

### DIFF
--- a/server/src/DBTables.cc
+++ b/server/src/DBTables.cc
@@ -64,8 +64,7 @@ struct DBTables::Impl {
 		  setupInfo.tablesId);
 		if (!dbAgent.isRecordExisting(tableProf.name, condition))
 			insertTablesVersion(setupInfo, tableProf);
-		else
-			updateTablesVersionIfNeeded(setupInfo, tableProf);
+		updateTablesVersionIfNeeded(setupInfo, tableProf);
 
 		// Create tables
 		vector<const TableSetupInfo *> createdTableInfoVect;


### PR DESCRIPTION
The prvious code doesn't call a DB updater when the DB version
record exists. In that situation, there's the corresponding
table typically. This implies that we cannot change existing tables.
