### PR TITLE
mlpl ParsableString: Fix signedness issues which prevent us from using on multibyte strings.

### DIFF
--- a/server/mlpl/src/ParsableString.cc
+++ b/server/mlpl/src/ParsableString.cc
@@ -48,7 +48,7 @@ SeparatorChecker::~SeparatorChecker()
 
 bool SeparatorChecker::isSeparator(const char c)
 {
-	int i = c;
+	int i = c & 0xff;
 	return m_separatorArray[i];
 }
 


### PR DESCRIPTION
An array (m_separatorArray[]) is used for checking if each character is
one of separators or not.  Array index was converted from char and
multi-byte characters are evaluated as negative value.  We screwed up
here.

I do think we can assume that all separators must be evaluated as
positive intergers, but user-supplied string must not cause accessing
outside of the array.

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
