### PR TITLE
[server][data] Avoid incomplete .sql files from being created.

### DIFF
--- a/server/data/Makefile.am
+++ b/server/data/Makefile.am
@@ -5,13 +5,17 @@ sql_DATA = \
 
 sqldir = $(pkgdatadir)/sql
 
+# To avoid making an incomplete .sql files, we once
+# use a tmporary file: _tmp.$@
 HATOHOL_SERVER_TYPE_UTIL = ../tools/hatohol-server-type-util
 server-type.sql: $(HATOHOL_SERVER_TYPE_UTIL)
-	$(HATOHOL_SERVER_TYPE_UTIL) mysql > $@
+	$(HATOHOL_SERVER_TYPE_UTIL) mysql > _tmp.$@
+	mv _tmp.$@ $@
 
 HATOHOL_INIT_USER_GENERATOR = ../tools/hatohol-init-user-generator
 init-user.sql: $(HATOHOL_INIT_USER_GENERATOR)
-	$(HATOHOL_INIT_USER_GENERATOR) > $@
+	$(HATOHOL_INIT_USER_GENERATOR) > _tmp.$@
+	mv _tmp.$@ $@
 
 pkgsysconf_DATA = \
 	hatohol.conf
@@ -20,3 +24,8 @@ pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 EXTRA_DIST = \
 	$(pkgsysconf_DATA) \
 	$(sql_DATA)
+
+CLEANFILES = \
+	server-type.sql \
+	init-user.sql \
+	_tmp.*


### PR DESCRIPTION
If hatohol-server-type-util aborts, an incomplete SQL file is created.
This patch prevents it by using a temporary working file.
