### PR TITLE
[server] ArmZabbixAPI,ConfigManager: Do not get old events at first by d...

### DIFF
--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -25,6 +25,7 @@ using namespace mlpl;
 #include <libsoup/soup.h>
 #include <json-glib/json-glib.h>
 
+#include "ConfigManager.h"
 #include "ArmZabbixAPI.h"
 #include "JSONParser.h"
 #include "JSONBuilder.h"
@@ -113,7 +114,8 @@ void ArmZabbixAPI::updateEvents(void)
 	  cache.getMonitoring().getLastEventId(m_impl->zabbixServerId);
 	MLPL_DBG("The last event ID in Hatohol DB: %" FMT_EVENT_ID "\n", dbLastEventId);
 	EventIdType eventIdFrom = dbLastEventId == EVENT_ID_NOT_FOUND ?
-	                          getEndEventId(true) :
+				  (ConfigManager::getInstance()->getLoadOldEvents() ?
+				   getEndEventId(true) : serverLastEventId) :
 	                          dbLastEventId + 1;
 
 	while (eventIdFrom <= serverLastEventId) {

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -92,6 +92,7 @@ CommandLineOptions::CommandLineOptions(void)
   testMode(FALSE),
   enableCopyOnDemand(FALSE),
   disableCopyOnDemand(FALSE),
+  loadOldEvents(FALSE),
   faceRestPort(-1)
 {
 }
@@ -114,6 +115,7 @@ struct ConfigManager::Impl {
 	AtomicValue<int>      faceRestPort;
 	string                user;
 	string                pidFilePath;
+	bool                  loadOldEvents;
 
 	// methods
 	Impl(void)
@@ -282,6 +284,10 @@ bool ConfigManager::parseCommandLine(gint *argc, gchar ***argv,
 		{"log-level",
 		 'l', 0, G_OPTION_ARG_CALLBACK, (gpointer)parseLogLevel,
 		 "Log level: DBG, INFO, WARN, ERR, CRIT, or BUG. ", NULL},
+		{"load-old-events",
+		 0, 0, G_OPTION_ARG_NONE,
+		 &cmdLineOpts->loadOldEvents,
+		 "Load old events when adding new monitoring server.", NULL},
 		{ NULL }
 	};
 
@@ -440,6 +446,11 @@ string ConfigManager::getPidFilePath(void) const
 string ConfigManager::getUser(void) const
 {
 	return m_impl->user;
+}
+
+bool ConfigManager::getLoadOldEvents(void) const
+{
+	return m_impl->loadOldEvents;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -35,6 +35,7 @@ struct CommandLineOptions {
 	gboolean  testMode;
 	gboolean  enableCopyOnDemand;
 	gboolean  disableCopyOnDemand;
+	gboolean  loadOldEvents;
 	gint      faceRestPort;
 
 	CommandLineOptions(void);
@@ -124,6 +125,7 @@ public:
 
 	std::string getUser(void) const;
 
+	bool getLoadOldEvents(void) const;
 protected:
 	void loadConfFile(void);
 	static gboolean parseLogLevel(


### PR DESCRIPTION
...efault.

When adding a new zabbix server, Hatohol tried to get all events
from the server.  It may take very long time if the server has
accumulated tons of events.  This seems very harmful because it
places a high load on the monitoring server.

Do not load old events by default unless --load-old-events option
is specified.

Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>