### PR TITLE
[DBAgent] Fix the problem in which updating an index fails.

### DIFF
--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -378,6 +378,9 @@ protected:
 	  std::vector<IndexInfo> &indexInfoVect,
 	  const TableProfile &tableProfile) = 0;
 
+	virtual std::string makeIndexName(const TableProfile &tableProfile,
+	                                  const IndexDef &indexDef);
+
 private:
 	struct Impl;
 };

--- a/server/src/DBAgentSQLite3.cc
+++ b/server/src/DBAgentSQLite3.cc
@@ -910,9 +910,9 @@ string DBAgentSQLite3::makeCreateIndexStatement(
   const TableProfile &tableProfile, const IndexDef &indexDef)
 {
 	string sql = StringUtils::sprintf(
-	  "CREATE %sINDEX i_%s_%s ON %s(",
+	  "CREATE %sINDEX %s ON %s(",
 	  indexDef.isUnique ? "UNIQUE " : "",
-	  tableProfile.name, indexDef.name, tableProfile.name);
+	  makeIndexName(tableProfile, indexDef).c_str(), tableProfile.name);
 
 	const int *columnIdxPtr = indexDef.columnIndexes;
 	while (true) {
@@ -953,6 +953,13 @@ void DBAgentSQLite3::getIndexInfoVect(
 		idxInfo.sql       = idxStruct.sql;
 		indexInfoVect.push_back(idxInfo);
 	}
+}
+
+string DBAgentSQLite3::makeIndexName(
+  const TableProfile &tableProfile, const IndexDef &indexDef)
+{
+	return StringUtils::sprintf("i_%s_%s",
+	                            tableProfile.name, indexDef.name);
 }
 
 string DBAgentSQLite3::getDBPath(void) const

--- a/server/src/DBAgentSQLite3.h
+++ b/server/src/DBAgentSQLite3.h
@@ -122,6 +122,9 @@ protected:
 	  std::vector<IndexInfo> &indexInfoVect,
 	  const TableProfile &tableProfile) override;
 
+	virtual std::string makeIndexName(const TableProfile &tableProfile,
+	                                  const IndexDef &indexDef) override;
+
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/test/DBAgentTest.cc
+++ b/server/test/DBAgentTest.cc
@@ -397,6 +397,37 @@ void dbAgentTestFixupIndexes(DBAgent &dbAgent, DBAgentChecker &checker)
 	checker.assertFixupIndexes(dbAgent, tableProfile);
 }
 
+void dbAgentTestFixupSameNameIndexes(DBAgent &dbAgent, DBAgentChecker &checker)
+{
+	// We make a copy to update a pointer of the indexDefArray
+	DBAgent::TableProfile tableProfile = tableProfileTest;
+
+	const int columnIndexes0[] = {
+	  IDX_TEST_TABLE_AGE, IDX_TEST_TABLE_NAME, IDX_TEST_TABLE_HEIGHT,
+	  DBAgent::IndexDef::END
+	};
+
+	const int columnIndexes1[] = {
+	  IDX_TEST_TABLE_NAME, IDX_TEST_TABLE_TIME, DBAgent::IndexDef::END
+	};
+
+	DBAgent::IndexDef indexDefArray[] = {
+	  {"testIndex",    columnIndexes0, false},
+	  {NULL, NULL, false},
+	};
+
+	// create the 1st index
+	tableProfile.indexDefArray = indexDefArray;
+	dbAgent.createTable(tableProfile);
+	dbAgent.fixupIndexes(tableProfile);
+	checker.assertFixupIndexes(dbAgent, tableProfile);
+
+	// create the 2nd index with the same name
+	indexDefArray[0].columnIndexes = columnIndexes1;
+	dbAgent.fixupIndexes(tableProfile);
+	checker.assertFixupIndexes(dbAgent, tableProfile);
+}
+
 void dbAgentTestInsert(DBAgent &dbAgent, DBAgentChecker &checker)
 {
 	// create table

--- a/server/test/DBAgentTest.h
+++ b/server/test/DBAgentTest.h
@@ -101,6 +101,7 @@ void dbAgentTestMakeCreateIndexStatement(
 void dbAgentTestMakeDropIndexStatement(
   DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestFixupIndexes(DBAgent &dbAgent, DBAgentChecker &checker);
+void dbAgentTestFixupSameNameIndexes(DBAgent &dbAgent, DBAgentChecker &checker);
 
 void dbAgentTestInsert(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentTestInsertUint64

--- a/server/test/testDBAgentMySQL.cc
+++ b/server/test/testDBAgentMySQL.cc
@@ -508,6 +508,12 @@ void test_fixupIndexes(void)
 	dbAgentTestFixupIndexes(dbAgent, dbAgentChecker);
 }
 
+void test_fixupSameNameIndexes(void)
+{
+	DBAgentMySQL dbAgent(TEST_DB_NAME);
+	dbAgentTestFixupSameNameIndexes(dbAgent, dbAgentChecker);
+}
+
 void test_insert(void)
 {
 	DBAgentMySQL dbAgent(TEST_DB_NAME);

--- a/server/test/testDBAgentSQLite3.cc
+++ b/server/test/testDBAgentSQLite3.cc
@@ -439,6 +439,12 @@ void test_fixupIndexes(void)
 	dbAgentTestFixupIndexes(dbAgent, dbAgentChecker);
 }
 
+void test_fixupSameNameIndexes(void)
+{
+	DBAgentSQLite3 dbAgent;
+	dbAgentTestFixupSameNameIndexes(dbAgent, dbAgentChecker);
+}
+
 void test_insert(void)
 {
 	DBAgentSQLite3 dbAgent;


### PR DESCRIPTION
When a combination of columns for an index is changed,
DBAgent tries to create the new one. However, it fals due
to existence of the previous one.

This patch removed the existing index with the same name as
the one that will be created before the creation.