### PR TITLE
Dbterm codec ver up

### DIFF
--- a/server/src/DBTermCStringProvider.cc
+++ b/server/src/DBTermCStringProvider.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "DBTermCStringProvider.h"
+using namespace std;
+
+struct DBTermCStringProvider::Impl {
+	const DBTermCodec &codec;
+	list<string>       strList;
+
+	// methods
+	Impl(const DBTermCodec &_codec)
+	: codec(_codec)
+	{
+	}
+
+	template<typename T>
+	const char *encAndStore(const T &val)
+	{
+		strList.push_back(codec.enc(val));
+		return strList.back().c_str();
+	}
+};
+
+DBTermCStringProvider::DBTermCStringProvider(const DBTermCodec &codec)
+: m_impl(new Impl(codec))
+{
+}
+
+DBTermCStringProvider::~DBTermCStringProvider()
+{
+}
+
+const char * DBTermCStringProvider::operator()(const int &val)
+{
+	return m_impl->encAndStore<int>(val);
+}
+
+const char * DBTermCStringProvider::operator()(const uint64_t &val)
+{
+	return m_impl->encAndStore<uint64_t>(val);
+}
+
+const char * DBTermCStringProvider::operator()(const string &val)
+{
+	return m_impl->encAndStore<string>(val);
+}
+
+const list<string> &DBTermCStringProvider::getStoredStringList(void) const
+{
+	return m_impl->strList;
+}

--- a/server/src/DBTermCStringProvider.h
+++ b/server/src/DBTermCStringProvider.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DBTermCStringProvider_h
+#define DBTermCStringProvider_h
+
+#include <string>
+#include <list>
+#include <stdint.h>
+#include <memory>
+#include "DBTermCodec.h"
+
+class DBTermCStringProvider {
+public:
+	DBTermCStringProvider(const DBTermCodec &codec);
+	~DBTermCStringProvider();
+
+	const char * operator()(const int &val);
+	const char * operator()(const uint64_t &val);
+	const char * operator()(const std::string &val);
+
+	const std::list<std::string> &getStoredStringList(void) const;
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
+#endif // DBTermCStringProvider_h
+

--- a/server/src/DBTermCodec.cc
+++ b/server/src/DBTermCodec.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -31,4 +31,30 @@ string DBTermCodec::enc(const int &val) const
 string DBTermCodec::enc(const uint64_t &val) const
 {
 	return StringUtils::sprintf("%" PRIu64, val);
+}
+
+string DBTermCodec::enc(const string &val) const
+{
+	// Find quotations that might cause an SQL injection
+	vector<const char *> quotPosArray;
+
+	for (const char *ch = val.c_str(); *ch; ch++) {
+		if (*ch == '\'')
+			quotPosArray.push_back(ch);
+	}
+
+	// Make a string in which quotations are escaped
+	string str = "'";
+	str.reserve(val.size() + quotPosArray.size());
+	const char *head = val.c_str();
+	for (size_t i = 0; i < quotPosArray.size(); i++) {
+		const char *tail = quotPosArray[i];
+		const size_t len = tail - head + 1;
+		str.append(head, len);
+		str += '\'';
+		head = tail + 1;
+	}
+	str.append(head);
+	str += '\'';
+	return str;
 }

--- a/server/src/DBTermCodec.cc
+++ b/server/src/DBTermCodec.cc
@@ -44,8 +44,10 @@ string DBTermCodec::enc(const string &val) const
 	}
 
 	// Make a string in which quotations are escaped
-	string str = "'";
-	str.reserve(val.size() + quotPosArray.size());
+	const size_t sizeQuationsAtBothEnds = 2;
+	string str;
+	str.reserve(val.size() + quotPosArray.size() + sizeQuationsAtBothEnds);
+	str += '\'';
 	const char *head = val.c_str();
 	for (size_t i = 0; i < quotPosArray.size(); i++) {
 		const char *tail = quotPosArray[i];

--- a/server/src/DBTermCodec.h
+++ b/server/src/DBTermCodec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -27,6 +27,7 @@ class DBTermCodec {
 public:
 	virtual std::string enc(const int &val) const;
 	virtual std::string enc(const uint64_t &val) const;
+	virtual std::string enc(const std::string &val) const;
 };
 
 #endif // DBTermCodec_h

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -34,6 +34,7 @@ libhatohol_la_SOURCES = \
 	DBTablesHost.cc DBTablesHost.h \
 	DBClientJoinBuilder.cc DBClientJoinBuilder.h \
 	DBTermCodec.h DBTermCodec.cc \
+	DBTermCStringProvier.h DBTermCStringProvider.cc \
 	DataStore.cc DataStore.h \
 	DataStoreFactory.cc DataStoreFactory.h \
 	DataStoreManager.cc DataStoreManager.h \

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -61,6 +61,7 @@ testHatohol_la_SOURCES = \
 	testDBTablesHost.cc \
 	testDBClientJoinBuilder.cc \
 	testDBTermCodec.cc \
+	testDBTermCStringProvider.cc \
 	testOperationPrivilege.cc \
 	testSQLUtils.cc \
 	testMySQLWorkerZabbix.cc \

--- a/server/test/testDBTermCStringProvider.cc
+++ b/server/test/testDBTermCStringProvider.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <cppcutter.h>
+#include <gcutter.h>
+#include "DBTermCStringProvider.h"
+
+using namespace std;
+
+namespace testDBTermCStringProvider {
+
+void test_int(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const int val = 1234567;
+	cppcut_assert_equal("1234567", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const int val2 = -10;
+	cppcut_assert_equal("-10", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+void test_uint64(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const uint64_t val = 0x123456789abcdef0;
+	cppcut_assert_equal("1311768467463790320", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const uint64_t val2 = 0xfedcba9876543210;
+	cppcut_assert_equal("18364758544493064720", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+void test_string(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const string val = "Lovin' You";
+	cppcut_assert_equal("'Lovin'' You'", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const string val2 = "I'm a cat.";
+	cppcut_assert_equal("'I''m a cat.'", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+} // testDBTermCStringProvider

--- a/server/test/testDBTermCodec.cc
+++ b/server/test/testDBTermCodec.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -76,6 +76,42 @@ void test_getUint64(gconstpointer data)
 {
 	DBTermCodec dbTermCodec;
 	string actual = dbTermCodec.enc(gcut_data_get_uint64(data, "val"));
+	string expect = gcut_data_get_string(data, "expect");
+	cppcut_assert_equal(expect, actual);
+}
+
+void data_getString(void)
+{
+	gcut_add_datum("Empty",
+	               "val", G_TYPE_STRING, "",
+	               "expect", G_TYPE_STRING, "''",
+	               NULL);
+	gcut_add_datum("No quotations",
+	               "val", G_TYPE_STRING,    "ABC foo",
+	               "expect", G_TYPE_STRING, "'ABC foo'",
+	               NULL);
+	gcut_add_datum("At the first",
+	               "val", G_TYPE_STRING,    "'ABC foo",
+	               "expect", G_TYPE_STRING, "'''ABC foo'",
+	               NULL);
+	gcut_add_datum("At the last",
+	               "val", G_TYPE_STRING,    "ABC foo'",
+	               "expect", G_TYPE_STRING, "'ABC foo'''",
+	               NULL);
+	gcut_add_datum("At the middle",
+	               "val", G_TYPE_STRING,    "AB'C fo'o",
+	               "expect", G_TYPE_STRING, "'AB''C fo''o'",
+	               NULL);
+	gcut_add_datum("Consecutive",
+	               "val", G_TYPE_STRING,    "AB'''C fo''o",
+	               "expect", G_TYPE_STRING, "'AB''''''C fo''''o'",
+	               NULL);
+}
+
+void test_getString(gconstpointer data)
+{
+	DBTermCodec dbTermCodec;
+	string actual = dbTermCodec.enc(gcut_data_get_string(data, "val"));
 	string expect = gcut_data_get_string(data, "expect");
 	cppcut_assert_equal(expect, actual);
 }


### PR DESCRIPTION
These patches adds the following feature.
- Create a string value for LHS of an SQL statement, in which quotations are escaped to prevent an SQL injection.
- Add a utilities class that safely provide C-style string for printf() families. This helps code to create an SQL statement simple.