### PR TITLE
[HostsQueryOption] Add a missing copy constructor

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1392,6 +1392,13 @@ HostsQueryOption::HostsQueryOption(const UserIdType &userId)
 {
 }
 
+HostsQueryOption::HostsQueryOption(const HostsQueryOption &src)
+: HostResourceQueryOption(src),
+  m_impl(new Impl())
+{
+	*m_impl = *src.m_impl;
+}
+
 HostsQueryOption::HostsQueryOption(DataQueryContext *dataQueryContext)
 : HostResourceQueryOption(synapseHostsQueryOption, dataQueryContext),
   m_impl(new Impl())

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -109,6 +109,7 @@ private:
 class HostsQueryOption : public HostResourceQueryOption {
 public:
 	HostsQueryOption(const UserIdType &userId = INVALID_USER_ID);
+	HostsQueryOption(const HostsQueryOption &src);
 	HostsQueryOption(DataQueryContext *dataQueryContext);
 	virtual ~HostsQueryOption();
 


### PR DESCRIPTION
This commit fixes the following compile time warning:

testArmBase.cc:549:38: warning: no viable constructor copying parameter of type 'HostsQueryOption'; C++98 requires a copy constructor when binding a reference to a temporary
      [-Wbind-to-temporary-copy]
        dbMonitoring.getHostInfoList(hosts, HostsQueryOption(USER_ID_SYSTEM));
