### PR TITLE
Clean up history view

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -108,7 +108,7 @@ div#noscript-background div#noscript-notice
     white-space: normal;
 }
 
-#item-graph-auto-refresh {
+#item-graph-auto-reload {
     margin-left: 1em;
     margin-right: 0;
     margin-bottom: 3.6em;

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -501,15 +501,11 @@ var HistoryView = function(userProfile, options) {
       min: undefined,
       max: undefined,
       set: function(beginTime, endTime) {
+        this.setEndTime(endTime);
         this.begin = beginTime;
-        this.end = endTime;
-        if (!this.max)
-          this.max = this.end;
-        if (!this.min)
-          this._adjustMin();
-        if (this.end - this.begin > this.maxSpan)
+        if (this.getSpan() > this.maxSpan)
           this.begin = this.end - this.maxSpan;
-        if (this.end - this.begin < this.minSpan) {
+        if (this.getSpan() < this.minSpan) {
           if (this.begin + this.minSpan >= this.max) {
             this.end = this.max;
             this.begin = this.max - this.minSpan;

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -479,11 +479,9 @@ var HistoryView = function(userProfile, options) {
   }
 
   function drawGraph() {
-    var beginTimeInSec = self.timeRange.begin;
-    var endTimeInSec = self.timeRange.end;
     var i;
 
-    self.plotOptions = getPlotOptions(beginTimeInSec, endTimeInSec);
+    self.plotOptions = getPlotOptions(self.timeRange.begin, self.timeRange.end);
     fixupYAxisMapping(self.plotData, self.plotOptions);
 
     for (i = 0; i < self.plotData.length; i++) {

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -251,7 +251,7 @@ var HistoryView = function(userProfile, options) {
       self.loaders[i] = new HistoryLoader({
         index: i,
         view: self,
-        defaultTimeSpan: self.timeSpan,
+        defaultTimeSpan: self.timeRange.getSpan(),
         query: historyQueries[i],
         onLoadItem: function(item, servers) {
           this.item = item;

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -502,9 +502,9 @@ var HistoryView = function(userProfile, options) {
       maxSpan: secondsInHour * 24,
       min: undefined,
       max: self.endTime,
-      set: function(range) {
-        this.begin = range[0];
-        this.end = range[1];
+      set: function(beginTime, endTime) {
+        this.begin = beginTime;
+        this.end = endTime;
         if (this.end - this.begin > this.maxSpan)
           this.begin = this.end - this.maxSpan;
         if (this.end - this.begin < this.minSpan) {
@@ -554,7 +554,7 @@ var HistoryView = function(userProfile, options) {
         if (self.isLoading())
           return;
 
-        timeRange.set(ui.values);
+        timeRange.set(ui.values[0], ui.values[1]);
         setSliderTimeRange(timeRange.begin, timeRange.end);
         setGraphTimeRange(timeRange.begin, timeRange.end);
         for (i = 0; i < self.loaders.length; i++)
@@ -572,7 +572,7 @@ var HistoryView = function(userProfile, options) {
           endTime = ui.values[0] + timeRange.getSpan();
         if (ui.values[1] - ui.values[0] < timeRange.minSpan)
           beginTime = ui.values[1] - timeRange.minSpan;
-        timeRange.set([beginTime, endTime]);
+        timeRange.set(beginTime, endTime);
         setSliderTimeRange(timeRange.begin, timeRange.end);
       },
     });

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -544,8 +544,8 @@ var HistoryView = function(userProfile, options) {
           return this.end - this.begin;
         else
           return secondsInHour * 6;
-      },
-    }
+      }
+    };
     return timeRange;
   }
 

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -350,7 +350,6 @@ var HistoryView = function(userProfile, options) {
       setSliderTimeRange(Math.floor(ranges.xaxis.from / 1000),
                          Math.floor(ranges.xaxis.to / 1000));
 
-      // disable auto reload
       disableAutoReload();
     });
 

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -555,7 +555,9 @@ var HistoryView = function(userProfile, options) {
   function drawSlider() {
     var timeRange = self.timeRange;
 
-    timeRange.set(timeRange.begin, timeRange.end);
+    // TODO: remove it
+    if (self.autoReloadIsEnabled && self.timeRange.end)
+      self.timeRange.setMax(self.timeRange.end);
 
     $("#item-graph-slider").slider({
       range: true,

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -518,25 +518,26 @@ var HistoryView = function(userProfile, options) {
           }
         }
       },
-      setMax: function(max) {
-	this.max = max;
-	this._adjustMin();
-      },
       setEndTime: function(endTime) {
-	var span = this.getSpan();
-	this.end = endTime;
-	this.begin = this.end - span;
+        var span = this.getSpan();
+        this.end = endTime;
+        this.begin = this.end - span;
+        if (!this.max || this.end > this.max) {
+          this.max = this.end;
+          this._adjustMin();
+        }
       },
       _adjustMin: function() {
         var date;
-
-        if (!self.plotOptions)
-          return;
+        var plotOptions = {
+          mode: "time",
+          timezone: "browser"
+        };
 
         // 1 week ago
         this.min = this.max - secondsInHour * 24 * 7;
         // Adjust to 00:00:00
-        date = $.plot.dateGenerator(this.min * 1000, self.plotOptions.xaxis);
+        date = $.plot.dateGenerator(this.min * 1000, plotOptions);
         this.min -=
           date.getHours() * 3600 +
           date.getMinutes() * 60 +
@@ -554,10 +555,6 @@ var HistoryView = function(userProfile, options) {
 
   function drawSlider() {
     var timeRange = self.timeRange;
-
-    // TODO: remove it
-    if (self.autoReloadIsEnabled && timeRange.end)
-      timeRange.setMax(timeRange.end);
 
     $("#item-graph-slider").slider({
       range: true,

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -244,7 +244,8 @@ var HistoryView = function(userProfile, options) {
   load();
 
   function prepareHistoryLoaders(historyQueries) {
-    var i;
+    var i, endTime, timeSpan;
+
     for (i = 0; i < historyQueries.length; i++) {
       self.plotData[i] = initLegendData();
       self.loaders[i] = new HistoryLoader({
@@ -265,8 +266,8 @@ var HistoryView = function(userProfile, options) {
     }
 
     // TODO: allow different time ranges?
-    var endTime = self.loaders[0].options.query.endTime;
-    var timeSpan = self.loaders[0].getTimeSpan();
+    endTime = self.loaders[0].options.query.endTime;
+    timeSpan = self.loaders[0].getTimeSpan();
     if (endTime)
       self.timeRange.set(endTime - timeSpan, endTime);
     self.autoReloadIsEnabled = !endTime;

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -556,8 +556,8 @@ var HistoryView = function(userProfile, options) {
     var timeRange = self.timeRange;
 
     // TODO: remove it
-    if (self.autoReloadIsEnabled && self.timeRange.end)
-      self.timeRange.setMax(self.timeRange.end);
+    if (self.autoReloadIsEnabled && timeRange.end)
+      timeRange.setMax(timeRange.end);
 
     $("#item-graph-slider").slider({
       range: true,

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -291,8 +291,8 @@ var HistoryView = function(userProfile, options) {
     });
   }
 
-  function enableAutoRefresh(onClickButton) {
-    var button = $("#item-graph-auto-refresh");
+  function enableAutoReload(onClickButton) {
+    var button = $("#item-graph-auto-reload");
 
     button.removeClass("btn-default");
     button.addClass("btn-primary");
@@ -303,8 +303,8 @@ var HistoryView = function(userProfile, options) {
     load();
   }
 
-  function disableAutoRefresh(onClickButton) {
-    var button = $("#item-graph-auto-refresh");
+  function disableAutoReload(onClickButton) {
+    var button = $("#item-graph-auto-reload");
     self.clearAutoReload();
     self.autoReloadIsEnabled = false;
     if (!onClickButton)
@@ -326,7 +326,7 @@ var HistoryView = function(userProfile, options) {
       id: "item-graph-slider",
     }))
     .append($("<button>", {
-      id: "item-graph-auto-refresh",
+      id: "item-graph-auto-reload",
       type: "button",
       class: "btn btn-primary glyphicon glyphicon-refresh active",
     }).attr("data-toggle", "button"));
@@ -350,8 +350,8 @@ var HistoryView = function(userProfile, options) {
       setSliderTimeRange(Math.floor(ranges.xaxis.from / 1000),
                          Math.floor(ranges.xaxis.to / 1000));
 
-      // disable auto refresh
-      disableAutoRefresh();
+      // disable auto reload
+      disableAutoReload();
     });
 
     // zoom cancel
@@ -361,12 +361,12 @@ var HistoryView = function(userProfile, options) {
                          Math.floor(self.plotOptions.xaxis.max / 1000));
     });
 
-    // toggle auto refresh
-    $("#item-graph-auto-refresh").on("click", function() {
+    // toggle auto reload
+    $("#item-graph-auto-reload").on("click", function() {
       if ($(this).hasClass("active")) {
-        disableAutoRefresh(true);
+        disableAutoReload(true);
       } else {
-        enableAutoRefresh(true);
+        enableAutoReload(true);
       }
     });
   };
@@ -570,9 +570,9 @@ var HistoryView = function(userProfile, options) {
         setGraphTimeRange(timeRange.begin, timeRange.end);
         for (i = 0; i < self.loaders.length; i++)
           self.loaders[i].setTimeRange(timeRange.begin, timeRange.end);
-        disableAutoRefresh();
+        disableAutoReload();
         load();
-        $("#item-graph-auto-refresh").removeClass("active");
+        $("#item-graph-auto-reload").removeClass("active");
       },
       slide: function(event, ui) {
         var beginTime = ui.values[0], endTime = ui.values[1];

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -507,7 +507,7 @@ var HistoryView = function(userProfile, options) {
         if (!this.max)
           this.max = this.end;
         if (!this.min)
-          this.adjustMin();
+          this._adjustMin();
         if (this.end - this.begin > this.maxSpan)
           this.begin = this.end - this.maxSpan;
         if (this.end - this.begin < this.minSpan) {
@@ -519,7 +519,11 @@ var HistoryView = function(userProfile, options) {
           }
         }
       },
-      adjustMin: function() {
+      setMax: function(max) {
+	this.max = max;
+	this._adjustMin();
+      },
+      _adjustMin: function() {
         var date;
 
         if (!self.plotOptions)
@@ -544,10 +548,8 @@ var HistoryView = function(userProfile, options) {
   function drawSlider() {
     var timeRange = self.timeRange;
 
-    if (self.autoReloadIsEnabled) {
-      self.timeRange.max = self.endTime;
-      self.timeRange.adjustMin();
-    }
+    if (self.autoReloadIsEnabled)
+      self.timeRange.setMax(self.endTime);
     self.timeRange.set(self.endTime - self.timeSpan, self.endTime);
 
     $("#item-graph-slider").slider({

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -382,9 +382,17 @@ var HistoryView = function(userProfile, options) {
     return legend;
   };
 
+  function getDate(timeMSec) {
+    var plotOptions = {
+      mode: "time",
+      timezone: "browser"
+    };
+    return $.plot.dateGenerator(timeMSec, plotOptions);
+  }
+
   function formatTime(val, unit) {
     var now = new Date();
-    var date = $.plot.dateGenerator(val, self.plotOptions.xaxis);
+    var date = getDate(val);
     var format = "";
 
     if (now.getFullYear() != date.getFullYear())
@@ -524,15 +532,10 @@ var HistoryView = function(userProfile, options) {
       },
       _adjustMin: function() {
         var date;
-        var plotOptions = {
-          mode: "time",
-          timezone: "browser"
-        };
-
         // 1 week ago
         this.min = this.max - secondsInHour * 24 * 7;
         // Adjust to 00:00:00
-        date = $.plot.dateGenerator(this.min * 1000, plotOptions);
+        date = getDate(this.min * 1000);
         this.min -=
           date.getHours() * 3600 +
           date.getMinutes() * 60 +

--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -178,7 +178,9 @@ HistoryLoader.prototype.updateHistory = function(history) {
   }
 }
 
-HistoryLoader.prototype.setTimeRange = function(beginTimeInSec, endTimeInSec, keepHistory) {
+HistoryLoader.prototype.setTimeRange = function(beginTimeInSec, endTimeInSec,
+                                                keepHistory)
+{
   if (isNaN(beginTimeInSec))
     delete this.options.query.beginTime;
   else


### PR DESCRIPTION
* Remove redundant properties of HistoryView ("endTime" and "timeSpan") because the "timeRange" object has same information
* Replace the word "refresh" with "reload" to unify them
* Unify calling $.plot.dateGenerator()