### PR TITLE
Db major version

### DIFF
--- a/server/src/DBHatohol.cc
+++ b/server/src/DBHatohol.cc
@@ -101,6 +101,7 @@ DBHatohol::DBHatohol(void)
 : DB(Impl::setupCtx),
   m_impl(new Impl(getDBAgent()))
 {
+	printf("DBHathol **********************\n");
 }
 
 DBHatohol::~DBHatohol()

--- a/server/src/DBHatohol.cc
+++ b/server/src/DBHatohol.cc
@@ -101,7 +101,6 @@ DBHatohol::DBHatohol(void)
 : DB(Impl::setupCtx),
   m_impl(new Impl(getDBAgent()))
 {
-	printf("DBHathol **********************\n");
 }
 
 DBHatohol::~DBHatohol()

--- a/server/src/DBHatohol.cc
+++ b/server/src/DBHatohol.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -31,9 +31,21 @@ static const char *DEFAULT_DB_NAME = "hatohol";
 static const char *DEFAULT_USER_NAME = "hatohol";
 static const char *DEFAULT_PASSWORD  = "hatohol";
 
+struct DBTablesMajorVersionChecker {
+	DBTablesMajorVersionChecker(DBAgent &dbAgent)
+	{
+		DBTables::checkMajorVersion<DBTablesConfig>(dbAgent);
+		DBTables::checkMajorVersion<DBTablesHost>(dbAgent);
+		DBTables::checkMajorVersion<DBTablesUser>(dbAgent);
+		DBTables::checkMajorVersion<DBTablesAction>(dbAgent);
+		DBTables::checkMajorVersion<DBTablesMonitoring>(dbAgent);
+	}
+};
+
 struct DBHatohol::Impl {
 	static SetupContext setupCtx;
 
+	DBTablesMajorVersionChecker verChecker;
 	DBTablesConfig  dbTablesConfig;
 	DBTablesHost    dbTablesHost;
 	DBTablesUser    dbTablesUser;
@@ -41,7 +53,8 @@ struct DBHatohol::Impl {
 	DBTablesMonitoring dbTablesMonitoring;
 
 	Impl(DBAgent &dbAgent)
-	: dbTablesConfig(dbAgent),
+	: verChecker(dbAgent),
+	  dbTablesConfig(dbAgent),
 	  dbTablesHost(dbAgent),
 	  dbTablesUser(dbAgent),
 	  dbTablesAction(dbAgent),

--- a/server/src/DBTables.cc
+++ b/server/src/DBTables.cc
@@ -276,6 +276,24 @@ DBAgent &DBTables::getDBAgent(void)
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------
+void DBTables::checkMajorVersionMain(
+  const SetupInfo &setupInfo, DBAgent &dbAgent)
+{
+	DBTables::Version versionInDB;
+	if (!Impl::getTablesVersion(versionInDB, setupInfo, dbAgent))
+		return;
+	DBTables::Version versionInProg;
+	versionInProg.setPackedVer(setupInfo.version);
+	if (versionInDB.majorVer != versionInProg.majorVer) {
+		THROW_HATOHOL_EXCEPTION(
+		  "Invalid Major version: DB/Prog: %s/%s "
+		  "(tablesId: %d)\n",
+		  versionInDB.toString().c_str(),
+		  versionInProg.toString().c_str(),
+		  setupInfo.tablesId);
+	}
+}
+
 void DBTables::begin(void)
 {
 	getDBAgent().begin();

--- a/server/src/DBTables.cc
+++ b/server/src/DBTables.cc
@@ -65,10 +65,10 @@ void DBTables::Version::setPackedVer(const int &packedVer)
 	minorVer = MINOR_MASK & packedVer;
 
 	shiftBits += MINOR_BITS;
-	majorVer = MAJOR_MASK & (packedVer >> shiftBits);
+	majorVer = (MAJOR_MASK & packedVer) >> shiftBits;
 
 	shiftBits += MAJOR_BITS;
-	vendorVer = VENDOR_MASK & (packedVer >> shiftBits);
+	vendorVer = (VENDOR_MASK & packedVer) >> shiftBits;
 }
 
 struct DBTables::Impl {

--- a/server/src/DBTables.cc
+++ b/server/src/DBTables.cc
@@ -71,6 +71,12 @@ void DBTables::Version::setPackedVer(const int &packedVer)
 	vendorVer = (VENDOR_MASK & packedVer) >> shiftBits;
 }
 
+string DBTables::Version::toString(void) const
+{
+	return StringUtils::sprintf("%02d.%02d [%02d]",
+	                            majorVer, minorVer, vendorVer);
+}
+
 struct DBTables::Impl {
 	DBAgent &dbAgent;
 

--- a/server/src/DBTables.cc
+++ b/server/src/DBTables.cc
@@ -24,6 +24,53 @@
 using namespace std;
 using namespace mlpl;
 
+const int DBTables::Version::VENDOR_BITS = 8;
+const int DBTables::Version::MAJOR_BITS  = 8;
+const int DBTables::Version::MINOR_BITS  = 12;
+
+static const int VENDOR_MASK = 0x0ff00000;
+static const int MAJOR_MASK  = 0x000ff000;
+static const int MINOR_MASK  = 0x00000fff;
+
+int DBTables::Version::getPackedVer(
+  const int &vendor, const int &major, const int &minor)
+{
+	int shiftBits = 0;
+	int ver = MINOR_MASK & minor;
+
+	shiftBits += MINOR_BITS;
+	ver += MAJOR_MASK & (major << shiftBits);
+
+	shiftBits += MAJOR_BITS;
+	ver += VENDOR_MASK & (vendor << shiftBits);
+
+	return ver;
+}
+
+DBTables::Version::Version(void)
+: vendorVer(0),
+  majorVer(0),
+  minorVer(0)
+{
+}
+
+int DBTables::Version::getPackedVer(void) const
+{
+	return getPackedVer(vendorVer, majorVer, minorVer);
+}
+
+void DBTables::Version::setPackedVer(const int &packedVer)
+{
+	int shiftBits = 0;
+	minorVer = MINOR_MASK & packedVer;
+
+	shiftBits += MINOR_BITS;
+	majorVer = MAJOR_MASK & (packedVer >> shiftBits);
+
+	shiftBits += MAJOR_BITS;
+	vendorVer = VENDOR_MASK & (packedVer >> shiftBits);
+}
+
 struct DBTables::Impl {
 	DBAgent &dbAgent;
 

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -48,7 +48,7 @@ public:
 	// TODO: remove DBClient::DBSetupFuncArg after this class is
 	// implemented.
 	typedef void (*CreateTableInitializer)(DBAgent &, void *data);
-	typedef bool (*DBUpdater)(DBAgent &, const int &oldVer, void *data);
+	typedef bool (*DBUpdater)(DBAgent &, const Version &oldVer, void *data);
 
 	struct TableSetupInfo {
 		const DBAgent::TableProfile *profile;

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -57,7 +57,7 @@ public:
 	};
 
 	struct SetupInfo {
-		const DBTablesId        tablesId; 
+		DBTablesId              tablesId;
 		int                     version;
 		size_t                  numTableInfo;
 		const TableSetupInfo   *tableInfoArray;

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -67,7 +67,11 @@ public:
 		mlpl::Mutex             lock;
 	};
 
-	static bool isMajorVerChanged(void);
+	template <class DBT>
+	static void checkMajorVersion(DBAgent &dbAgent)
+	{
+		checkMajorVersionMain(DBT::getConstSetupInfo(), dbAgent);
+	}
 
 	DBTables(DBAgent &dbAgent, SetupInfo &setupInfo);
 	virtual ~DBTables(void);
@@ -75,6 +79,9 @@ public:
 	DBAgent &getDBAgent(void);
 
 protected:
+	static void checkMajorVersionMain(
+	  const SetupInfo &setupInfo, DBAgent &dbAgent);
+
 	void begin(void);
 	void rollback(void);
 	void commit(void);

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -28,6 +28,22 @@
 
 class DBTables {
 public:
+	struct Version {
+		static const int VENDOR_BITS;
+		static const int MAJOR_BITS;
+		static const int MINOR_BITS;
+
+		int vendorVer;
+		int majorVer;
+		int minorVer;
+
+		static int getPackedVer(const int &vendor,
+		                        const int &major, const int &manior);
+		Version(void);
+		int getPackedVer(void) const;
+		void setPackedVer(const int &packedVer);
+	};
+
 	// TODO: remove DBClient::DBSetupFuncArg after this class is
 	// implemented.
 	typedef void (*CreateTableInitializer)(DBAgent &, void *data);
@@ -49,6 +65,8 @@ public:
 		bool                    initialized;
 		mlpl::Mutex             lock;
 	};
+
+	static bool isMajorVerChanged(void);
 
 	DBTables(DBAgent &dbAgent, SetupInfo &setupInfo);
 	virtual ~DBTables(void);

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -42,6 +42,7 @@ public:
 		Version(void);
 		int getPackedVer(void) const;
 		void setPackedVer(const int &packedVer);
+		std::string toString(void) const;
 	};
 
 	// TODO: remove DBClient::DBSetupFuncArg after this class is

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -386,6 +386,11 @@ void DBTablesAction::reset(void)
 	getSetupInfo().initialized = false;
 }
 
+const DBTables::SetupInfo &DBTablesAction::getConstSetupInfo(void)
+{
+	return getSetupInfo();
+}
+
 void DBTablesAction::stop(void)
 {
 	Utils::executeOnGLibEventLoop(stopIdleDeleteAction);

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -329,8 +329,10 @@ static bool addColumnOwnerUserId(DBAgent &dbAgent)
 	return true;
 }
 
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data)
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
+	const int oldVer = oldPackedVer.minorVer;
 	if (oldVer <= 8) {
 		if (!addColumnOwnerUserId(dbAgent))
 			return false;

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -276,6 +276,7 @@ public:
 
 	static void init(void);
 	static void reset(void);
+	static const SetupInfo &getConstSetupInfo(void);
 	static void stop(void);
 	static const char *getTableNameActions(void);
 	static const char *getTableNameActionLogs(void);

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -789,6 +789,11 @@ bool DBTablesConfig::isHatoholArmPlugin(const MonitoringSystemType &type)
 	return false;
 }
 
+const DBTables::SetupInfo &DBTablesConfig::getConstSetupInfo(void)
+{
+	return getSetupInfo();
+}
+
 DBTablesConfig::DBTablesConfig(DBAgent &dbAgent)
 : DBTables(dbAgent, getSetupInfo()),
   m_impl(new Impl())

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -527,8 +527,10 @@ struct DBTablesConfig::Impl
 	}
 };
 
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data)
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
+	const int &oldVer = oldPackedVer.minorVer;
 	if (oldVer <= 5) {
 		DBAgent::AddColumnsArg addColumnsArg(tableProfileSystem);
 		addColumnsArg.columnIndexes.push_back(

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -141,6 +141,7 @@ public:
 	static int CONFIG_DB_VERSION;
 	static void reset(void);
 	static bool isHatoholArmPlugin(const MonitoringSystemType &type);
+	static const SetupInfo &getConstSetupInfo(void);
 
 	DBTablesConfig(DBAgent &dbAgent);
 	virtual ~DBTablesConfig();

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -325,8 +325,10 @@ struct DBTablesHost::Impl
 	}
 };
 
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data)
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
+	const int &oldVer = oldPackedVer.minorVer;
 	if (oldVer == 1) {
 		// In table ver.1 (on 14.09), this table is not used.
 		// So we can drop it.

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -353,6 +353,11 @@ void DBTablesHost::reset(void)
 	getSetupInfo().initialized = false;
 }
 
+const DBTables::SetupInfo &DBTablesHost::getConstSetupInfo(void)
+{
+	return getSetupInfo();
+}
+
 DBTablesHost::DBTablesHost(DBAgent &dbAgent)
 : DBTables(dbAgent, getSetupInfo()),
   m_impl(new Impl())

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -61,6 +61,7 @@ public:
 	static const int TABLES_VERSION;
 
 	static void reset(void);
+	static const SetupInfo &getConstSetupInfo(void);
 
 	DBTablesHost(DBAgent &dbAgent);
 	virtual ~DBTablesHost();

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1581,6 +1581,11 @@ void DBTablesMonitoring::reset(void)
 	getSetupInfo().initialized = false;
 }
 
+const DBTables::SetupInfo &DBTablesMonitoring::getConstSetupInfo(void)
+{
+	return getSetupInfo();
+}
+
 DBTablesMonitoring::DBTablesMonitoring(DBAgent &dbAgent)
 : DBTables(dbAgent, getSetupInfo()),
   m_impl(new Impl())

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2778,7 +2778,8 @@ uint64_t DBTablesMonitoring::getLastUpdateTimeOfIncidents(
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data);
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data);
 
 DBTables::SetupInfo &DBTablesMonitoring::getSetupInfo(void)
 {
@@ -3009,8 +3010,10 @@ HatoholError DBTablesMonitoring::getHostgroupElementList
 	return HTERR_OK;
 }
 
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data)
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
+	const int &oldVer = oldPackedVer.minorVer;
 	if (oldVer == 4) {
 		const string oldTableName = "issues";
 		if (dbAgent.isTableExisting(oldTableName)) {

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -147,6 +147,7 @@ class DBTablesMonitoring : public DBTables {
 public:
 	static const int         MONITORING_DB_VERSION;
 	static void reset(void);
+	static const SetupInfo &getConstSetupInfo(void);
 
 	static const char *TABLE_NAME_TRIGGERS;
 	static const char *TABLE_NAME_EVENTS;

--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -470,6 +470,11 @@ void DBTablesUser::reset(void)
 	getSetupInfo().initialized = false;
 }
 
+const DBTables::SetupInfo &DBTablesUser::getConstSetupInfo(void)
+{
+	return getSetupInfo();
+}
+
 DBTablesUser::DBTablesUser(DBAgent &dbAgent)
 : DBTables(dbAgent, getSetupInfo()),
   m_impl(new Impl())

--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -224,10 +224,12 @@ static void updateAdminPrivilege(DBAgent &dbAgent,
 	dbAgent.update(arg);
 }
 
-static bool updateDB(DBAgent &dbAgent, const int &oldVer, void *data)
+static bool updateDB(
+  DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
 	static OperationPrivilegeType old_NUM_OPPRVLG;
 
+	const int &oldVer = oldPackedVer.minorVer;
 	if (oldVer <= 1) {
 		old_NUM_OPPRVLG = static_cast<OperationPrivilegeType>(10);
 		updateAdminPrivilege(dbAgent, old_NUM_OPPRVLG);

--- a/server/src/DBTablesUser.h
+++ b/server/src/DBTablesUser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -141,6 +141,7 @@ public:
 	static const size_t MAX_USER_ROLE_NAME_LENGTH;
 	static void init(void);
 	static void reset(void);
+	static const SetupInfo &getConstSetupInfo(void);
 
 	DBTablesUser(DBAgent &dbAgent);
 	virtual ~DBTablesUser();

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -148,22 +148,22 @@ void test_tableUpdater(void)
 {
 	struct Gizmo {
 		bool called;
-		int oldVer;
+		DBTables::Version oldVer;
 		bool updateSuccess;
 
 		Gizmo(void)
 		: called(false),
-		  oldVer(0),
 		  updateSuccess(true)
 		{
 		}
 
-		static bool updater(DBAgent &agent, const int &oldVer,
-		                    void *data)
+		static bool updater(
+		  DBAgent &agent, const DBTables::Version &oldPackedVer,
+		  void *data)
 		{
 			Gizmo *obj = static_cast<Gizmo *>(data);
 			obj->called = true;
-			obj->oldVer = oldVer;
+			obj->oldVer = oldPackedVer;
 			return obj->updateSuccess;
 		}
 	} gizmo;
@@ -197,7 +197,7 @@ void test_tableUpdater(void)
 	TestDBTables tables2(testDB.getDBAgent(), SETUP_INFO);
 	cppcut_assert_equal(true, SETUP_INFO.initialized);
 	cppcut_assert_equal(false, gizmo.called);
-	cppcut_assert_equal(0, gizmo.oldVer);
+	cppcut_assert_equal(0, gizmo.oldVer.getPackedVer());
 
 	// Create again with the upper version of DBTables.
 	SETUP_INFO.version++;
@@ -205,7 +205,7 @@ void test_tableUpdater(void)
 	TestDBTables tables3(testDB.getDBAgent(), SETUP_INFO);
 	cppcut_assert_equal(true, SETUP_INFO.initialized);
 	cppcut_assert_equal(true, gizmo.called);
-	cppcut_assert_equal(DB_VERSION, gizmo.oldVer);
+	cppcut_assert_equal(DB_VERSION, gizmo.oldVer.getPackedVer());
 
 	// A case that an update fails.
 	SETUP_INFO.version++;

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -231,6 +231,30 @@ void test_constructor(void)
 	cppcut_assert_equal(0, ver.minorVer);
 }
 
+void test_staticGetPackedVer(void)
+{
+	cppcut_assert_equal(
+	  0x01234567, DBTables::Version::getPackedVer(0x12, 0x34, 0x567));
+}
+
+void test_getPackedVer(void)
+{
+	DBTables::Version ver;
+	ver.vendorVer = 0xab;
+	ver.majorVer  = 0xcd;
+	ver.minorVer  = 0xef1;
+	cppcut_assert_equal(0x0abcdef1, ver.getPackedVer());
+}
+
+void test_setPackedVer(void)
+{
+	DBTables::Version ver;
+	ver.setPackedVer(0x0fedcba9);
+	cppcut_assert_equal(0xfe, ver.vendorVer);
+	cppcut_assert_equal(0xdc, ver.majorVer);
+	cppcut_assert_equal(0xba9, ver.minorVer);
+}
+
 } //namespace testDBTablesVersion
 
 

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -23,6 +23,8 @@
 #include "DBAgentTest.h"
 #include "Helpers.h"
 
+using namespace std;
+
 namespace testDBTables {
 
 const DBTablesId DB_TABLES_ID_TEST = 0x1234567;
@@ -253,6 +255,13 @@ void test_setPackedVer(void)
 	cppcut_assert_equal(0xfe, ver.vendorVer);
 	cppcut_assert_equal(0xdc, ver.majorVer);
 	cppcut_assert_equal(0xba9, ver.minorVer);
+}
+
+void test_toString(void)
+{
+	DBTables::Version ver;
+	ver.setPackedVer(0x02468ace);
+	cppcut_assert_equal(string("104.2766 [36]"), ver.toString());
 }
 
 } //namespace testDBTablesVersion

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -132,38 +132,15 @@ void test_createTable(void)
 
 void test_createIndex(void)
 {
-	// TODO: Use TestDBKit
-	// We make a copy to update TableProfile::indexDefArray
-	DBAgent::TableProfile tableProfile = tableProfileTest;
+	TestDBKit dbKit;
+	DBTables::SetupInfo &setupInfo = dbKit.setupInfo;
+	cppcut_assert_equal(false, setupInfo.initialized);
 
-	static const int columnIndexes[] = {
-	  IDX_TEST_TABLE_AGE, IDX_TEST_TABLE_NAME, DBAgent::IndexDef::END};
-	static const DBAgent::IndexDef indexDef[] = {
-		{"index_age_name", columnIndexes, false},
-		{NULL}
-	};
-	tableProfile.indexDefArray = indexDef;
-
-	static const DBTables::TableSetupInfo TABLE_INFO[] = {
-	{
-		&tableProfile,
-	},
-	};
-
-	static DBTables::SetupInfo SETUP_INFO = {
-		DB_TABLES_ID_TEST,
-		DB_VERSION,
-		ARRAY_SIZE(TABLE_INFO),
-		TABLE_INFO,
-	};
-	cppcut_assert_equal(false, SETUP_INFO.initialized);
-
-	TestDB::setup();
-	TestDB testDB;
-	TestDBTables tables(testDB.getDBAgent(), SETUP_INFO);
-	assertExistIndex(testDB.getDBAgent(), tableProfile.name,
+	TestDB &testDB = dbKit.db;
+	TestDBTables tables(testDB.getDBAgent(), setupInfo);
+	assertExistIndex(testDB.getDBAgent(), dbKit.tableProfile.name,
 	                 "index_age_name", 2);
-	cppcut_assert_equal(true, SETUP_INFO.initialized);
+	cppcut_assert_equal(true, setupInfo.initialized);
 }
 
 void test_checkMajorVersion(void)

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -221,4 +221,16 @@ void test_tableUpdater(void)
 
 } //namespace testDBTables
 
+namespace testDBTablesVersion {
+
+void test_constructor(void)
+{
+	DBTables::Version ver;
+	cppcut_assert_equal(0, ver.vendorVer);
+	cppcut_assert_equal(0, ver.majorVer);
+	cppcut_assert_equal(0, ver.minorVer);
+}
+
+} //namespace testDBTablesVersion
+
 

--- a/server/test/testDBTables.cc
+++ b/server/test/testDBTables.cc
@@ -39,11 +39,6 @@ static const DBAgent::IndexDef g_indexDef[] = {
 	{NULL}
 };
 
-static const DBTables::SetupInfo DEFAULT_SETUP_INFO = {
-	DB_TABLES_ID_TEST,
-	DB_VERSION,
-};
-
 static DBTables::SetupInfo *g_setupInfo = NULL;
 
 struct TestDBKit {
@@ -61,17 +56,26 @@ struct TestDBKit {
 	DBTables::SetupInfo      setupInfo;
 
 	TestDBKit(void)
-	: tableProfile(tableProfileTest),
-	  setupInfo(DEFAULT_SETUP_INFO)
+	: tableProfile(tableProfileTest)
 	{
 		tableProfile.indexDefArray = g_indexDef;
 
 		memset(&tableInfo[0], 0, sizeof(DBTables::TableSetupInfo));
 		tableInfo[0].profile = &tableProfile;
 
-		setupInfo.numTableInfo = ARRAY_SIZE(tableInfo);
-		setupInfo.tableInfoArray = tableInfo;
+		initSetupInfo();
 		g_setupInfo = &setupInfo;
+	}
+
+	void initSetupInfo(void)
+	{
+		setupInfo.tablesId       = DB_TABLES_ID_TEST;
+		setupInfo.version        = DB_VERSION;
+		setupInfo.numTableInfo   = ARRAY_SIZE(tableInfo);
+		setupInfo.tableInfoArray = tableInfo;
+		setupInfo.updater        = NULL;
+		setupInfo.updaterData    = NULL;
+		setupInfo.initialized    = false;
 	}
 };
 


### PR DESCRIPTION
These patches add a mechanism to check DBTables's major versions.
And if one of the major versions changes, it throws an exception. As a
result, hatohol server stop at the boot.