### PR TITLE
[DBTermCStringProvider] Add a new class.

### DIFF
--- a/server/src/DBTermCStringProvider.cc
+++ b/server/src/DBTermCStringProvider.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "DBTermCStringProvider.h"
+using namespace std;
+
+struct DBTermCStringProvider::Impl {
+	const DBTermCodec &codec;
+	list<string>       strList;
+
+	// methods
+	Impl(const DBTermCodec &_codec)
+	: codec(_codec)
+	{
+	}
+
+	template<typename T>
+	const char *encAndStore(const T &val)
+	{
+		strList.push_back(codec.enc(val));
+		return strList.back().c_str();
+	}
+};
+
+DBTermCStringProvider::DBTermCStringProvider(const DBTermCodec &codec)
+: m_impl(new Impl(codec))
+{
+}
+
+DBTermCStringProvider::~DBTermCStringProvider()
+{
+}
+
+const char * DBTermCStringProvider::operator()(const int &val)
+{
+	return m_impl->encAndStore<int>(val);
+}
+
+const char * DBTermCStringProvider::operator()(const uint64_t &val)
+{
+	return m_impl->encAndStore<uint64_t>(val);
+}
+
+const char * DBTermCStringProvider::operator()(const string &val)
+{
+	return m_impl->encAndStore<string>(val);
+}
+
+const list<string> &DBTermCStringProvider::getStoredStringList(void) const
+{
+	return m_impl->strList;
+}

--- a/server/src/DBTermCStringProvider.h
+++ b/server/src/DBTermCStringProvider.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DBTermCStringProvider_h
+#define DBTermCStringProvider_h
+
+#include <string>
+#include <list>
+#include <stdint.h>
+#include <memory>
+#include "DBTermCodec.h"
+
+class DBTermCStringProvider {
+public:
+	DBTermCStringProvider(const DBTermCodec &codec);
+	~DBTermCStringProvider();
+
+	const char * operator()(const int &val);
+	const char * operator()(const uint64_t &val);
+	const char * operator()(const std::string &val);
+
+	const std::list<std::string> &getStoredStringList(void) const;
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
+#endif // DBTermCStringProvider_h
+

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -34,6 +34,7 @@ libhatohol_la_SOURCES = \
 	DBTablesHost.cc DBTablesHost.h \
 	DBClientJoinBuilder.cc DBClientJoinBuilder.h \
 	DBTermCodec.h DBTermCodec.cc \
+	DBTermCStringProvier.h DBTermCStringProvider.cc \
 	DataStore.cc DataStore.h \
 	DataStoreFactory.cc DataStoreFactory.h \
 	DataStoreManager.cc DataStoreManager.h \

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -61,6 +61,7 @@ testHatohol_la_SOURCES = \
 	testDBTablesHost.cc \
 	testDBClientJoinBuilder.cc \
 	testDBTermCodec.cc \
+	testDBTermCStringProvider.cc \
 	testOperationPrivilege.cc \
 	testSQLUtils.cc \
 	testMySQLWorkerZabbix.cc \

--- a/server/test/testDBTermCStringProvider.cc
+++ b/server/test/testDBTermCStringProvider.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <cppcutter.h>
+#include <gcutter.h>
+#include "DBTermCStringProvider.h"
+
+using namespace std;
+
+namespace testDBTermCStringProvider {
+
+void test_int(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const int val = 1234567;
+	cppcut_assert_equal("1234567", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const int val2 = -10;
+	cppcut_assert_equal("-10", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+void test_uint64(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const uint64_t val = 0x123456789abcdef0;
+	cppcut_assert_equal("1311768467463790320", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const uint64_t val2 = 0xfedcba9876543210;
+	cppcut_assert_equal("18364758544493064720", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+void test_string(void)
+{
+	DBTermCodec codec;
+	DBTermCStringProvider csProvider(codec);
+	const string val = "Lovin' You";
+	cppcut_assert_equal("'Lovin'' You'", csProvider(val));
+	cppcut_assert_equal((size_t)1, csProvider.getStoredStringList().size());
+
+	const string val2 = "I'm a cat.";
+	cppcut_assert_equal("'I''m a cat.'", csProvider(val2));
+	cppcut_assert_equal((size_t)2, csProvider.getStoredStringList().size());
+}
+
+} // testDBTermCStringProvider


### PR DESCRIPTION
This class provides a method that returns a C-style string (const char *).
This is covenient to be used in conjunction with printf families
to make an SQL statement.

 For example,

[Previously]
StringUtils::sprintf("column=%s", dbTermCodec.enc(value).c_str());

[New]
StringUtils::sprintf("column=%s", dbTermProvider(value));