### PR TITLE
[testHatoholArmPluginGate] Remove a unnecessary setup.

### DIFF
--- a/server/test/testHatoholArmPluginGate.cc
+++ b/server/test/testHatoholArmPluginGate.cc
@@ -88,7 +88,6 @@ void cut_setup(void)
 	hatoholInit();
 	setupTestDB();
 	loadTestDBTablesConfig();
-	loadTestDBServer();
 	loadTestDBArmPlugin();
 }
 


### PR DESCRIPTION
loadTestDBServer() is called in the previous function loadTestDBTablesConfig().
So it is called twice in mistake.