### PR TITLE
Add new index for events: TimeSec

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -319,8 +319,14 @@ static const int columnIndexesEventsUniqId[] = {
   IDX_EVENTS_SERVER_ID, IDX_EVENTS_ID, DBAgent::IndexDef::END,
 };
 
+static const int columnIndexesEventsTimeSec[] = {
+  IDX_EVENTS_TIME_SEC, IDX_EVENTS_TIME_NS,
+  IDX_EVENTS_UNIFIED_ID, DBAgent::IndexDef::END,
+};
+
 static const DBAgent::IndexDef indexDefsEvents[] = {
   {"EventsId", (const int *)columnIndexesEventsUniqId, false},
+  {"TimeSec", (const int *)columnIndexesEventsTimeSec, false},
   {NULL}
 };
 


### PR DESCRIPTION
In Hatohol DB has tens of millions of events data (occured 40 events / sec), ajax_events show events too slow.

I and @yoshfuji san investigate this problem and found cause of this issue.
As a result of investigation, the cause did not create index for events.

So, I think we need to add new index for events.

Related to #158