### PR TITLE
Add the process of setting ”validity” to host registration of NagiosNDOUtils.

### DIFF
--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -697,6 +697,7 @@ void ArmNagiosNDOUtils::getHost(void)
 		ItemGroupStream itemGroupStream(*itemGrpItr);
 		HostInfo hostInfo;
 		hostInfo.serverId = svInfo.id;
+		hostInfo.validity = HOST_VALID;
 		itemGroupStream >> hostInfo.id;
 		itemGroupStream >> hostInfo.hostName;
 		hostInfoList.push_back(hostInfo);


### PR DESCRIPTION
Dealing with issue #993 .