### PR TITLE
[WebUI][LogSearchView] open new window when searching

### DIFF
--- a/client/static/js/dashboard_view.js
+++ b/client/static/js/dashboard_view.js
@@ -254,7 +254,7 @@ var DashboardView = function(userProfile) {
     }
 
     if (type == "groonga") {
-      window.open().location = baseURL + '?query=' + escape(query);
+      window.open(baseURL + '?query=' + escape(query));
     }
   }
 


### PR DESCRIPTION
Related to #824 behavior change.

Currently, link(s) which is linked to `LogSearchSystems` is opened in watching page.
And, when users submit `LogsearchSystems` button, users are forced to be transferred to `LogSearchSystems` (For now, `Groonga Admin`) Web UI.
I think that it is not good because user want to go back to Hatohol client page.
