### PR TITLE
[server][tools] hatohol-db-initiator starts to use hatohol.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Makefile.in
 /server/test/zabbix-api-response-collector
 /server/tools/build/
 /server/tools/hatohol-config-db-creator
+/server/tools/hatohol-db-initiator
 /server/tools/hatohol-def-src-file-generator
 /server/tools/hatohol/hatohol_def.py
 /server/tools/usr/

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ if test x"$sysconfdir" = x"NONE"; then
 fi
 AC_DEFINE_UNQUOTED(SYSCONFDIR, "`eval echo $sysconfdir`", "Data directory.")
 
+expanded_sysconfdir="`eval echo $sysconfdir`"
+AC_SUBST(expanded_sysconfdir)
+
 if test x"$localstatedir" = x"NONE"; then
     runstatedir=$ac_default_localstatedir
 fi
@@ -261,6 +264,7 @@ server/src/Makefile
 server/hap/Makefile
 server/data/Makefile
 server/tools/Makefile
+server/tools/hatohol-db-initiator
 server/tools/hatohol/Makefile
 server/tools/tls/Makefile
 server/tools/tls/hatohol-ca-initialize

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ if test x"$sysconfdir" = x"NONE"; then
     sysconfdir=$ac_default_sysconfdir
 fi
 expanded_sysconfdir="`eval echo $sysconfdir`"
-AC_DEFINE_UNQUOTED(SYSCONFDIR, "$expanded_sysconfdir`", "Data directory.")
+AC_DEFINE_UNQUOTED(SYSCONFDIR, "$expanded_sysconfdir", "Data directory.")
 AC_SUBST(expanded_sysconfdir)
 
 if test x"$localstatedir" = x"NONE"; then

--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,8 @@ AC_DEFINE_UNQUOTED(PREFIX, "$prefix", "Prefix for install directory")
 if test x"$sysconfdir" = x"NONE"; then
     sysconfdir=$ac_default_sysconfdir
 fi
-AC_DEFINE_UNQUOTED(SYSCONFDIR, "`eval echo $sysconfdir`", "Data directory.")
-
 expanded_sysconfdir="`eval echo $sysconfdir`"
+AC_DEFINE_UNQUOTED(SYSCONFDIR, "$expanded_sysconfdir`", "Data directory.")
 AC_SUBST(expanded_sysconfdir)
 
 if test x"$localstatedir" = x"NONE"; then

--- a/server/README.md
+++ b/server/README.md
@@ -159,7 +159,7 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
-Edit `${prefix}/etc/hatohol/hatohol` which is used for database settings (username, database name and password) in MySQL section before you execute `hatohol-db-initiator` to prepare database.
+Edit `${prefix}/etc/hatohol/hatohol.conf` in mysql section which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
 
     $ hatohol-db-initiator
 

--- a/server/README.md
+++ b/server/README.md
@@ -159,7 +159,7 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
-Edit `${prefix}/etc/hatohol/hatohol` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
+Edit `${prefix}/etc/hatohol/hatohol` which is used for database settings (username, database name and password) in MySQL section before you execute `hatohol-db-initiator` to prepare database.
 
     $ hatohol-db-initiator
 

--- a/server/README.md
+++ b/server/README.md
@@ -160,6 +160,7 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 (1) Setup database of MySQL
 
 Edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
+Specify DBUSER and PASSWORD whose MySQL administrator user, respectively.
 
     $ hatohol-db-initiator --db_user DBUSER --db_password DBPASSWORD
 
@@ -172,8 +173,9 @@ Note: Since 15.03, hatohol-db-initiator doesn't require command line argument af
 For example, `hatohol.conf` is placed in `${prefix}/etc/hatohol/hatohol.conf`.
 
 Tips:
-- If the root password of the MySQL server is not set, just pass ''.
+- If the root password of the MySQL server is not set, just pass '' for `--db_password`.
 - You can change password of the created DB by --hatohol-db-user and --hatohol-db-password options.
+- You can change database, username and password by editing mysql section in `hatohol.conf`.
 - If Hatohol server and MySQL server are executed on different machines, you have to input GRANT statement manually with the mysql command line tool.
 
 For example, user/password are 'myuser'/'mypasswd' and the IP address of

--- a/server/README.md
+++ b/server/README.md
@@ -159,11 +159,11 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
-    $ hatohol-db-initiator database_name mysql_user mysql_password
+    $ hatohol-db-initiator
 
-Example:
-
-    $ hatohol-db-initiator hatohol root rootpass
+Note: Since 15.03, hatohol-db-initiator doesn't require command line argument.
+`db_name`, `db_user` and `db_password` are read from `hatohol.conf` by default.
+For example, `hatohol.conf` is placed in `${prefix}/etc/hatohol/hatohol.conf`.
 
 Tips:
 - If the root password of the MySQL server is not set, just pass ''.

--- a/server/README.md
+++ b/server/README.md
@@ -159,6 +159,8 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
+Edit `${prefix}/etc/hatohol/hatohol` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
+
     $ hatohol-db-initiator
 
 Note: Since 15.03, hatohol-db-initiator doesn't require command line argument.

--- a/server/README.md
+++ b/server/README.md
@@ -159,6 +159,8 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
+To setup database used by hatohol server, you need to execute helper command `hatohol-db-initiator`.
+
 Edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
 Specify DBUSER and PASSWORD whose MySQL administrator user, respectively.
 

--- a/server/README.md
+++ b/server/README.md
@@ -161,10 +161,12 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 To setup database used by hatohol server, you need to execute helper command `hatohol-db-initiator`.
 
-Edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
-Specify DBUSER and PASSWORD whose MySQL administrator user, respectively.
+Before you execute this helper command, you can edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password).
+Then, run this helper command as follows:
 
     $ hatohol-db-initiator --db_user DBUSER --db_password DBPASSWORD
+
+You must specify DBUSER and PASSWORD whose MySQL administrator user, respectively.
 
 Example:
 

--- a/server/README.md
+++ b/server/README.md
@@ -159,7 +159,7 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 (1) Setup database of MySQL
 
-Edit `${prefix}/etc/hatohol/hatohol.conf` in mysql section which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
+Edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
 
     $ hatohol-db-initiator
 

--- a/server/README.md
+++ b/server/README.md
@@ -70,7 +70,7 @@ packages
 
     # yum groupinstall "Development Tools"
 
-You need to register a yum repository for installing qpid-cpp-client-devel packages 
+You need to register a yum repository for installing qpid-cpp-client-devel packages
 by the following command
 
     # wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
@@ -104,7 +104,7 @@ Building & installing by following commands:
     $ su
     # make install
 
-### Example to install required libraries on ubuntu 14.04 
+### Example to install required libraries on ubuntu 14.04
 
 You should install these package to build Hatohol and required libraries.
 
@@ -127,7 +127,7 @@ installing by following commands:
     $ sudo apt-get install automake g++ libtool libsoup2.4-dev libjson-glib-dev libsqlite3-dev libmysqlclient-dev mysql-server sqlite3 uuid-dev qpidd libqpidmessaging2-dev libqpidtypes1-dev libqpidcommon2-dev
 
 ## How to build Hatohol
-First, you need to install required libraries.  
+First, you need to install required libraries.
 Then run the following commands to install Hatohol:
 
     $ ./autogen.sh
@@ -300,4 +300,3 @@ Tips:
 
 * You have to install SPHINX package for making the html files.
 When you use Ubuntu 13.04, 'python3-sphinx' package is available.
-

--- a/server/README.md
+++ b/server/README.md
@@ -161,9 +161,13 @@ NOTE: You have to restart qpidd after you edit /etc/qpid/qpiid.acl.
 
 Edit mysql section in `${prefix}/etc/hatohol/hatohol.conf` which is used for database settings (username, database name and password) before you execute `hatohol-db-initiator` to prepare database.
 
-    $ hatohol-db-initiator
+    $ hatohol-db-initiator --db_user DBUSER --db_password DBPASSWORD
 
-Note: Since 15.03, hatohol-db-initiator doesn't require command line argument.
+Example:
+
+    $ hatohol-db-initiator --db_user root --db_password rootpass
+
+Note: Since 15.03, hatohol-db-initiator doesn't require command line argument after hatohol database created.
 `db_name`, `db_user` and `db_password` are read from `hatohol.conf` by default.
 For example, `hatohol.conf` is placed in `${prefix}/etc/hatohol/hatohol.conf`.
 

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -4,6 +4,7 @@ import os
 import argparse
 import MySQLdb
 from ctypes import *
+import ConfigParser
 
 sql_file_list = [
     {'table_name': 'users',
@@ -112,6 +113,20 @@ def add_sql_directory(args, sql_file_list):
 
 def get_default_conf():
     return os.path.dirname(__file__) + '/../etc/hatohol/hatohol.conf'
+
+
+def parse_default_conf(args):
+    config_list = []
+    config = ConfigParser.ConfigParser()
+    try:
+        config.read(args.conf_file)
+        config_list.append({'database': config.get('mysql', 'database'),
+                            'user':     config.get('mysql', 'user'),
+                            'password': config.get('mysql', 'password')})
+    except:
+        print "Could not read hatohol conf."
+
+    return config_list
 
 
 def start(args):

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -129,6 +129,13 @@ def parse_default_conf():
     return config_list
 
 
+def get_default_conf_item(item_name):
+    config = parse_default_conf()
+    for conf in config:
+        item = conf[item_name]
+    return item
+
+
 def start(args):
 
     add_sql_directory(args, sql_file_list)
@@ -166,11 +173,14 @@ def get_target_list():
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Hatohol DB Initiator')
-    parser.add_argument('db_name', type=str,
+    parser.add_argument('--db_name', default=get_default_conf_item('database'),
+                        type=str,
                         help='A database name to be initialized.')
-    parser.add_argument('db_user', type=str,
+    parser.add_argument('--db_user', default=get_default_conf_item('user'),
+                        type=str,
                         help='A user for the database server.')
-    parser.add_argument('db_password', default='', type=str,
+    parser.add_argument('--db_password', default=get_default_conf_item('password'),
+                        type=str,
                         help='A password for the database server.'
                         ' If the password is not set, give \'\' for this argument.')
     parser.add_argument('--host', default='localhost', type=str,

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -115,11 +115,11 @@ def get_default_conf():
     return os.path.dirname(__file__) + '/../etc/hatohol/hatohol.conf'
 
 
-def parse_default_conf(args):
+def parse_default_conf():
     config_list = []
     config = ConfigParser.ConfigParser()
     try:
-        config.read(args.conf_file)
+        config.read(get_default_conf())
         config_list.append({'database': config.get('mysql', 'database'),
                             'user':     config.get('mysql', 'user'),
                             'password': config.get('mysql', 'password')})
@@ -177,8 +177,6 @@ if __name__ == '__main__':
                         help='A database server.')
     parser.add_argument('--sql-dir', default=get_default_sql_dir(), type=str,
                         help='A directory that contains SQL files.')
-    parser.add_argument('--conf-file', default=get_default_conf(), type=str,
-                        help='A file that contains hatohol setting.')
     parser.add_argument('--hatohol-db-user', default='hatohol', type=str,
                         help='A user who is allowed to access the database.')
     parser.add_argument('--hatohol-db-password', default='hatohol', type=str,

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -110,6 +110,10 @@ def add_sql_directory(args, sql_file_list):
         sql_file['file_name'] = args.sql_dir + '/' + sql_file['file_name']
 
 
+def get_default_conf():
+    return os.path.dirname(__file__) + '/../etc/hatohol/hatohol.conf'
+
+
 def start(args):
 
     add_sql_directory(args, sql_file_list)
@@ -158,6 +162,8 @@ if __name__ == '__main__':
                         help='A database server.')
     parser.add_argument('--sql-dir', default=get_default_sql_dir(), type=str,
                         help='A directory that contains SQL files.')
+    parser.add_argument('--conf-file', default=get_default_conf(), type=str,
+                        help='A file that contains hatohol setting.')
     parser.add_argument('--hatohol-db-user', default='hatohol', type=str,
                         help='A user who is allowed to access the database.')
     parser.add_argument('--hatohol-db-password', default='hatohol', type=str,

--- a/server/tools/hatohol-db-initiator
+++ b/server/tools/hatohol-db-initiator
@@ -118,13 +118,14 @@ def get_default_conf():
 def parse_default_conf():
     config_list = []
     config = ConfigParser.ConfigParser()
+    config_file = get_default_conf()
     try:
-        config.read(get_default_conf())
+        config.read(config_file)
         config_list.append({'database': config.get('mysql', 'database'),
                             'user':     config.get('mysql', 'user'),
                             'password': config.get('mysql', 'password')})
     except:
-        print "Could not read hatohol conf."
+        print "Could not read %s." % config_file
 
     return config_list
 

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -126,6 +126,7 @@ def parse_default_conf():
                             'password': config.get('mysql', 'password')})
     except:
         print "Could not read %s." % config_file
+        sys.exit(-1)
 
     return config_list
 

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -112,7 +112,7 @@ def add_sql_directory(args, sql_file_list):
 
 
 def get_default_conf():
-    return os.path.dirname(__file__) + '/../etc/hatohol/hatohol.conf'
+    return '@expanded_sysconfdir@/hatohol/hatohol.conf'
 
 
 def parse_default_conf():

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -117,7 +117,7 @@ def get_default_conf():
 
 def parse_default_conf():
     config_file = get_default_conf()
-    if not os.path.isfile(config_file):
+    if not os.access(config_file, os.R_OK):
         print "Could not read %s." % config_file
         sys.exit(-1)
 

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -116,18 +116,17 @@ def get_default_conf():
 
 
 def parse_default_conf():
-    config_list = []
-    config = ConfigParser.ConfigParser()
     config_file = get_default_conf()
-    try:
-        config.read(config_file)
-        config_list.append({'database': config.get('mysql', 'database'),
-                            'user':     config.get('mysql', 'user'),
-                            'password': config.get('mysql', 'password')})
-    except:
+    if not os.path.isfile(config_file):
         print "Could not read %s." % config_file
         sys.exit(-1)
 
+    config_list = []
+    config = ConfigParser.ConfigParser()
+    config.read(config_file)
+    config_list.append({'database': config.get('mysql', 'database'),
+                        'user':     config.get('mysql', 'user'),
+                        'password': config.get('mysql', 'password')})
     return config_list
 
 

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -188,9 +188,13 @@ if __name__ == '__main__':
                         help='A database server.')
     parser.add_argument('--sql-dir', default=get_default_sql_dir(), type=str,
                         help='A directory that contains SQL files.')
-    parser.add_argument('--hatohol-db-user', default='hatohol', type=str,
+    parser.add_argument('--hatohol-db-user',
+                        default=get_default_conf_item('user'),
+                        type=str,
                         help='A user who is allowed to access the database.')
-    parser.add_argument('--hatohol-db-password', default='hatohol', type=str,
+    parser.add_argument('--hatohol-db-password',
+                        default=get_default_conf_item('password'),
+                        type=str,
                         help='A password that is used to access the database.')
     parser.add_argument('-f', '--force', action='store_true',
                         help='Delete existing data in a table before the initial data are inserted. '


### PR DESCRIPTION
A part of works related to #672.

* `hatohol-db-initiator` start to use `hatohol.conf` settings info.
* After this pull request is merged, `hatohol-db-initiator` requires command line arguments as follows:

Before:

```bash
$ hatohol-db-initiator db_name db_user db_password
```

After:

Before creating hatohol database:

```bash
$ hatohol-db-initiator --db_user root --db_password rootpass
```

After creating hatohol database:

```bash
$ hatohol-db-initiator
```

`db_name`, `db_user` and `db_password` are read from `hatohol.conf` by default.