### PR TITLE
Dbterm codec ver up 2

### DIFF
--- a/server/src/DBTermCodec.cc
+++ b/server/src/DBTermCodec.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -31,4 +31,32 @@ string DBTermCodec::enc(const int &val) const
 string DBTermCodec::enc(const uint64_t &val) const
 {
 	return StringUtils::sprintf("%" PRIu64, val);
+}
+
+string DBTermCodec::enc(const string &val) const
+{
+	// Find quotations that might cause an SQL injection
+	vector<const char *> quotPosArray;
+
+	for (const char *ch = val.c_str(); *ch; ch++) {
+		if (*ch == '\'')
+			quotPosArray.push_back(ch);
+	}
+
+	// Make a string in which quotations are escaped
+	const size_t sizeQuationsAtBothEnds = 2;
+	string str;
+	str.reserve(val.size() + quotPosArray.size() + sizeQuationsAtBothEnds);
+	str += '\'';
+	const char *head = val.c_str();
+	for (size_t i = 0; i < quotPosArray.size(); i++) {
+		const char *tail = quotPosArray[i];
+		const size_t len = tail - head + 1;
+		str.append(head, len);
+		str += '\'';
+		head = tail + 1;
+	}
+	str.append(head);
+	str += '\'';
+	return str;
 }

--- a/server/src/DBTermCodec.h
+++ b/server/src/DBTermCodec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -27,6 +27,7 @@ class DBTermCodec {
 public:
 	virtual std::string enc(const int &val) const;
 	virtual std::string enc(const uint64_t &val) const;
+	virtual std::string enc(const std::string &val) const;
 };
 
 #endif // DBTermCodec_h

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -141,15 +141,15 @@ bool getParamWithErrorReply(
   FaceRest::ResourceHandler *job, const char *paramName, const char *scanFmt,
   T &dest, bool *exist)
 {
-	char *value = (char *)g_hash_table_lookup(job->m_query, paramName);
+	HatoholError err = getParam<T>(job->m_query, paramName, scanFmt, dest);
 	if (exist)
-		*exist = value;
-	if (!value)
+		*exist = (err != HTERR_NOT_FOUND_PARAMETER);
+	if (err == HTERR_NOT_FOUND_PARAMETER)
 		return true;
 
-	if (sscanf(value, scanFmt, &dest) != 1) {
-		REPLY_ERROR(job, HTERR_INVALID_PARAMETER,
-		            "%s: %s", paramName, value);
+	if (err != HTERR_OK) {
+		REPLY_ERROR(job, err.getCode(),
+		            "%s", err.getOptionMessage().c_str());
 		return false;
 	}
 	return true;

--- a/server/test/testDBTermCodec.cc
+++ b/server/test/testDBTermCodec.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -76,6 +76,42 @@ void test_getUint64(gconstpointer data)
 {
 	DBTermCodec dbTermCodec;
 	string actual = dbTermCodec.enc(gcut_data_get_uint64(data, "val"));
+	string expect = gcut_data_get_string(data, "expect");
+	cppcut_assert_equal(expect, actual);
+}
+
+void data_getString(void)
+{
+	gcut_add_datum("Empty",
+	               "val", G_TYPE_STRING, "",
+	               "expect", G_TYPE_STRING, "''",
+	               NULL);
+	gcut_add_datum("No quotations",
+	               "val", G_TYPE_STRING,    "ABC foo",
+	               "expect", G_TYPE_STRING, "'ABC foo'",
+	               NULL);
+	gcut_add_datum("At the first",
+	               "val", G_TYPE_STRING,    "'ABC foo",
+	               "expect", G_TYPE_STRING, "'''ABC foo'",
+	               NULL);
+	gcut_add_datum("At the last",
+	               "val", G_TYPE_STRING,    "ABC foo'",
+	               "expect", G_TYPE_STRING, "'ABC foo'''",
+	               NULL);
+	gcut_add_datum("At the middle",
+	               "val", G_TYPE_STRING,    "AB'C fo'o",
+	               "expect", G_TYPE_STRING, "'AB''C fo''o'",
+	               NULL);
+	gcut_add_datum("Consecutive",
+	               "val", G_TYPE_STRING,    "AB'''C fo''o",
+	               "expect", G_TYPE_STRING, "'AB''''''C fo''''o'",
+	               NULL);
+}
+
+void test_getString(gconstpointer data)
+{
+	DBTermCodec dbTermCodec;
+	string actual = dbTermCodec.enc(gcut_data_get_string(data, "val"));
 	string expect = gcut_data_get_string(data, "expect");
 	cppcut_assert_equal(expect, actual);
 }


### PR DESCRIPTION
Different from the previous one #1024, this pull request only contains a fix of DBTermCodec.
The way to provide C-style string will be proposed in another pull request.