### PR TITLE
[Issue 595] Add 'Polling interval' and 'Retry interval' to validation

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/djangojs.po
+++ b/client/conf/locale/ja/LC_MESSAGES/djangojs.po
@@ -639,6 +639,14 @@ msgstr "不正なサーバータイプです。"
 msgid "Not found hypervisor."
 msgstr "ハイパーバイザが見つかりません。"
 
+#: static/js/hatohol_def.js:256
+msgid "Invalid polling interval."
+msgstr "不正なポーリング間隔です。"
+
+#: static/js/hatohol_def.js:257
+msgid "Invalid retry interval."
+msgstr "不正なリトライ間隔です。"
+
 #: static/js/hatohol_host_selector.js:31
 msgid "Host selecion"
 msgstr "ホスト選択"

--- a/server/common/HatoholError.cc
+++ b/server/common/HatoholError.cc
@@ -72,6 +72,10 @@ void HatoholError::init(void)
 		   "Invalid incident tracker type.");
 	DEFINE_ERR(NO_INCIDENT_TRACKER_LOCATION,
 		   "NO incident tracker location.");
+	DEFINE_ERR(INVALID_POLLING_INTERVAL,
+		   "Invalid polling interval.");
+	DEFINE_ERR(INVALID_RETRY_INTERVAL,
+		   "Invalid retry interval.");
 
 	// DBTablesUser
 	DEFINE_ERR(EMPTY_USER_NAME,

--- a/server/common/HatoholError.h
+++ b/server/common/HatoholError.h
@@ -114,6 +114,8 @@ enum HatoholErrorCode
 
 	// 15.03
 	HTERR_DELETE_MYSELF,
+	HTERR_INVALID_POLLING_INTERVAL,	// DBTablesConfig
+	HTERR_INVALID_RETRY_INTERVAL,	// DBTablesConfig
 
 	// End of code
 	NUM_HATOHOL_ERROR_CODE

--- a/server/common/MonitoringServerInfo.cc
+++ b/server/common/MonitoringServerInfo.cc
@@ -24,6 +24,14 @@
 using namespace std;
 using namespace mlpl;
 
+// 1 <= Polling Interval [s] <= 60*60*24*366 (366days)
+const int MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC = 1;
+const int MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC = 60*60*24*366;
+
+// 1 <= Retry Interval [s] <= 60*60*24*31 (31days)
+const int MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC = 1;
+const int MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC = 60*60*24*31;
+
 string MonitoringServerInfo::getHostAddress(bool forURI) const
 {
 	if (ipAddress.empty())
@@ -54,8 +62,8 @@ void MonitoringServerInfo::initialize(MonitoringServerInfo &monSvInfo)
 	monSvInfo.id = 0;
 	monSvInfo.type = MONITORING_SYSTEM_UNKNOWN;
 	monSvInfo.port               = 0;
-	monSvInfo.pollingIntervalSec = 1;
-	monSvInfo.retryIntervalSec   = 1;
+	monSvInfo.pollingIntervalSec = MAX_POLLING_INTERVAL_SEC;
+	monSvInfo.retryIntervalSec   = MAX_RETRY_INTERVAL_SEC;
 	monSvInfo.hostName  = "localhost";
 	monSvInfo.ipAddress = "127.0.0.1";
 }

--- a/server/common/MonitoringServerInfo.cc
+++ b/server/common/MonitoringServerInfo.cc
@@ -54,8 +54,8 @@ void MonitoringServerInfo::initialize(MonitoringServerInfo &monSvInfo)
 	monSvInfo.id = 0;
 	monSvInfo.type = MONITORING_SYSTEM_UNKNOWN;
 	monSvInfo.port               = 0;
-	monSvInfo.pollingIntervalSec = 0;
-	monSvInfo.retryIntervalSec   = 0;
+	monSvInfo.pollingIntervalSec = 1;
+	monSvInfo.retryIntervalSec   = 1;
 	monSvInfo.hostName  = "localhost";
 	monSvInfo.ipAddress = "127.0.0.1";
 }

--- a/server/common/MonitoringServerInfo.h
+++ b/server/common/MonitoringServerInfo.h
@@ -47,6 +47,11 @@ struct MonitoringServerInfo {
 	int                  pollingIntervalSec;
 	int                  retryIntervalSec;
 
+	static const int MIN_POLLING_INTERVAL_SEC;
+	static const int MAX_POLLING_INTERVAL_SEC;
+	static const int MIN_RETRY_INTERVAL_SEC;
+	static const int MAX_RETRY_INTERVAL_SEC;
+
 	// The following variables are used in different purposes
 	// depending on the MonitoringSystemType.
 	//

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -38,14 +38,6 @@ static const char *TABLE_NAME_SERVERS = "servers";
 static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
 
-// 1 <= Polling Interval [s] <= 60*60*24*366 (366days)
-const int DBTablesConfig::MIN_POLLING_INTERVAL_SEC = 1;
-const int DBTablesConfig::MAX_POLLING_INTERVAL_SEC = 60*60*24*366;
-
-// 1 <= Retry Interval [s] <= 60*60*24*31 (31days)
-const int DBTablesConfig::MIN_RETRY_INTERVAL_SEC = 1;
-const int DBTablesConfig::MAX_RETRY_INTERVAL_SEC = 60*60*24*31;
-
 int DBTablesConfig::CONFIG_DB_VERSION = 13;
 
 const ServerIdSet EMPTY_SERVER_ID_SET;
@@ -961,13 +953,12 @@ HatoholError validServerInfo(const MonitoringServerInfo &serverInfo)
 	    !Utils::isValidIPAddress(serverInfo.ipAddress)) {
 		return HTERR_INVALID_IP_ADDRESS;
 	}
-	if (serverInfo.pollingIntervalSec < DBTablesConfig::MIN_POLLING_INTERVAL_SEC ||
-	    serverInfo.pollingIntervalSec > DBTablesConfig::MAX_POLLING_INTERVAL_SEC) {
+	if (serverInfo.pollingIntervalSec < MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC ||
+	    serverInfo.pollingIntervalSec > MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC) {
 		return HTERR_INVALID_POLLING_INTERVAL;
 	}
-
-	if (serverInfo.retryIntervalSec < DBTablesConfig::MIN_RETRY_INTERVAL_SEC ||
-	    serverInfo.retryIntervalSec > DBTablesConfig::MAX_RETRY_INTERVAL_SEC) {
+	if (serverInfo.retryIntervalSec < MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC ||
+	    serverInfo.retryIntervalSec > MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC) {
 		return HTERR_INVALID_RETRY_INTERVAL;
 	}
 	return HTERR_OK;

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -39,12 +39,12 @@ static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
 
 // 1 <= Polling Interval [s] <= 60*60*24*366 (366days)
-static const int MIN_POLLING_INTERVAL_SEC = 1;
-static const int MAX_POLLING_INTERVAL_SEC = 60*60*24*366;
+const int DBTablesConfig::MIN_POLLING_INTERVAL_SEC = 1;
+const int DBTablesConfig::MAX_POLLING_INTERVAL_SEC = 60*60*24*366;
 
 // 1 <= Retry Interval [s] <= 60*60*24*31 (31days)
-static const int MIN_RETRY_INTERVAL_SEC = 1;
-static const int MAX_RETRY_INTERVAL_SEC = 60*60*24*31;
+const int DBTablesConfig::MIN_RETRY_INTERVAL_SEC = 1;
+const int DBTablesConfig::MAX_RETRY_INTERVAL_SEC = 60*60*24*31;
 
 int DBTablesConfig::CONFIG_DB_VERSION = 13;
 
@@ -961,13 +961,13 @@ HatoholError validServerInfo(const MonitoringServerInfo &serverInfo)
 	    !Utils::isValidIPAddress(serverInfo.ipAddress)) {
 		return HTERR_INVALID_IP_ADDRESS;
 	}
-	if (serverInfo.pollingIntervalSec < MIN_POLLING_INTERVAL_SEC ||
-	    serverInfo.pollingIntervalSec > MAX_POLLING_INTERVAL_SEC) {
+	if (serverInfo.pollingIntervalSec < DBTablesConfig::MIN_POLLING_INTERVAL_SEC ||
+	    serverInfo.pollingIntervalSec > DBTablesConfig::MAX_POLLING_INTERVAL_SEC) {
 		return HTERR_INVALID_POLLING_INTERVAL;
 	}
 
-	if (serverInfo.retryIntervalSec < MIN_RETRY_INTERVAL_SEC ||
-	    serverInfo.retryIntervalSec > MAX_RETRY_INTERVAL_SEC) {
+	if (serverInfo.retryIntervalSec < DBTablesConfig::MIN_RETRY_INTERVAL_SEC ||
+	    serverInfo.retryIntervalSec > DBTablesConfig::MAX_RETRY_INTERVAL_SEC) {
 		return HTERR_INVALID_RETRY_INTERVAL;
 	}
 	return HTERR_OK;

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -38,6 +38,14 @@ static const char *TABLE_NAME_SERVERS = "servers";
 static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
 
+// 1 <= Polling Interval [s] <= 60*60*24*366 (366days)
+static const int MIN_POLLING_INTERVAL_SEC = 1;
+static const int MAX_POLLING_INTERVAL_SEC = 60*60*24*366;
+
+// 1 <= Retry Interval [s] <= 60*60*24*31 (31days)
+static const int MIN_RETRY_INTERVAL_SEC = 1;
+static const int MAX_RETRY_INTERVAL_SEC = 60*60*24*31;
+
 int DBTablesConfig::CONFIG_DB_VERSION = 13;
 
 const ServerIdSet EMPTY_SERVER_ID_SET;
@@ -952,6 +960,15 @@ HatoholError validServerInfo(const MonitoringServerInfo &serverInfo)
 	if (!serverInfo.ipAddress.empty() &&
 	    !Utils::isValidIPAddress(serverInfo.ipAddress)) {
 		return HTERR_INVALID_IP_ADDRESS;
+	}
+	if (serverInfo.pollingIntervalSec < MIN_POLLING_INTERVAL_SEC ||
+	    serverInfo.pollingIntervalSec > MAX_POLLING_INTERVAL_SEC) {
+		return HTERR_INVALID_POLLING_INTERVAL;
+	}
+
+	if (serverInfo.retryIntervalSec < MIN_RETRY_INTERVAL_SEC ||
+	    serverInfo.retryIntervalSec > MAX_RETRY_INTERVAL_SEC) {
+		return HTERR_INVALID_RETRY_INTERVAL;
 	}
 	return HTERR_OK;
 }

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -139,12 +139,6 @@ private:
 class DBTablesConfig : public DBTables {
 public:
 	static int CONFIG_DB_VERSION;
-
-	static const int MIN_POLLING_INTERVAL_SEC;
-	static const int MAX_POLLING_INTERVAL_SEC;
-	static const int MIN_RETRY_INTERVAL_SEC;
-	static const int MAX_RETRY_INTERVAL_SEC;
-
 	static void reset(void);
 	static bool isHatoholArmPlugin(const MonitoringSystemType &type);
 

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -139,6 +139,12 @@ private:
 class DBTablesConfig : public DBTables {
 public:
 	static int CONFIG_DB_VERSION;
+
+	static const int MIN_POLLING_INTERVAL_SEC;
+	static const int MAX_POLLING_INTERVAL_SEC;
+	static const int MIN_RETRY_INTERVAL_SEC;
+	static const int MAX_RETRY_INTERVAL_SEC;
+
 	static void reset(void);
 	static bool isHatoholArmPlugin(const MonitoringSystemType &type);
 

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -469,6 +469,42 @@ void test_addTargetServerWithEmptyIPAddressAndHostname(void)
 	assertAddTargetServer(testInfo, HTERR_NO_IP_ADDRESS_AND_HOST_NAME);
 }
 
+void test_addTargetServerWithValidPollingInterval(int sec)
+{
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	// MIN_POLLING_INTERVAL_SEC <= sec &&
+	// sec <= MAX_POLLING_INTERVAL_SEC
+	testInfo.pollingIntervalSec = sec;
+	assertAddTargetServer(testInfo, HTERR_OK);
+}
+
+void test_addTargetServerWithInvalidPollingInterval(int sec)
+{
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	// sec < MIN_POLLING_INTERVAL_SEC ||
+	// MAX_POLLING_INTERVAL_SEC < sec
+	testInfo.pollingIntervalSec = sec;
+	assertAddTargetServer(testInfo, HTERR_INVALID_POLLING_INTERVAL);
+}
+
+void test_addTargetServerWithValidRetryInterval(int sec)
+{
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	// MIN_RETRY_INTERVAL_SEC <= sec &&
+	// sec <= MAX_RETRY_INTERVAL_SEC
+	testInfo.retryIntervalSec = sec;
+	assertAddTargetServer(testInfo, HTERR_OK);
+}
+
+void test_addTargetServerWithInvalidRetryInterval(int sec)
+{
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	// sec < MIN_RETRY_INTERVAL_SEC ||
+	// MAX_RETRY_INTERVAL_SEC < sec
+	testInfo.retryIntervalSec = sec;
+	assertAddTargetServer(testInfo, HTERR_INVALID_RETRY_INTERVAL);
+}
+
 void _assertUpdateTargetServer(
   MonitoringServerInfo serverInfo, const HatoholErrorCode expectedErrorCode,
   OperationPrivilege privilege = ALL_PRIVILEGES)

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -471,21 +471,21 @@ void test_addTargetServerWithEmptyIPAddressAndHostname(void)
 
 void data_addTargetServerWithValidPollingInterval(void)
 {
-	int	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC;
+	int	n = MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC;
 	string	s = StringUtils::sprintf("MIN (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC;
+	n = MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC;
 	s = StringUtils::sprintf("MAX (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC - 1;
+	n = MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC - 1;
 	s = StringUtils::sprintf("MIN-1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
@@ -493,7 +493,7 @@ void data_addTargetServerWithValidPollingInterval(void)
 		       (int)HTERR_INVALID_POLLING_INTERVAL,
 		       NULL);
 
-	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC + 1;
+	n = MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC + 1;
 	s = StringUtils::sprintf("MAX+1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
@@ -511,28 +511,28 @@ void test_addTargetServerWithValidPollingInterval(gconstpointer data)
 
 void data_addTargetServerWithValidRetryInterval(void)
 {
-	int	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC;
+	int	n = MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC;
 	string	s = StringUtils::sprintf("MIN (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC;
+	n = MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC;
 	s = StringUtils::sprintf("MAX (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC - 1;
+	n = MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC - 1;
 	s = StringUtils::sprintf("MIN-1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_INVALID_RETRY_INTERVAL,
 		       NULL);
 
-	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC + 1;
+	n = MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC + 1;
 	s = StringUtils::sprintf("MAX+1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
@@ -611,28 +611,28 @@ void test_updateTargetServerWithNoHostNameAndIPAddress(void)
 
 void data_updateTargetServerWithValidPollingInterval(void)
 {
-	int	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC;
+	int	n = MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC;
 	string	s = StringUtils::sprintf("MIN (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC;
+	n = MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC;
 	s = StringUtils::sprintf("MAX (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC - 1;
+	n = MonitoringServerInfo::MIN_POLLING_INTERVAL_SEC - 1;
 	s = StringUtils::sprintf("MIN-1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_INVALID_POLLING_INTERVAL,
 		       NULL);
 
-	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC + 1;
+	n = MonitoringServerInfo::MAX_POLLING_INTERVAL_SEC + 1;
 	s = StringUtils::sprintf("MAX+1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
@@ -652,28 +652,28 @@ void test_updateTargetServerWithValidPollingInterval(gconstpointer data)
 
 void data_updateTargetServerWithValidRetryInterval(void)
 {
-	int	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC;
+	int	n = MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC;
 	string	s = StringUtils::sprintf("MIN (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC;
+	n = MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC;
 	s = StringUtils::sprintf("MAX (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_OK,
 		       NULL);
 
-	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC - 1;
+	n = MonitoringServerInfo::MIN_RETRY_INTERVAL_SEC - 1;
 	s = StringUtils::sprintf("MIN-1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,
 		       "expect", G_TYPE_INT, (int)HTERR_INVALID_RETRY_INTERVAL,
 		       NULL);
 
-	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC + 1;
+	n = MonitoringServerInfo::MAX_RETRY_INTERVAL_SEC + 1;
 	s = StringUtils::sprintf("MAX+1 (%d)", n);
 	gcut_add_datum(s.c_str(),
 		       "data", G_TYPE_INT, n,

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -469,40 +469,84 @@ void test_addTargetServerWithEmptyIPAddressAndHostname(void)
 	assertAddTargetServer(testInfo, HTERR_NO_IP_ADDRESS_AND_HOST_NAME);
 }
 
-void test_addTargetServerWithValidPollingInterval(int sec)
+void data_addTargetServerWithValidPollingInterval(void)
 {
-	MonitoringServerInfo testInfo = testServerInfo[0];
-	// MIN_POLLING_INTERVAL_SEC <= sec &&
-	// sec <= MAX_POLLING_INTERVAL_SEC
-	testInfo.pollingIntervalSec = sec;
-	assertAddTargetServer(testInfo, HTERR_OK);
+	int	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC;
+	string	s = StringUtils::sprintf("MIN (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC;
+	s = StringUtils::sprintf("MAX (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC - 1;
+	s = StringUtils::sprintf("MIN-1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT,
+		       (int)HTERR_INVALID_POLLING_INTERVAL,
+		       NULL);
+
+	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC + 1;
+	s = StringUtils::sprintf("MAX+1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_POLLING_INTERVAL,
+		       NULL);
 }
 
-void test_addTargetServerWithInvalidPollingInterval(int sec)
+void test_addTargetServerWithValidPollingInterval(gconstpointer data)
 {
 	MonitoringServerInfo testInfo = testServerInfo[0];
-	// sec < MIN_POLLING_INTERVAL_SEC ||
-	// MAX_POLLING_INTERVAL_SEC < sec
-	testInfo.pollingIntervalSec = sec;
-	assertAddTargetServer(testInfo, HTERR_INVALID_POLLING_INTERVAL);
+	testInfo.pollingIntervalSec = gcut_data_get_int(data, "data");
+	assertAddTargetServer(testInfo,
+		(HatoholErrorCode)gcut_data_get_int(data, "expect"));
 }
 
-void test_addTargetServerWithValidRetryInterval(int sec)
+void data_addTargetServerWithValidRetryInterval(void)
 {
-	MonitoringServerInfo testInfo = testServerInfo[0];
-	// MIN_RETRY_INTERVAL_SEC <= sec &&
-	// sec <= MAX_RETRY_INTERVAL_SEC
-	testInfo.retryIntervalSec = sec;
-	assertAddTargetServer(testInfo, HTERR_OK);
+	int	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC;
+	string	s = StringUtils::sprintf("MIN (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC;
+	s = StringUtils::sprintf("MAX (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC - 1;
+	s = StringUtils::sprintf("MIN-1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_RETRY_INTERVAL,
+		       NULL);
+
+	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC + 1;
+	s = StringUtils::sprintf("MAX+1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT,
+		       (int)HTERR_INVALID_RETRY_INTERVAL,
+		       NULL);
 }
 
-void test_addTargetServerWithInvalidRetryInterval(int sec)
+void test_addTargetServerWithValidRetryInterval(gconstpointer data)
 {
 	MonitoringServerInfo testInfo = testServerInfo[0];
-	// sec < MIN_RETRY_INTERVAL_SEC ||
-	// MAX_RETRY_INTERVAL_SEC < sec
-	testInfo.retryIntervalSec = sec;
-	assertAddTargetServer(testInfo, HTERR_INVALID_RETRY_INTERVAL);
+	testInfo.retryIntervalSec = gcut_data_get_int(data, "data");
+	assertAddTargetServer(testInfo,
+		(HatoholErrorCode)gcut_data_get_int(data, "expect"));
 }
 
 void _assertUpdateTargetServer(
@@ -563,6 +607,88 @@ void test_updateTargetServerWithNoHostNameAndIPAddress(void)
 	serverInfo.ipAddress = "";
 	assertUpdateTargetServer(
 	  serverInfo, HTERR_NO_IP_ADDRESS_AND_HOST_NAME);
+}
+
+void data_updateTargetServerWithValidPollingInterval(void)
+{
+	int	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC;
+	string	s = StringUtils::sprintf("MIN (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC;
+	s = StringUtils::sprintf("MAX (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MIN_POLLING_INTERVAL_SEC - 1;
+	s = StringUtils::sprintf("MIN-1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_POLLING_INTERVAL,
+		       NULL);
+
+	n = DBTablesConfig::MAX_POLLING_INTERVAL_SEC + 1;
+	s = StringUtils::sprintf("MAX+1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_POLLING_INTERVAL,
+		       NULL);
+}
+
+void test_updateTargetServerWithValidPollingInterval(gconstpointer data)
+{
+	int targetId = 2;
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	testInfo.id = targetId;
+	testInfo.pollingIntervalSec = gcut_data_get_int(data, "data");
+	assertUpdateTargetServer(testInfo,
+		(HatoholErrorCode)gcut_data_get_int(data, "expect"));
+}
+
+void data_updateTargetServerWithValidRetryInterval(void)
+{
+	int	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC;
+	string	s = StringUtils::sprintf("MIN (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC;
+	s = StringUtils::sprintf("MAX (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_OK,
+		       NULL);
+
+	n = DBTablesConfig::MIN_RETRY_INTERVAL_SEC - 1;
+	s = StringUtils::sprintf("MIN-1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_RETRY_INTERVAL,
+		       NULL);
+
+	n = DBTablesConfig::MAX_RETRY_INTERVAL_SEC + 1;
+	s = StringUtils::sprintf("MAX+1 (%d)", n);
+	gcut_add_datum(s.c_str(),
+		       "data", G_TYPE_INT, n,
+		       "expect", G_TYPE_INT, (int)HTERR_INVALID_RETRY_INTERVAL,
+		       NULL);
+}
+
+void test_updateTargetServerWithValidRetryInterval(gconstpointer data)
+{
+	int targetId = 2;
+	MonitoringServerInfo testInfo = testServerInfo[0];
+	testInfo.id = targetId;
+	testInfo.retryIntervalSec = gcut_data_get_int(data, "data");
+	assertUpdateTargetServer(testInfo,
+		(HatoholErrorCode)gcut_data_get_int(data, "expect"));
 }
 
 void data_deleteTargetServer(void)


### PR DESCRIPTION
監視サーバ設定でポーリング間隔とリトライ間隔のチェックを行うようにしました。
それぞれの有効範囲は以下の通りです。
ポーリング間隔（秒）: 1～31,622,400(366日)
リトライ間隔（秒）: 1～2,678,400(31日)
