### PR TITLE
HAPI-JSON supports event type

### DIFF
--- a/server/src/GateJSONEventMessage.h
+++ b/server/src/GateJSONEventMessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -43,6 +43,7 @@ public:
 	const char *getHostName();
 	const char *getContent();
 	TriggerSeverityType getSeverity();
+	EventType getType();
 
 private:
 	struct Impl;

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -119,7 +119,7 @@ private:
 		eventInfo.serverId = m_serverInfo.id;
 		eventInfo.id = message.getID();
 		eventInfo.time = message.getTimestamp();
-		eventInfo.type = EVENT_TYPE_BAD;
+		eventInfo.type = message.getType();
 		eventInfo.severity = message.getSeverity();
 		eventInfo.hostName = message.getHostName();
 		eventInfo.hostId = findOrCreateHostID(eventInfo.hostName);

--- a/server/test/testGateJSONEventMessage.cc
+++ b/server/test/testGateJSONEventMessage.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -245,6 +245,25 @@ namespace validate {
 			       "  }\n"
 			       "}\n");
 	}
+
+	void test_invalidBodyTypeValue(void)
+	{
+		assertValidate(gcut_take_new_list_string(
+				       "$.body.type must be valid type: "
+				       "<invalid>: "
+				       "available values: good, bad, unknown",
+				       NULL),
+			       "{\n"
+			       "  \"type\": \"event\"\n,"
+			       "  \"body\": {\n"
+			       "    \"id\":        1,\n"
+			       "    \"timestamp\": 1407824772.9396641,\n"
+			       "    \"hostName\":  \"www.example.com\",\n"
+			       "    \"content\":   \"Error!\",\n"
+			       "    \"type\":      \"invalid\"\n"
+			       "  }\n"
+			       "}\n");
+	}
 #undef assertValidate
 }
 
@@ -432,6 +451,71 @@ namespace severityGetter {
 		message = parse("emergency");
 		cppcut_assert_equal(TRIGGER_SEVERITY_EMERGENCY,
 				    message->getSeverity());
+	}
+}
+
+namespace typeGetter {
+	JsonParser *parser;
+	GateJSONEventMessage *message;
+
+	void cut_setup(void)
+	{
+		parser = json_parser_new();
+		message = NULL;
+	}
+
+	void cut_teardown(void)
+	{
+		delete message;
+		g_object_unref(parser);
+	}
+
+	GateJSONEventMessage *parse(const string &typeValue)
+	{
+		string json;
+
+		json += "{\n";
+		json += "  \"type\": \"event\",\n";
+		json += "  \"body\": {\n";
+		if (!typeValue.empty()) {
+			json += "\"type\": \"" + typeValue + "\",\n";
+		}
+		json += "    \"id\":        1,\n";
+		json += "    \"timestamp\": 1407824772.939664125,\n";
+		json += "    \"hostName\":  \"www.example.com\",\n";
+		json += "    \"content\":   \"Error!\"\n";
+		json += "  }\n";
+		json += "}\n";
+
+		return parseRaw(parser, json);
+	}
+
+	void test_default()
+	{
+		message = parse("");
+		cppcut_assert_equal(EVENT_TYPE_BAD,
+				    message->getType());
+	}
+
+	void test_good()
+	{
+		message = parse("good");
+		cppcut_assert_equal(EVENT_TYPE_GOOD,
+				    message->getType());
+	}
+
+	void test_bad()
+	{
+		message = parse("bad");
+		cppcut_assert_equal(EVENT_TYPE_BAD,
+				    message->getType());
+	}
+
+	void test_unknown()
+	{
+		message = parse("unknown");
+		cppcut_assert_equal(EVENT_TYPE_UNKNOWN,
+				    message->getType());
 	}
 }
 


### PR DESCRIPTION
It implements a request at #1009.

New HAPI JSON format:

```text
{
  "type": "event",
  "body": {
    "id": ${Event ID as an integer},
    "timestamp": ${Event occurred time as UNIX time in float or ISO 8601 format string},
    "hostName": "${Host name where event is occurred as string}",
    "content": "${Event detail as string}",
    "severity": "${Severity of the event (optional) (default: unknown)}",
    "type": "${Type of the event (optional) (default: bad)}"
  }
}
```

Optional `$.body.type` parameter is added. Available values are `good`, `bad` (default) and `unknown`. They are mapped to `EVENT_TYPE_GOOD`, `EVENT_TYPE_BAD` and `EVENT_TYPE_UNKNOWN`.