### PR TITLE
[Client][Python] Add space after '#'.

### DIFF
--- a/client/hatohol/settings.py
+++ b/client/hatohol/settings.py
@@ -101,7 +101,7 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    #'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 # Make this unique, and don't share it with anybody.
@@ -111,7 +111,7 @@ SECRET_KEY = '9xkobcf%(rj(u54^zf7+-c^@+59c9dqg&amp;he2ue65v88z&amp;dyy_k'
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-    #'django.template.loaders.eggs.Loader',
+    # 'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -136,11 +136,11 @@ TEMPLATE_DIRS = (
 )
 
 INSTALLED_APPS = (
-    #'django.contrib.auth',
-    #'django.contrib.contenttypes',
-    #'django.contrib.sessions',
-    #'django.contrib.sites',
-    #'django.contrib.messages',
+    # 'django.contrib.auth',
+    # 'django.contrib.contenttypes',
+    # 'django.contrib.sessions',
+    # 'django.contrib.sites',
+    # 'django.contrib.messages',
     'django.contrib.staticfiles',
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',


### PR DESCRIPTION
I found these line when use pep8 command to check pep8 style.

```
hatohol/client/hatohol $ pep8 *.py
hatohol_def.py:155:1: W391 blank line at end of file
settings.py:104:5: E265 block comment should start with '# '
settings.py:114:5: E265 block comment should start with '# '
settings.py:139:5: E265 block comment should start with '# '
settings.py:140:5: E265 block comment should start with '# '
settings.py:141:5: E265 block comment should start with '# '
settings.py:142:5: E265 block comment should start with '# '
settings.py:143:5: E265 block comment should start with '# '
```