### PR TITLE
[DBTablesUser] Suppress a warning when using C++11 compiler.

### DIFF
--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -317,7 +317,7 @@ string UserQueryOption::getCondition(void) const
 
 	if (m_impl->hasPrivilegesFlags) {
 		string nameCond =
-		  StringUtils::sprintf("%s=%"FMT_OPPRVLG,
+		  StringUtils::sprintf("%s=%" FMT_OPPRVLG,
 		                       COLUMN_DEF_USERS[IDX_USERS_FLAGS].columnName,
 		                       m_impl->targetFlags);
 		condition = nameCond;


### PR DESCRIPTION
Without this patch, the following warning is shown.

DBTablesUser.cc:320:26: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
     StringUtils::sprintf("%s=%"FMT_OPPRVLG,