### PR TITLE
mlpl ParsableString: Fix segmentation fault caused by user-supplied non-ascii strings.

### DIFF
--- a/server/mlpl/src/ParsableString.cc
+++ b/server/mlpl/src/ParsableString.cc
@@ -48,7 +48,7 @@ SeparatorChecker::~SeparatorChecker()
 
 bool SeparatorChecker::isSeparator(const char c)
 {
-	int i = c;
+	int i = c & 0xff;
 	return m_separatorArray[i];
 }
 


### PR DESCRIPTION
In SeparatorChecker, an array (m_separatorArray[]) is used for checking if each character is one of separators or not.
The array index is converted from char. Singedness of char is implementation-defined and non-ascii (e.g. utf-8) characters may be evaluated as negative values.
In fact, we screwed up if a user set up an "action" with non-ascii string (ああああ.sh for example).
Note that we can assume that all separators are ascii characters, however, user-supplied string must not result in accessing the array out of bounds.

Signed-off-by: YOSHIFUJI Hideaki hideaki.yoshifuji@miraclelinux.com
