### PR TITLE
HatoholArmPlugin memory leaks in cycle monitoring.

### DIFF
--- a/server/common/HatoholArmPluginInterface.cc
+++ b/server/common/HatoholArmPluginInterface.cc
@@ -320,6 +320,7 @@ void HatoholArmPluginInterface::reply(const MessagingContext &msgCtx,
 	reply.setContent(replyBuf.getPointer<char>(0), replyBuf.size());
 	Sender sender = m_impl->session.createSender(msgCtx.replyAddress);
 	sender.send(reply);
+	sender.close();
 }
 
 void HatoholArmPluginInterface::replyError(const HapiResponseCode &code)


### PR DESCRIPTION
Fix the memory leak in HatoholArmPlugin.

Memory leak in the function "HatoholArmPluginInterface::reply".
Resource(Sender sender) of acquired by "session.createSender()",
it must be released in "Sender.close()".
