### PR TITLE
[DBAgentMySQL] Set MYSQL_READ_DEFAULT_GROUP to hatohol

### DIFF
--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -578,6 +578,7 @@ void DBAgentMySQL::connect(void)
 	const char *passwd = getCStringOrNullIfEmpty(m_impl->password);
 	const char *db     = getCStringOrNullIfEmpty(m_impl->dbName);
 	mysql_init(&m_impl->mysql);
+	mysql_options(&m_impl->mysql, MYSQL_READ_DEFAULT_GROUP, "hatohol");
 	MYSQL *result = mysql_real_connect(&m_impl->mysql, host, user, passwd,
 	                                   db, m_impl->port,
 	                                   unixSocket, clientFlag);


### PR DESCRIPTION
So that Hatohol can read "client" group and "hatohol" group in
my.cnf.
Users should set default-character-set=utf8 (or utf8mb4) to
one of these groups to handle UTF-8 correctly.
