### PR TITLE
[AMQPMessageHandler] Remove an wrong override keyword.

### DIFF
--- a/server/src/AMQPMessageHandler.h
+++ b/server/src/AMQPMessageHandler.h
@@ -29,7 +29,7 @@ public:
 	AMQPMessageHandler();
 	virtual ~AMQPMessageHandler();
 
-	virtual bool handle(const amqp_envelope_t *envelope) override;
+	virtual bool handle(const amqp_envelope_t *envelope);
 };
 
 #endif // AMQPMessageHandler_h


### PR DESCRIPTION
The keyword can be used only for override method.
But it had been used for a normal method.