### PR TITLE
Use g_strerror() instead of strerror() to improve portability

### DIFF
--- a/server/common/NamedPipe.cc
+++ b/server/common/NamedPipe.cc
@@ -492,7 +492,7 @@ bool NamedPipe::openPipe(const string &name)
 			return false;
 		if (mkfifo(m_impl->path.c_str(), FIFO_MODE) == -1) { 
 			MLPL_ERR("Failed to make FIFO: %s, %s\n",
-			         m_impl->path.c_str(), strerror(errno));
+			         m_impl->path.c_str(), g_strerror(errno));
 			return false;
 		}
 	}
@@ -504,7 +504,7 @@ retry:
 		if (errno == EINTR)
 			goto retry;
 		MLPL_ERR("Failed to open: %s, %s\n",
-		         m_impl->path.c_str(), strerror(errno));
+		         m_impl->path.c_str(), g_strerror(errno));
 		return false;
 	}
 
@@ -557,7 +557,7 @@ bool NamedPipe::isExistingDir(const string &dirname, bool &hasError)
 	struct stat buf;
 	if (stat(dirname.c_str(), &buf) == -1 && errno != ENOENT) {
 		MLPL_ERR("Failed to stat: %s, %s\n",
-		         dirname.c_str(), strerror(errno));
+		         dirname.c_str(), g_strerror(errno));
 		return false;
 	}
 	if (errno == ENOENT) {
@@ -596,7 +596,7 @@ bool NamedPipe::makeBasedirIfNeeded(const string &baseDir)
 	if (result == -1) {
 		if (errno != EEXIST) {
 			MLPL_ERR("Failed to make dir: %s, %s\n",
-			         BASE_DIR, strerror(errno));
+			         BASE_DIR, g_strerror(errno));
 			return false;
 		}
 		// The other process or thread may create the directory
@@ -611,7 +611,7 @@ bool NamedPipe::deleteFileIfExists(const string &path)
 	struct stat buf;
 	if (stat(path.c_str(), &buf) == -1 && errno != ENOENT) {
 		MLPL_ERR("Failed to stat: %s, %s\n",
-		         path.c_str(), strerror(errno));
+		         path.c_str(), g_strerror(errno));
 		return false;
 	}
 	if (errno == ENOENT)
@@ -619,7 +619,7 @@ bool NamedPipe::deleteFileIfExists(const string &path)
 
 	if (unlink(path.c_str()) == -1) {
 		MLPL_ERR("Failed to unlink: %s, %s\n",
-		         path.c_str(), strerror(errno));
+		         path.c_str(), g_strerror(errno));
 		return false;
 	}
 

--- a/server/common/Utils.cc
+++ b/server/common/Utils.cc
@@ -160,7 +160,7 @@ string Utils::getSelfExeDir(void)
 	if (bytesRead == -1) {
 		THROW_HATOHOL_EXCEPTION(
 		  "Failed to readlink(\"/proc/self/exe\"): %s",
-		  strerror(errno));
+		  g_strerror(errno));
 	}
 	p = memrchr(buf, '/', bytesRead);
 	if (!p) {

--- a/server/mlpl/test/testLogger.cc
+++ b/server/mlpl/test/testLogger.cc
@@ -180,12 +180,12 @@ static void _assertWaitSyslogUpdate(int fd, int timeout, bool &timedOut)
 		timedOut = true;
 		return;
 	}
-	cppcut_assert_not_equal(-1, ret, cut_message("%s", strerror(errno)));
+	cppcut_assert_not_equal(-1, ret, cut_message("%s", g_strerror(errno)));
 
 	char buf[INOTIFY_EVT_BUF_SIZE];
 	ssize_t readRet = read(fd, buf, sizeof(buf));
 	cppcut_assert_not_equal((ssize_t)-1, readRet,
-	                        cut_message("%s", strerror(errno)));
+	                        cut_message("%s", g_strerror(errno)));
 }
 #define assertWaitSyslogUpdate(F,T,O) cut_trace(_assertWaitSyslogUpdate(F,T,O))
 

--- a/server/src/ActionManager.cc
+++ b/server/src/ActionManager.cc
@@ -1474,7 +1474,7 @@ void ActionManager::closeResident(ResidentInfo *residentInfo)
 	// will be called back from ActorCollector::checkExitProcess().
 	pid_t pid = residentInfo->pid;
 	if (pid && kill(pid, SIGKILL))
-		MLPL_ERR("Failed to kill. pid: %d, %s\n", pid, strerror(errno));
+		MLPL_ERR("Failed to kill. pid: %d, %s\n", pid, g_strerror(errno));
 }
 
 /*

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -364,7 +364,7 @@ gpointer FaceRest::mainThread(HatoholThreadArg *arg)
 		MLPL_ERR("%s", Utils::getUsingPortInfo(m_impl->port).c_str());
 	HATOHOL_ASSERT(m_impl->soupServer,
 	               "failed: soup_server_new: %u, errno: %d (%s)\n",
-	               m_impl->port, errno, strerror(errno));
+	               m_impl->port, errno, g_strerror(errno));
 	soup_server_add_handler(m_impl->soupServer, NULL,
 	                        handlerDefault, this, NULL);
 	m_impl->addHandler("/hello.html",

--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -186,13 +186,13 @@ static bool changeUser(const string &user)
 	struct passwd *pwd = getpwnam(user.c_str());
 	if (!pwd) {
 		MLPL_ERR("Failed to get user %s: %s\n",
-			 user.c_str(), strerror(errno));
+			 user.c_str(), g_strerror(errno));
 		return false;
 	}
 	if (setuid(pwd->pw_uid)) {
 		MLPL_ERR("Failed to switch user to %s (uid=%" PRIuMAX "); %s\n",
 			 user.c_str(), (uintmax_t)pwd->pw_uid,
-			 strerror(errno));
+			 g_strerror(errno));
 		return false;
 	}
 	return true;

--- a/server/test/HttpServerStub.cc
+++ b/server/test/HttpServerStub.cc
@@ -92,7 +92,7 @@ void HttpServerStub::start(guint port)
 			break;
 
 		MLPL_ERR("Failed to create SoupServer: %d: %s\n",
-			 errno, strerror(errno));
+			 errno, g_strerror(errno));
 		if (i < retryCount)
 			sleep(5);
 		else

--- a/server/test/testActionManager.cc
+++ b/server/test/testActionManager.cc
@@ -144,7 +144,7 @@ struct ExecCommandContext : public ResidentPullHelper<ExecCommandContext> {
 				cut_notify(
 				  "Failed to call kill: "
 				  "pid: %d, signo: %d, %s\n",
-				  actionTpPid, signo, strerror(errno));
+				  actionTpPid, signo, g_strerror(errno));
 			}
 		}
 


### PR DESCRIPTION
https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-strerror
