### PR TITLE
[web] hatohol/settings: Do not emit DEBUG/INFO logs to console by default.

### DIFF
--- a/client/hatohol/settings.py
+++ b/client/hatohol/settings.py
@@ -168,7 +168,7 @@ LOGGING = {
             'class': 'django.utils.log.AdminEmailHandler'
         },
         'console':{
-            'level':'DEBUG',
+            'level':'WARNING',
             'class':'logging.StreamHandler',
         },
         'syslog': {


### PR DESCRIPTION
Info nor debug logs should not be written to stderr by default,
especially if the frontend web is running with apache.
Otherwise, such log messages are recorded in error_log.

Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>