### PR TITLE
[server][Zabbix] Zabbix macro replacement adjust argument

### DIFF
--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -280,7 +280,7 @@ ItemTablePtr ZabbixAPI::getTrigger(int requestSince)
 	return ItemTablePtr(tablePtr);
 }
 
-ItemTablePtr ZabbixAPI::getTriggerExpandedDescription(ItemTablePtr items, int requestSince)
+ItemTablePtr ZabbixAPI::getTriggerExpandedDescription(int requestSince)
 {
 	HatoholError queryRet;
 	SoupMessage *msg =

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -112,7 +112,7 @@ protected:
 	 * @return The obtained triggers as an ItemTable format.
 	 */
 	ItemTablePtr getTrigger(int requestSince = 0);
-	ItemTablePtr getTriggerExpandedDescription(ItemTablePtr items, int requestSince = 0);
+	ItemTablePtr getTriggerExpandedDescription(int requestSince = 0);
 
 	/**
 	 * Get the items.

--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -86,12 +86,12 @@ ItemTablePtr ArmZabbixAPI::updateTriggers(void)
 	return getTrigger(requestSince);
 }
 
-ItemTablePtr ArmZabbixAPI::updateTriggerExpandedDescriptions(ItemTablePtr triggers)
+ItemTablePtr ArmZabbixAPI::updateTriggerExpandedDescriptions(void)
 {
 	UnifiedDataStore *uds = UnifiedDataStore::getInstance();
 	SmartTime last = uds->getTimestampOfLastTrigger(m_impl->zabbixServerId);
 	const int requestSince = last.getAsTimespec().tv_sec;
-	return getTriggerExpandedDescription(triggers, requestSince);
+	return getTriggerExpandedDescription(requestSince);
 }
 
 void ArmZabbixAPI::updateItems(void)
@@ -180,7 +180,7 @@ void ArmZabbixAPI::makeHatoholTriggers(ItemTablePtr triggers)
 	HatoholDBUtils::transformTriggersToHatoholFormat(
 	  triggerInfoList, triggers, m_impl->zabbixServerId,
 	  m_impl->hostInfoCache);
-	expandedDescription = updateTriggerExpandedDescriptions(triggers);
+	expandedDescription = updateTriggerExpandedDescriptions();
 	HatoholDBUtils::transformTriggerExpandedDescriptionToHatoholFormat(
 	  expandedTriggerInfoList, expandedDescription);
 	HatoholDBUtils::mergePlainTriggersListAndExpandedDescriptionList(

--- a/server/src/ArmZabbixAPI.h
+++ b/server/src/ArmZabbixAPI.h
@@ -44,7 +44,7 @@ public:
 
 protected:
 	ItemTablePtr updateTriggers(void);
-	ItemTablePtr updateTriggerExpandedDescriptions(ItemTablePtr triggers);
+	ItemTablePtr updateTriggerExpandedDescriptions(void);
 	void updateItems(void);
 
 	/**

--- a/server/test/testArmZabbixAPI.cc
+++ b/server/test/testArmZabbixAPI.cc
@@ -65,7 +65,7 @@ typedef bool (ArmZabbixAPITestee::*ThreadOneProc)(void);
 public:
 	enum GetTestType {
 		GET_TEST_TYPE_TRIGGERS,
-		GET_TEST_TYPE_TRIGGERS_WITH_EXPANDED_DESCRIPTION,
+		GET_TEST_TYPE_TRIGGER_EXPANDED_DESCRIPTION,
 		GET_TEST_TYPE_ITEMS,
 		GET_TEST_TYPE_HOSTS,
 		GET_TEST_TYPE_APPLICATIONS,
@@ -122,9 +122,9 @@ public:
 			succeeded =
 			  launch(&ArmZabbixAPITestee::threadOneProcTriggers,
 			         exitCbDefault, this);
-		} else if (type == GET_TEST_TYPE_TRIGGERS_WITH_EXPANDED_DESCRIPTION) {
+		} else if (type == GET_TEST_TYPE_TRIGGER_EXPANDED_DESCRIPTION) {
 			succeeded =
-			  launch(&ArmZabbixAPITestee::threadOneProcTriggersWithExpandedDescriptions,
+			  launch(&ArmZabbixAPITestee::threadOneProcTriggerExpandedDescriptions,
 			         exitCbDefault, this);
 		} else if (type == GET_TEST_TYPE_ITEMS) {
 			succeeded =
@@ -303,10 +303,9 @@ protected:
 		return true;
 	}
 
-	bool threadOneProcTriggersWithExpandedDescriptions(void)
+	bool threadOneProcTriggerExpandedDescriptions(void)
 	{
-		ItemTablePtr triggers = updateTriggers();
-		updateTriggerExpandedDescriptions(triggers);
+		updateTriggerExpandedDescriptions();
 		return true;
 	}
 
@@ -447,7 +446,7 @@ void test_getTriggers(void)
 
 void test_getTriggerWithExpandedDescriptions(void)
 {
-	assertTestGet(ArmZabbixAPITestee::GET_TEST_TYPE_TRIGGERS_WITH_EXPANDED_DESCRIPTION);
+	assertTestGet(ArmZabbixAPITestee::GET_TEST_TYPE_TRIGGER_EXPANDED_DESCRIPTION);
 }
 
 void test_getTriggers_2_2_0(void)


### PR DESCRIPTION
I've remove unused `items` argument from functions which are getting expanded information from Zabbix.