### PR TITLE
[spec] Fix require package.

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -17,12 +17,11 @@ Requires: json-glib >= 0.12
 Requires: sqlite >= 3.6
 %if %is_el6
 Requires: mysql >= 5.1
-Requires: mysql-server >= 5.1
 %endif
 %if %is_el7
-Requires: MySQL-python
 Requires: mariadb
 %endif
+Requires: MySQL-python
 Requires: libuuid >= 2.17
 Requires: qpid-cpp-client >= 0.14
 Requires: librabbitmq >= 0.4.1


### PR DESCRIPTION
- Remove "mysql-server" package
  - Because there is some possibility of doing that user put MySQL (or
    MariaDB) server on other machine.
- Add "MySQL-python" package
  - Because `hatohol-db-initiator` uses it.

This Pull Request is related to #768.
If you want to fix spec file, please, let me know, commit your change into this branch.
