### PR TITLE
[server][Zabbix] Zabbix macro replacement face rest

### DIFF
--- a/server/src/FaceRest.h
+++ b/server/src/FaceRest.h
@@ -23,6 +23,7 @@
 #include <libsoup/soup.h>
 #include "FaceBase.h"
 #include "JSONBuilder.h"
+#include "JSONParser.h"
 #include "SmartTime.h"
 #include "Params.h"
 #include "HatoholError.h"

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -524,7 +524,7 @@ static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue
 	if (parser.hasError())
 		return false;
 
-	return parser.read("expandedDesctription", extendedInfoValue);
+	return parser.read("extendedDesctription", extendedInfoValue);
 }
 
 void RestResourceHost::handlerGetTrigger(void)

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -524,7 +524,7 @@ static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue
 	if (parser.hasError())
 		return false;
 
-	return parser.read("extendedDesctription", extendedInfoValue);
+	return parser.read("expandedDescription", extendedInfoValue);
 }
 
 void RestResourceHost::handlerGetTrigger(void)

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -545,6 +545,8 @@ void RestResourceHost::handlerGetTrigger(void)
 		agent.add("serverId", triggerInfo.serverId);
 		agent.add("hostId",   StringUtils::toString(triggerInfo.hostId));
 		agent.add("brief",    triggerInfo.brief);
+		agent.add("extendedInfo",
+		          triggerInfo.extendedInfo);
 		agent.endObject();
 	}
 	agent.endArray();

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -550,6 +550,10 @@ void RestResourceHost::handlerGetTrigger(void)
 	TriggerInfoListIterator it = triggerList.begin();
 	for (; it != triggerList.end(); ++it) {
 		TriggerInfo &triggerInfo = *it;
+		string extendedInfoValue = "";
+		bool foundExtendInfo = false;
+		foundExtendInfo = parseExtendedInfo(triggerInfo, extendedInfoValue);
+
 		agent.startObject();
 		agent.add("id",       StringUtils::toString(triggerInfo.id));
 		agent.add("status",   triggerInfo.status);
@@ -559,8 +563,8 @@ void RestResourceHost::handlerGetTrigger(void)
 		agent.add("serverId", triggerInfo.serverId);
 		agent.add("hostId",   StringUtils::toString(triggerInfo.hostId));
 		agent.add("brief",    triggerInfo.brief);
-		agent.add("extendedInfo",
-		          triggerInfo.extendedInfo);
+		if (foundExtendInfo)
+			agent.add("extendedInfo", extendedInfoValue);
 		agent.endObject();
 	}
 	agent.endArray();

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -564,7 +564,7 @@ void RestResourceHost::handlerGetTrigger(void)
 		agent.add("hostId",   StringUtils::toString(triggerInfo.hostId));
 		agent.add("brief",    triggerInfo.brief);
 		if (foundExtendInfo)
-			agent.add("extendedInfo", extendedInfoValue);
+			agent.add("expandedDescription", extendedInfoValue);
 		agent.endObject();
 	}
 	agent.endArray();

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -515,7 +515,7 @@ void RestResourceHost::handlerGetHost(void)
 	replyJSONData(agent);
 }
 
-static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue)
+bool RestResourceHost::parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue)
 {
 	if (triggerInfo.extendedInfo.empty())
 		return false;

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -549,8 +549,8 @@ void RestResourceHost::handlerGetTrigger(void)
 	for (; it != triggerList.end(); ++it) {
 		TriggerInfo &triggerInfo = *it;
 		string extendedInfoValue = "";
-		bool foundExtendInfo = false;
-		foundExtendInfo = parseExtendedInfo(triggerInfo, extendedInfoValue);
+		bool foundExtendedInfo = false;
+		foundExtendedInfo = parseExtendedInfo(triggerInfo, extendedInfoValue);
 
 		agent.startObject();
 		agent.add("id",       StringUtils::toString(triggerInfo.id));
@@ -561,7 +561,7 @@ void RestResourceHost::handlerGetTrigger(void)
 		agent.add("serverId", triggerInfo.serverId);
 		agent.add("hostId",   StringUtils::toString(triggerInfo.hostId));
 		agent.add("brief",    triggerInfo.brief);
-		if (foundExtendInfo)
+		if (foundExtendedInfo)
 			agent.add("expandedDescription", extendedInfoValue);
 		agent.endObject();
 	}

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -518,14 +518,15 @@ void RestResourceHost::handlerGetHost(void)
 static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue)
 {
 	bool foundExtendInfo = false;
-	if (!triggerInfo.extendedInfo.empty()) {
-		JSONParser parser(triggerInfo.extendedInfo);
-		if (parser.hasError())
-			return false;
+	if (triggerInfo.extendedInfo.empty())
+		return false;
 
-		foundExtendInfo =
-		  parser.read("extendedDesctription", extendedInfoValue);
-		}
+	JSONParser parser(triggerInfo.extendedInfo);
+	if (parser.hasError())
+		return false;
+
+	foundExtendInfo =
+	  parser.read("extendedDesctription", extendedInfoValue);
 	return foundExtendInfo;
 }
 

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -517,7 +517,6 @@ void RestResourceHost::handlerGetHost(void)
 
 static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue)
 {
-	bool foundExtendInfo = false;
 	if (triggerInfo.extendedInfo.empty())
 		return false;
 
@@ -525,9 +524,7 @@ static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue
 	if (parser.hasError())
 		return false;
 
-	foundExtendInfo =
-	  parser.read("expandedDesctription", extendedInfoValue);
-	return foundExtendInfo;
+	return parser.read("expandedDesctription", extendedInfoValue);
 }
 
 void RestResourceHost::handlerGetTrigger(void)

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -515,6 +515,20 @@ void RestResourceHost::handlerGetHost(void)
 	replyJSONData(agent);
 }
 
+static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue)
+{
+	bool foundExtendInfo = false;
+	if (!triggerInfo.extendedInfo.empty()) {
+		JSONParser parser(triggerInfo.extendedInfo);
+		if (parser.hasError())
+			return false;
+
+		foundExtendInfo =
+		  parser.read("extendedDesctription", extendedInfoValue);
+		}
+	return foundExtendInfo;
+}
+
 void RestResourceHost::handlerGetTrigger(void)
 {
 	TriggersQueryOption option(m_dataQueryContextPtr);

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -526,7 +526,7 @@ static bool parseExtendedInfo(TriggerInfo triggerInfo, string &extendedInfoValue
 		return false;
 
 	foundExtendInfo =
-	  parser.read("extendedDesctription", extendedInfoValue);
+	  parser.read("expandedDesctription", extendedInfoValue);
 	return foundExtendInfo;
 }
 

--- a/server/src/RestResourceHost.h
+++ b/server/src/RestResourceHost.h
@@ -47,6 +47,7 @@ struct RestResourceHost : public FaceRest::ResourceHandler
 
 	static HatoholError parseEventParameter(EventsQueryOption &option,
 						GHashTable *query);
+	static bool parseExtendedInfo(TriggerInfo triggerInfo, std::string &extendedInfoValue);
 
 	static const char *pathForOverview;
 	static const char *pathForHost;

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -178,7 +178,7 @@ TriggerInfo testTriggerInfo[] =
 	235012,                   // hostId,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1a",        // brief,
-	"{\"expanded_description\":\"Test Trigger on hostX1\"}", // extendedInfo
+	"{\"expandedDescription\":\"Test Trigger on hostX1\"}", // extendedInfo
 },{
 	1,                        // serverId
 	3,                        // id
@@ -218,7 +218,7 @@ TriggerInfo testTriggerInfo[] =
 	10001,                    // hostId,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
-	"{\"expanded_description\":\"Test Trigger on hostZ1\"}", // extendedInfo
+	"{\"expandedDescription\":\"Test Trigger on hostZ1\"}", // extendedInfo
 },{
 	3,                        // serverId
 	3,                        // id

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -178,7 +178,7 @@ TriggerInfo testTriggerInfo[] =
 	235012,                   // hostId,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1a",        // brief,
-	"",                       // extendedInfo
+	"{\"expanded_description\":\"Test Trigger on hostX1\"}", // extendedInfo
 },{
 	1,                        // serverId
 	3,                        // id
@@ -218,7 +218,7 @@ TriggerInfo testTriggerInfo[] =
 	10001,                    // hostId,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
-	"",                       // extendedInfo
+	"{\"expanded_description\":\"Test Trigger on hostZ1\"}", // extendedInfo
 },{
 	3,                        // serverId
 	3,                        // id

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -25,6 +25,7 @@
 #include "UnifiedDataStore.h"
 #include "testDBTablesMonitoring.h"
 #include "FaceRestTestUtils.h"
+#include "RestResourceHost.h"
 #include "ThreadLocalDBCache.h"
 using namespace std;
 using namespace mlpl;
@@ -42,8 +43,11 @@ static void _assertTestTriggerInfo(
 	assertValueInParser(parser, "hostId", StringUtils::toString(triggerInfo.hostId));
 	assertValueInParser(parser, "brief", triggerInfo.brief);
 	if (!triggerInfo.extendedInfo.empty()) {
+		string parsedExtendedInfo = "";
+		RestResourceHost::parseExtendedInfo(triggerInfo,
+		                                    parsedExtendedInfo);
 		assertValueInParser(parser, "expandedDescription",
-		                    triggerInfo.extendedInfo);
+		                    parsedExtendedInfo);
 	}
 }
 #define assertTestTriggerInfo(P, T) cut_trace(_assertTestTriggerInfo(P, T))

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -41,7 +41,7 @@ static void _assertTestTriggerInfo(
 	assertValueInParser(parser, "serverId", triggerInfo.serverId);
 	assertValueInParser(parser, "hostId", StringUtils::toString(triggerInfo.hostId));
 	assertValueInParser(parser, "brief", triggerInfo.brief);
-	if (triggerInfo.extendedInfo.empty()) {
+	if (!triggerInfo.extendedInfo.empty()) {
 		assertValueInParser(parser, "expandedDescription",
 		                    triggerInfo.extendedInfo);
 	}

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -41,6 +41,8 @@ static void _assertTestTriggerInfo(
 	assertValueInParser(parser, "serverId", triggerInfo.serverId);
 	assertValueInParser(parser, "hostId", StringUtils::toString(triggerInfo.hostId));
 	assertValueInParser(parser, "brief", triggerInfo.brief);
+	assertValueInParser(parser, "extendedInfo",
+	                    triggerInfo.extendedInfo);
 }
 #define assertTestTriggerInfo(P, T) cut_trace(_assertTestTriggerInfo(P, T))
 

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -142,7 +142,7 @@ static void _assertHosts(const string &path, const string &callbackName = "",
 	StringMap queryMap;
 	if (serverId != ALL_SERVERS) {
 		queryMap["serverId"] =
-		   StringUtils::sprintf("%" PRIu32, serverId); 
+		   StringUtils::sprintf("%" PRIu32, serverId);
 	}
 	RequestArg arg(path, callbackName);
 	arg.parameters = queryMap;
@@ -191,7 +191,7 @@ static void _assertTriggers(const string &path, const string &callbackName = "",
 		  StringUtils::sprintf("%" PRIu32, serverId);
 	}
 	if (hostId != ALL_HOSTS)
-		queryMap["hostId"] = StringUtils::sprintf("%" PRIu64, hostId); 
+		queryMap["hostId"] = StringUtils::sprintf("%" PRIu64, hostId);
 	arg.parameters = queryMap;
 	JSONParser *parser = getResponseAsJSONParser(arg);
 	unique_ptr<JSONParser> parserPtr(parser);
@@ -360,7 +360,7 @@ static void _assertItems(const string &path, const string &callbackName = "",
 		parser->endElement();
 
 		// Check duplication
-		pair<set<ItemInfo *>::iterator, bool> result = 
+		pair<set<ItemInfo *>::iterator, bool> result =
 		  itemInfoPtrSet.insert(itemInfoPtr);
 		cppcut_assert_equal(true, result.second);
 	}
@@ -419,7 +419,7 @@ static void assertSystemStatusInParserEach(
   JSONParser *parser, const int &severityNum,
   const ServerIdType &serverId, const HostgroupIdType &hostgroupId)
 {
-	const TriggerSeverityType severity = 
+	const TriggerSeverityType severity =
 	  static_cast<TriggerSeverityType>(severityNum);
 	const size_t expectedTriggers =
 	  getNumberOfTestTriggers(serverId, hostgroupId, severity);

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -42,7 +42,7 @@ static void _assertTestTriggerInfo(
 	assertValueInParser(parser, "hostId", StringUtils::toString(triggerInfo.hostId));
 	assertValueInParser(parser, "brief", triggerInfo.brief);
 	if (triggerInfo.extendedInfo.empty()) {
-		assertValueInParser(parser, "extendedInfo",
+		assertValueInParser(parser, "expandedDescription",
 		                    triggerInfo.extendedInfo);
 	}
 }

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -41,8 +41,10 @@ static void _assertTestTriggerInfo(
 	assertValueInParser(parser, "serverId", triggerInfo.serverId);
 	assertValueInParser(parser, "hostId", StringUtils::toString(triggerInfo.hostId));
 	assertValueInParser(parser, "brief", triggerInfo.brief);
-	assertValueInParser(parser, "extendedInfo",
-	                    triggerInfo.extendedInfo);
+	if (triggerInfo.extendedInfo.empty()) {
+		assertValueInParser(parser, "extendedInfo",
+		                    triggerInfo.extendedInfo);
+	}
 }
 #define assertTestTriggerInfo(P, T) cut_trace(_assertTestTriggerInfo(P, T))
 


### PR DESCRIPTION
This pull request a part of works related to issue #326.

Contains:

* deliver ~~`extendedInfo`~~ `expandedDescription` column information to hatohol client
* Add ~~`extendedIinfo`~~ `expandedDescription` assertion into FaceRestHost
