### PR TITLE
[HatoholArmPluginGate] Replace a wrong timeout value for SIGTERM

### DIFF
--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -638,7 +638,7 @@ void HatoholArmPluginGate::terminatePluginSync(void)
 	size_t elapsedTime = timeoutMSec;
 
 	// Send SIGTERM
-	timeoutMSec = TIMEOUT_PLUGIN_TERM_SIGKILL_MS - elapsedTime;
+	timeoutMSec = TIMEOUT_PLUGIN_TERM_SIGTERM_MS - elapsedTime;
 	MLPL_INFO("Send SIGTERM to the plugin and wait for %zd sec.\n",
 	          timeoutMSec/1000);
 	if (kill(m_impl->pid, SIGTERM) == -1) {


### PR DESCRIPTION
TIMEOUT_PLUGIN_TERM_SIGKILL_MS was wrongly used for it.

This commit fixes the following compile time warning:

HatoholArmPluginGate.cc:53:21: warning: unused variable 'TIMEOUT_PLUGIN_TERM_SIGTERM_MS' [-Wunused-const-variable]
static const size_t TIMEOUT_PLUGIN_TERM_SIGTERM_MS =  60 \* 1000;
