### PR TITLE
[server] Fix incorrect updating of BIGUINT values

### DIFF
--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -603,7 +603,7 @@ string DBAgent::makeUpdateStatement(const UpdateArg &updateArg)
 		statement += StringUtils::sprintf("%s=%s",
 		                                  columnDef.columnName,
 		                                  valueStr.c_str());
-		if (i < numColumns-1)
+		if (i < numColumns - 1)
 			statement += ",";
 	}
 

--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -549,7 +549,7 @@ string DBAgent::getColumnValueString(const ColumnDef *columnDef,
 		if (itemData->isNull()) {
 			valueStr = "NULL";
 		} else {
-			valueStr = StringUtils::sprintf("%" PRId64,
+			valueStr = StringUtils::sprintf("%" PRIu64,
 		                            (uint64_t)*itemData);
 		}
 		break;

--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -533,39 +533,30 @@ string DBAgent::makeSelectStatement(const SelectExArg &selectExArg)
 string DBAgent::getColumnValueString(const ColumnDef *columnDef,
                                      const ItemData *itemData)
 {
+	if (itemData->isNull())
+		return "NULL";
+
 	string valueStr;
 	switch (columnDef->type) {
 	case SQL_COLUMN_TYPE_INT:
 	{
-		if (itemData->isNull()) {
-			valueStr = "NULL";
-		} else {
-			valueStr = StringUtils::sprintf("%d", (int)*itemData);
-		}
+		valueStr = StringUtils::sprintf("%d", (int)*itemData);
 		break;
 	}
 	case SQL_COLUMN_TYPE_BIGUINT:
 	{
-		if (itemData->isNull()) {
-			valueStr = "NULL";
-		} else {
-			valueStr = StringUtils::sprintf("%" PRIu64,
-		                            (uint64_t)*itemData);
-		}
+		valueStr = StringUtils::sprintf("%" PRIu64,
+						(uint64_t)*itemData);
 		break;
 	}
 	case SQL_COLUMN_TYPE_VARCHAR:
 	case SQL_COLUMN_TYPE_CHAR:
 	case SQL_COLUMN_TYPE_TEXT:
 	{
-		if (itemData->isNull()) {
-			valueStr = "NULL";
-		} else {
-			string escaped =
-			   StringUtils::replace((string)*itemData, "'", "''");
-			valueStr =
-			   StringUtils::sprintf("'%s'", escaped.c_str());
-		}
+		string escaped =
+		  StringUtils::replace((string)*itemData, "'", "''");
+		valueStr =
+		  StringUtils::sprintf("'%s'", escaped.c_str());
 		break;
 	}
 	case SQL_COLUMN_TYPE_DOUBLE:

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -343,14 +343,15 @@ public:
 protected:
 	static std::string makeSelectStatement(const SelectArg &selectArg);
 	static std::string makeSelectStatement(const SelectExArg &selectExArg);
-	static std::string getColumnValueString(const ColumnDef *columnDef,
-	                                        const ItemData *itemData);
-	static std::string makeUpdateStatement(const UpdateArg &updateArg);
 	static std::string makeDeleteStatement(const DeleteArg &deleteArg);
 	static std::string makeRenameTableStatement(
 	  const std::string &srcName,
 	  const std::string &destName);
 	static std::string makeDatetimeString(int datetime);
+	std::string makeUpdateStatement(const UpdateArg &updateArg);
+
+	virtual std::string getColumnValueString(const ColumnDef *columnDef,
+						 const ItemData *itemData);
 
 	virtual std::string
 	  makeCreateIndexStatement(const TableProfile &tableProfile,

--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -303,41 +303,6 @@ void DBAgentMySQL::createTable(const TableProfile &tableProfile)
 	execSql(query);
 }
 
-string DBAgentMySQL::getColumnValueString(const ColumnDef *columnDef,
-					  const ItemData *itemData)
-{
-	using mlpl::StringUtils::sprintf;
-
-	if (itemData->isNull())
-		return "NULL";
-
-	switch (columnDef->type) {
-	case SQL_COLUMN_TYPE_INT:
-	case SQL_COLUMN_TYPE_BIGUINT:
-	case SQL_COLUMN_TYPE_DOUBLE:
-		return itemData->getString();
-
-	case SQL_COLUMN_TYPE_VARCHAR:
-	case SQL_COLUMN_TYPE_CHAR:
-	case SQL_COLUMN_TYPE_TEXT:
-	{ // bracket is used to avoid an error:
-	  // jump to case label
-		string src = itemData->getString();
-		char *escaped = new char[src.size() * 2 + 1]; 
-		mysql_real_escape_string(&m_impl->mysql, escaped, src.c_str(), src.size());
-		string val = sprintf("'%s'", escaped);
-		delete [] escaped;
-		return val;
-	}
-	case SQL_COLUMN_TYPE_DATETIME:
-		return makeDatetimeString(*itemData);
-	default:
-		HATOHOL_ASSERT(false, "Unknown type: %d",
-			       columnDef->type);
-		return "";
-	}
-}
-
 void DBAgentMySQL::insert(const DBAgent::InsertArg &insertArg)
 {
 	using mlpl::StringUtils::sprintf;
@@ -650,6 +615,41 @@ void DBAgentMySQL::queryWithRetry(const string &statement)
 		THROW_HATOHOL_EXCEPTION("Failed to query: %s: (%u) %s\n",
 					statement.c_str(), errorNumber,
 					mysql_error(&m_impl->mysql));
+	}
+}
+
+string DBAgentMySQL::getColumnValueString(const ColumnDef *columnDef,
+					  const ItemData *itemData)
+{
+	using mlpl::StringUtils::sprintf;
+
+	if (itemData->isNull())
+		return "NULL";
+
+	switch (columnDef->type) {
+	case SQL_COLUMN_TYPE_INT:
+	case SQL_COLUMN_TYPE_BIGUINT:
+	case SQL_COLUMN_TYPE_DOUBLE:
+		return itemData->getString();
+
+	case SQL_COLUMN_TYPE_VARCHAR:
+	case SQL_COLUMN_TYPE_CHAR:
+	case SQL_COLUMN_TYPE_TEXT:
+	{ // bracket is used to avoid an error:
+	  // jump to case label
+		string src = itemData->getString();
+		char *escaped = new char[src.size() * 2 + 1]; 
+		mysql_real_escape_string(&m_impl->mysql, escaped, src.c_str(), src.size());
+		string val = sprintf("'%s'", escaped);
+		delete [] escaped;
+		return val;
+	}
+	case SQL_COLUMN_TYPE_DATETIME:
+		return makeDatetimeString(*itemData);
+	default:
+		HATOHOL_ASSERT(false, "Unknown type: %d",
+			       columnDef->type);
+		return "";
 	}
 }
 

--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -303,47 +303,44 @@ void DBAgentMySQL::createTable(const TableProfile &tableProfile)
 	execSql(query);
 }
 
+string DBAgentMySQL::getColumnValueString(const ColumnDef *columnDef,
+					  const ItemData *itemData)
+{
+	using mlpl::StringUtils::sprintf;
+
+	if (itemData->isNull())
+		return "NULL";
+
+	switch (columnDef->type) {
+	case SQL_COLUMN_TYPE_INT:
+	case SQL_COLUMN_TYPE_BIGUINT:
+	case SQL_COLUMN_TYPE_DOUBLE:
+		return itemData->getString();
+
+	case SQL_COLUMN_TYPE_VARCHAR:
+	case SQL_COLUMN_TYPE_CHAR:
+	case SQL_COLUMN_TYPE_TEXT:
+	{ // bracket is used to avoid an error:
+	  // jump to case label
+		string src = itemData->getString();
+		char *escaped = new char[src.size() * 2 + 1]; 
+		mysql_real_escape_string(&m_impl->mysql, escaped, src.c_str(), src.size());
+		string val = sprintf("'%s'", escaped);
+		delete [] escaped;
+		return val;
+	}
+	case SQL_COLUMN_TYPE_DATETIME:
+		return makeDatetimeString(*itemData);
+	default:
+		HATOHOL_ASSERT(false, "Unknown type: %d",
+			       columnDef->type);
+		return "";
+	}
+}
+
 void DBAgentMySQL::insert(const DBAgent::InsertArg &insertArg)
 {
 	using mlpl::StringUtils::sprintf;
-	struct {
-		string operator ()(const DBAgent::InsertArg &insertArg,
-		                   const size_t &idx, MYSQL *mysql)
-		{
-			const ColumnDef &columnDef =
-			  insertArg.tableProfile.columnDefs[idx];
-			const ItemData *itemData = insertArg.row->getItemAt(idx);
-			if (itemData->isNull())
-				return "NULL";
-
-			switch (columnDef.type) {
-			case SQL_COLUMN_TYPE_INT:
-			case SQL_COLUMN_TYPE_BIGUINT:
-			case SQL_COLUMN_TYPE_DOUBLE:
-				return itemData->getString();
-
-			case SQL_COLUMN_TYPE_VARCHAR:
-			case SQL_COLUMN_TYPE_CHAR:
-			case SQL_COLUMN_TYPE_TEXT:
-			{ // bracket is used to avoid an error:
-			  // jump to case label
-				string src = itemData->getString();
-				char *escaped = new char[src.size() * 2 + 1]; 
-				mysql_real_escape_string(
-				  mysql, escaped, src.c_str(), src.size());
-				string val = sprintf("'%s'", escaped);
-				delete [] escaped;
-				return val;
-			}
-			case SQL_COLUMN_TYPE_DATETIME:
-				return makeDatetimeString(*itemData);
-			default:
-				HATOHOL_ASSERT(false, "Unknown type: %d",
-				               columnDef.type);
-			return "";
-			}
-		}
-	} valueMaker;
 
 	const size_t numColumns = insertArg.tableProfile.numColumns;
 	HATOHOL_ASSERT(m_impl->connected, "Not connected.");
@@ -373,7 +370,8 @@ void DBAgentMySQL::insert(const DBAgent::InsertArg &insertArg)
 
 	for (size_t i = 0; i < numColumns; i++) {
 		const ColumnDef &columnDef = insertArg.tableProfile.columnDefs[i];
-		values.push_back(valueMaker(insertArg, i, &m_impl->mysql));
+		const ItemData *itemData = insertArg.row->getItemAt(i);
+		values.push_back(getColumnValueString(&columnDef, itemData));
 		if (!insertArg.upsertOnDuplicate)
 			continue;
 

--- a/server/src/DBAgentMySQL.h
+++ b/server/src/DBAgentMySQL.h
@@ -67,6 +67,8 @@ public:
 	virtual uint64_t getNumberOfAffectedRows(void);
 
 protected:
+	std::string getColumnValueString(const ColumnDef *columnDef,
+					 const ItemData *itemData);
 	static const char *getCStringOrNullIfEmpty(const std::string &str);
 	void connect(void);
 	void sleepAndReconnect(unsigned int sleepTimeSec);

--- a/server/src/DBAgentMySQL.h
+++ b/server/src/DBAgentMySQL.h
@@ -67,14 +67,15 @@ public:
 	virtual uint64_t getNumberOfAffectedRows(void);
 
 protected:
-	std::string getColumnValueString(const ColumnDef *columnDef,
-					 const ItemData *itemData);
 	static const char *getCStringOrNullIfEmpty(const std::string &str);
 	void connect(void);
 	void sleepAndReconnect(unsigned int sleepTimeSec);
 	void queryWithRetry(const std::string &statement);
 
 	// virtual methods
+	virtual std::string getColumnValueString(
+	  const ColumnDef *columnDef, const ItemData *itemData) override;
+
 	virtual std::string
 	  makeCreateIndexStatement(const TableProfile &tableProfile,
 	                           const IndexDef &indexDef) override;

--- a/server/src/DBAgentSQLite3.cc
+++ b/server/src/DBAgentSQLite3.cc
@@ -484,6 +484,9 @@ static bool isPrimaryOrUniqueKeyDuplicated(sqlite3 *db)
 string DBAgentSQLite3::getColumnValueStringStatic(const ColumnDef *columnDef,
 						  const ItemData *itemData)
 {
+	if (itemData->isNull())
+		return "NULL";
+
 	string valueStr;
 	switch (columnDef->type) {
 	case SQL_COLUMN_TYPE_INT:
@@ -501,14 +504,10 @@ string DBAgentSQLite3::getColumnValueStringStatic(const ColumnDef *columnDef,
 	case SQL_COLUMN_TYPE_CHAR:
 	case SQL_COLUMN_TYPE_TEXT:
 	{
-		if (itemData->isNull()) {
-			valueStr = "NULL";
-		} else {
-			string escaped =
-			   StringUtils::replace((string)*itemData, "'", "''");
-			valueStr =
-			   StringUtils::sprintf("'%s'", escaped.c_str());
-		}
+		string escaped =
+		  StringUtils::replace((string)*itemData, "'", "''");
+		valueStr =
+		  StringUtils::sprintf("'%s'", escaped.c_str());
 		break;
 	}
 	case SQL_COLUMN_TYPE_DOUBLE:

--- a/server/src/DBAgentSQLite3.cc
+++ b/server/src/DBAgentSQLite3.cc
@@ -478,6 +478,58 @@ static bool isPrimaryOrUniqueKeyDuplicated(sqlite3 *db)
 #endif
 }
 
+// TODO:
+// Should be unified with DBAgent::getColumnValueString() and override only
+// SQL_COLUMN_TYPE_BIGUINT.
+string DBAgentSQLite3::getColumnValueStringStatic(const ColumnDef *columnDef,
+						  const ItemData *itemData)
+{
+	string valueStr;
+	switch (columnDef->type) {
+	case SQL_COLUMN_TYPE_INT:
+	{
+		valueStr = StringUtils::sprintf("%d", (int)*itemData);
+		break;
+	}
+	case SQL_COLUMN_TYPE_BIGUINT:
+	{
+		valueStr = StringUtils::sprintf("%" PRId64,
+		                                (uint64_t)*itemData);
+		break;
+	}
+	case SQL_COLUMN_TYPE_VARCHAR:
+	case SQL_COLUMN_TYPE_CHAR:
+	case SQL_COLUMN_TYPE_TEXT:
+	{
+		if (itemData->isNull()) {
+			valueStr = "NULL";
+		} else {
+			string escaped =
+			   StringUtils::replace((string)*itemData, "'", "''");
+			valueStr =
+			   StringUtils::sprintf("'%s'", escaped.c_str());
+		}
+		break;
+	}
+	case SQL_COLUMN_TYPE_DOUBLE:
+	{
+		string fmt
+		  = StringUtils::sprintf("%%.%zdlf", columnDef->decFracLength);
+		valueStr = StringUtils::sprintf(fmt.c_str(), (double)*itemData);
+		break;
+	}
+	case SQL_COLUMN_TYPE_DATETIME:
+	{
+		valueStr = makeDatetimeString(*itemData);
+		break;
+	}
+	default:
+		HATOHOL_ASSERT(true, "Unknown column type: %d (%s)",
+		             columnDef->type, columnDef->columnName);
+	}
+	return valueStr;
+}
+
 void DBAgentSQLite3::insert(sqlite3 *db, const DBAgent::InsertArg &insertArg)
 {
 	size_t numColumns = insertArg.row->getNumberOfItems();
@@ -500,7 +552,7 @@ void DBAgentSQLite3::insert(sqlite3 *db, const DBAgent::InsertArg &insertArg)
 		if (itemData->isNull()) {
 			valueStr = "NULL";
 		} else {
-			valueStr = getColumnValueString(&columnDef, itemData);
+			valueStr = getColumnValueStringStatic(&columnDef, itemData);
 			if (columnDef.flags & SQL_COLUMN_FLAG_AUTO_INC) {
 				// Converting 0 to NULL makes the behavior
 				// compatible with DBAgentMySQL.
@@ -534,9 +586,38 @@ void DBAgentSQLite3::insert(sqlite3 *db, const DBAgent::InsertArg &insertArg)
 	}
 }
 
+// TODO: Should be unified with DBAgent::makeUpdateStatement()
+string DBAgentSQLite3::makeUpdateStatementStatic(const UpdateArg &updateArg)
+{
+	// make a SQL statement
+	string statement = StringUtils::sprintf("UPDATE %s SET ",
+	                                        updateArg.tableProfile.name);
+	const size_t numColumns = updateArg.rows.size();
+	for (size_t i = 0; i < numColumns; i++) {
+		const RowElement *elem = updateArg.rows[i];
+		const ColumnDef &columnDef =
+		  updateArg.tableProfile.columnDefs[elem->columnIndex];
+		const string valueStr =
+		  getColumnValueStringStatic(&columnDef, elem->dataPtr);
+
+		statement += StringUtils::sprintf("%s=%s",
+		                                  columnDef.columnName,
+		                                  valueStr.c_str());
+		if (i < numColumns - 1)
+			statement += ",";
+	}
+
+	// condition
+	if (!updateArg.condition.empty()) {
+		statement += StringUtils::sprintf(" WHERE %s",
+		                                  updateArg.condition.c_str());
+	}
+	return statement;
+}
+
 void DBAgentSQLite3::update(sqlite3 *db, const UpdateArg &updateArg)
 {
-	string sql = makeUpdateStatement(updateArg);
+	string sql = makeUpdateStatementStatic(updateArg);
 
 	// exectute the SQL statement
 	char *errmsg;
@@ -563,7 +644,7 @@ void DBAgentSQLite3::update(sqlite3 *db, const DBAgent::InsertArg &insertArg)
 
 			columnDef = &tableProfile.columnDefs[idx];
 			itemData = itemGroupPtr->getItemAt(idx);
-			valStr = getColumnValueString(columnDef, itemData);
+			valStr = getColumnValueStringStatic(columnDef, itemData);
 			return sprintf("%s=%s", columnDef->columnName,
 			                        valStr.c_str());
 		}
@@ -810,6 +891,12 @@ void DBAgentSQLite3::createIndexIfNotExistsEach(
 		THROW_HATOHOL_EXCEPTION("Failed to exec: %d, %s, %s",
 		                      result, err.c_str(), sql.c_str());
 	}
+}
+
+string DBAgentSQLite3::getColumnValueString(const ColumnDef *columnDef,
+					    const ItemData *itemData)
+{
+	return getColumnValueStringStatic(columnDef, itemData);
 }
 
 string DBAgentSQLite3::makeCreateIndexStatement(

--- a/server/src/DBAgentSQLite3.h
+++ b/server/src/DBAgentSQLite3.h
@@ -81,6 +81,9 @@ protected:
 	static bool isTableExisting(sqlite3 *db,
 	                            const std::string &tableName);
 	static void createTable(sqlite3 *db, const TableProfile &tableProfile);
+	static std::string getColumnValueStringStatic(const ColumnDef *columnDef,
+						      const ItemData *itemData);
+	static std::string makeUpdateStatementStatic(const UpdateArg &updateArg);
 	static void insert(sqlite3 *db, const InsertArg &insertArg);
 	static void update(sqlite3 *db, const UpdateArg &updateArg);
 	static void update(sqlite3 *db, const InsertArg &updateArg);
@@ -103,6 +106,9 @@ protected:
 	void execSql(const char *fmt, ...);
 
 	// virtual methods
+	virtual std::string getColumnValueString(
+	  const ColumnDef *columnDef, const ItemData *itemData) override;
+
 	virtual std::string
 	  makeCreateIndexStatement(const TableProfile &tableProfile,
 	                           const IndexDef &indexDef) override;

--- a/server/test/DBAgentTest.cc
+++ b/server/test/DBAgentTest.cc
@@ -509,6 +509,20 @@ void dbAgentTestUpdate(DBAgent &dbAgent, DBAgentChecker &checker)
 	checkUpdate(dbAgent, checker, ID, AGE, NAME, HEIGHT);
 }
 
+void dbAgentTestUpdateBigUint(DBAgent &dbAgent, DBAgentChecker &checker)
+{
+	// create table and insert a row
+	dbAgentTestInsert(dbAgent, checker);
+
+	// insert a row
+	const uint64_t ID = static_cast<uint64_t>(G_MAXINT64) + 1;
+	const int AGE = 20;
+	const char *NAME = "yui";
+	const double HEIGHT = 158.0;
+	const string condition = StringUtils::sprintf("id=1");
+	checkUpdate(dbAgent, checker, ID, AGE, NAME, HEIGHT);
+}
+
 void dbAgentTestUpdateCondition(DBAgent &dbAgent, DBAgentChecker &checker)
 {
 	// create table

--- a/server/test/DBAgentTest.h
+++ b/server/test/DBAgentTest.h
@@ -110,6 +110,7 @@ void dbAgentTestUpsert(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestUpsertWithPrimaryKeyAutoInc(
   DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestUpdate(DBAgent &dbAgent, DBAgentChecker &checker);
+void dbAgentTestUpdateBigUint(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestUpdateCondition(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestSelect(DBAgent &dbAgent);
 void dbAgentTestSelectEx(DBAgent &dbAgent);

--- a/server/test/testDBAgentMySQL.cc
+++ b/server/test/testDBAgentMySQL.cc
@@ -556,6 +556,12 @@ void test_update(void)
 	dbAgentTestUpdate(dbAgent, dbAgentChecker);
 }
 
+void test_updateBigUint(void)
+{
+	DBAgentMySQL dbAgent(TEST_DB_NAME);
+	dbAgentTestUpdateBigUint(dbAgent, dbAgentChecker);
+}
+
 void test_updateCondition(void)
 {
 	DBAgentMySQL dbAgent(TEST_DB_NAME);


### PR DESCRIPTION
Because an inappropriate format specifier "PRId64" is used for uint64_t, a value which is bigger
than max int64 becomes zero on updating it on MySQL.
(DBAgentSQLite3 uses PRId64 intentionally because it doesn't have unsigned type.)

Although it's a small bug, we have to fix many codes since it's a static function and used from
some other static functions in DBAgentSQLite3.

issue #850