### PR TITLE
[HatoholException] Fix the problem in which the error code is not initialized.

### DIFF
--- a/server/common/HatoholException.cc
+++ b/server/common/HatoholException.cc
@@ -42,7 +42,8 @@ HatoholException::HatoholException(
   const string &brief, const string &sourceFileName, const int &lineNumber)
 : m_what(brief),
   m_sourceFileName(sourceFileName),
-  m_lineNumber(lineNumber)
+  m_lineNumber(lineNumber),
+  m_errCode(HTERR_UNKNOWN_REASON)
 {
 	MLPL_DBG("HatoholException: <%s:%d> %s\n", sourceFileName.c_str(), lineNumber,
 	         brief.c_str());

--- a/server/test/ExceptionTestUtils.h
+++ b/server/test/ExceptionTestUtils.h
@@ -23,7 +23,7 @@
 #include <cppcutter.h>
 
 template<class ThrowExceptionType, class CaughtExceptionType>
-void _assertThrow(void)
+void _assertThrow(void (*catchCb)(const CaughtExceptionType &e) = NULL)
 {
 	const char *brief = "foo";
 	bool exceptionReceived = false;
@@ -35,9 +35,11 @@ void _assertThrow(void)
 		expected += brief;
 		expected += "\n";
 		cppcut_assert_equal(expected, std::string(e.what()));
+		if (catchCb)
+			(*catchCb)(e);
 	}
 	cppcut_assert_equal(true, exceptionReceived);
 }
-#define assertThrow(T,C) cut_trace((_assertThrow<T,C>()))
+#define assertThrow(T,C,...) cut_trace((_assertThrow<T,C>(__VA_ARGS__)))
 
 #endif // ExceptionTestUtils_h

--- a/server/test/testHatoholException.cc
+++ b/server/test/testHatoholException.cc
@@ -31,7 +31,13 @@ namespace testHatoholException {
 // ---------------------------------------------------------------------------
 void test_throw(void)
 {
-	assertThrow(HatoholException, HatoholException);
+	struct Check {
+		static void errCode(const HatoholException &e) {
+			cppcut_assert_equal(HTERR_UNKNOWN_REASON,
+			                    e.getErrCode());
+		}
+	};
+	assertThrow(HatoholException, HatoholException, Check::errCode);
 }
 
 void test_throwAsException(void)


### PR DESCRIPTION
Without this patch, the error code of HatoholException object is uncertain.
