### PR TITLE
[web] userconfig: Change log level of starting userconfig from INFO to DEBUG.

### DIFF
--- a/client/viewer/userconfig.py
+++ b/client/viewer/userconfig.py
@@ -26,7 +26,7 @@ import logging
 import traceback
 
 logger = logging.getLogger(__name__)
-logger.info('A logger: %s has been created' % __name__)
+logger.debug('A logger: %s has been created' % __name__)
 
 def get_user_id_from_hatohol_server(session_id):
     server = hatoholserver.get_address()


### PR DESCRIPTION
We see tons of following message in apache error_log:
| [:error] [pid xxx] A logger: viewer.userconfig has been created

This is annoying for ordinal users.

Drop the level from INFO to DEBUG.

Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>
Closes: #987