### PR TITLE
[web] userconfig: Use content_type instead of deprecated mimetype.

### DIFF
--- a/client/viewer/userconfig.py
+++ b/client/viewer/userconfig.py
@@ -71,7 +71,7 @@ def index_core(request):
     item_name_list = request.GET.getlist('items[]')
 
     body = json.dumps(UserConfig.get_items(item_name_list, user_id))
-    return HttpResponse(body, mimetype='application/json')
+    return HttpResponse(body, content_type='application/json')
 
 def store(request, user_id):
     items = json.loads(request.body)


### PR DESCRIPTION
mimetype is depreated.  Use content_type instead.
Otherwise, we get following noisy errors:
| [:error] [pid XXX] /usr/lib/python2.7/site-packages/django/http/response.py:xxx: DeprecationWarning: Using mimetype keyword argument is deprecated, use content_type instead
| [:error] [pid XXX]   super(HttpResponse, self).__init__(*args, **kwargs)

Note that other callers already use content_type. index_core is the
last one.

Closes: #985 
Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>