### PR TITLE
[HatoholConnector] Add a missing local variable "self"

### DIFF
--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -73,6 +73,8 @@ var HatoholConnector = function(connectParams) {
 };
 
 HatoholConnector.prototype.start = function(connectParams) {
+  var self = this;
+
   if (connectParams.request)
     self.request = connectParams.request;
   else


### PR DESCRIPTION
This commit fixes issue #938.

Because the "request" property of HatoholConnector is stored to
an inappropriate object, it can't recognize the HTTP method
correctly on a certain condition.