### PR TITLE
[server] ConfigManager: --load-old-events option was not applied.

### DIFF
--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -209,6 +209,8 @@ struct ConfigManager::Impl {
 			pidFilePath = cmdLineOpts.pidFilePath;
 		if (cmdLineOpts.user)
 			user = cmdLineOpts.user;
+		if (cmdLineOpts.loadOldEvents)
+			loadOldEvents = cmdLineOpts.loadOldEvents;
 	}
 
 private:


### PR DESCRIPTION
Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>