### PR TITLE
[ZabbixAPI] Use addTrue() function instead of add() function.

### DIFF
--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -713,7 +713,7 @@ SoupMessage *ZabbixAPI::queryGroup(HatoholError &queryRet)
 	agent.add("method", "hostgroup.get");
 
 	agent.startObject("params");
-	agent.add("real_hosts", true);
+	agent.addTrue("real_hosts");
 	agent.add("output", "extend");
 	agent.add("selectHosts", "refer");
 	agent.endObject(); //params


### PR DESCRIPTION
I found a mistake in #934.

We should use ```addTrue()``` or ```addFalse()``` function when we set value of JSON as boolean value.