### PR TITLE
Use dbterm codec

### DIFF
--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -357,9 +357,9 @@ string HostResourceQueryOption::makeConditionServer(
 string HostResourceQueryOption::makeConditionServer(
   const ServerIdType &serverId, const HostgroupIdSet &hostgroupIdSet,
   const string &serverIdColumnName, const string &hostgroupIdColumnName,
-  const HostgroupIdType &hostgroupId)
+  const HostgroupIdType &hostgroupId) const
 {
-	const DBTermCodec *dbTermCodec = Impl::dbTermCodec;
+	const DBTermCodec *dbTermCodec = getDBTermCodec();
 	string condition;
 	condition = StringUtils::sprintf(
 	  "%s=%s", serverIdColumnName.c_str(),
@@ -390,7 +390,7 @@ string HostResourceQueryOption::makeCondition(
   const string &hostIdColumnName,
   ServerIdType targetServerId,
   HostgroupIdType targetHostgroupId,
-  HostIdType targetHostId)
+  HostIdType targetHostId) const
 {
 	// TODO: consider if we use isHostgroupEnumerationInCondition()
 	string condition;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -127,7 +127,7 @@ const char *HostResourceQueryOption::getPrimaryTableName(void) const
 
 string HostResourceQueryOption::getCondition(void) const
 {
-	const DBTermCodec *dbTermCodec = Impl::dbTermCodec;
+	const DBTermCodec *dbTermCodec = getDBTermCodec();
 	string condition;
 	if (getFilterForDataOfDefunctServers()) {
 		addCondition(
@@ -331,7 +331,7 @@ string HostResourceQueryOption::makeConditionHostgroup(
 }
 
 string HostResourceQueryOption::makeConditionServer(
-  const ServerIdSet &serverIdSet, const std::string &serverIdColumnName)
+  const ServerIdSet &serverIdSet, const std::string &serverIdColumnName) const
 {
 	if (serverIdSet.empty())
 		return DBHatohol::getAlwaysFalseCondition();
@@ -341,7 +341,7 @@ string HostResourceQueryOption::makeConditionServer(
 
 	ServerIdSetConstIterator serverId = serverIdSet.begin();
 	bool first = true;
-	const DBTermCodec *dbTermCodec = Impl::dbTermCodec;
+	const DBTermCodec *dbTermCodec = getDBTermCodec();
 	for (; serverId != serverIdSet.end(); ++serverId) {
 		if (first)
 			first = false;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -81,13 +81,6 @@ struct HostResourceQueryOption::Impl {
 	}
 };
 
-// TODO: Use a more smart way
-//static DBTermCodec _dbTermCodec;
-//const DBTermCodec *HostResourceQueryOption::Impl::dbTermCodec =
-//  &_dbTermCodec;
-// Use this if the backend DB is SQLite3:
-//  DBAgentSQLite3::getDBTermCodecStatic();
-
 // ---------------------------------------------------------------------------
 // Public methods
 // ---------------------------------------------------------------------------

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -20,12 +20,10 @@
 #include "Params.h"
 #include "HostResourceQueryOption.h"
 #include "DBTablesMonitoring.h"
-#include "DBAgentSQLite3.h" // TODO: Shouldn't use explicitly
 #include "DBHatohol.h"
+
 using namespace std;
 using namespace mlpl;
-
-// *** TODO: use OptionTermGenrator to make SQL's clauses ****
 
 // ---------------------------------------------------------------------------
 // Synapse
@@ -58,7 +56,6 @@ HostResourceQueryOption::Synapse::Synapse(
 // Impl
 // ---------------------------------------------------------------------------
 struct HostResourceQueryOption::Impl {
-	static const DBTermCodec *dbTermCodec;
 	const Synapse  &synapse;
 	ServerIdType    targetServerId;
 	HostIdType      targetHostId;
@@ -85,9 +82,9 @@ struct HostResourceQueryOption::Impl {
 };
 
 // TODO: Use a more smart way
-static DBTermCodec _dbTermCodec;
-const DBTermCodec *HostResourceQueryOption::Impl::dbTermCodec =
-  &_dbTermCodec;
+//static DBTermCodec _dbTermCodec;
+//const DBTermCodec *HostResourceQueryOption::Impl::dbTermCodec =
+//  &_dbTermCodec;
 // Use this if the backend DB is SQLite3:
 //  DBAgentSQLite3::getDBTermCodecStatic();
 
@@ -286,11 +283,6 @@ const bool &HostResourceQueryOption::getFilterForDataOfDefunctServers(void) cons
 	return m_impl->filterDataOfDefunctServers;
 }
 
-const DBTermCodec *HostResourceQueryOption::getDBTermCodec(void) const
-{
-	return m_impl->dbTermCodec;
-}
-
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------
@@ -428,7 +420,7 @@ string HostResourceQueryOption::makeCondition(
 	}
 
 	if (targetHostId != ALL_HOSTS) {
-		const DBTermCodec *dbTermCodec = Impl::dbTermCodec;
+		const DBTermCodec *dbTermCodec = getDBTermCodec();
 		return StringUtils::sprintf(
 		  "((%s) AND %s=%s)",
 		  condition.c_str(), hostIdColumnName.c_str(),

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -151,9 +151,9 @@ protected:
 	  ServerIdType targetServerId = ALL_SERVERS,
 	  HostgroupIdType targetHostgroup = ALL_HOST_GROUPS,
 	  HostIdType targetHostId = ALL_HOSTS);
-	static std::string makeConditionServer(
+	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,
-	  const std::string &serverIdColumnName);
+	  const std::string &serverIdColumnName) const;
 	static std::string makeConditionServer(
 	  const ServerIdType &serverId,
 	  const HostgroupIdSet &hostgroupIdSet,

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -134,8 +134,6 @@ public:
 	 */
 	const bool &getFilterForDataOfDefunctServers(void) const;
 
-	virtual const DBTermCodec *getDBTermCodec(void) const override;
-
 	std::string getJoinClause(void) const;
 
 protected:

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -143,23 +143,23 @@ protected:
 	std::string getHostgroupIdColumnName(void) const;
 	std::string getHostIdColumnName(void) const;
 
-	static std::string makeCondition(
+	std::string makeCondition(
 	  const ServerHostGrpSetMap &srvHostGrpSetMap,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
 	  const std::string &hostIdColumnName,
 	  ServerIdType targetServerId = ALL_SERVERS,
 	  HostgroupIdType targetHostgroup = ALL_HOST_GROUPS,
-	  HostIdType targetHostId = ALL_HOSTS);
+	  HostIdType targetHostId = ALL_HOSTS) const;
 	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,
 	  const std::string &serverIdColumnName) const;
-	static std::string makeConditionServer(
+	std::string makeConditionServer(
 	  const ServerIdType &serverId,
 	  const HostgroupIdSet &hostgroupIdSet,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
-	  const HostgroupIdType &hostgroupId = ALL_HOST_GROUPS);
+	  const HostgroupIdType &hostgroupId = ALL_HOST_GROUPS) const;
 	static std::string makeConditionHostgroup(
 	  const HostgroupIdSet &hostgroupIdSet,
 	  const std::string &hostgroupIdColumnName);

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -47,7 +47,7 @@ testHatohol_la_SOURCES = \
 	testHatoholThreadBase.cc \
 	testHatoholDBUtils.cc \
 	testHostInfoCache.cc \
-	TestHostResourceQueryOption.h \
+	TestHostResourceQueryOption.cc TestHostResourceQueryOption.h \
 	testHostResourceQueryOption.cc \
 	testHostResourceQueryOptionSubClasses.cc \
 	testDBAgent.cc \

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -21,15 +21,18 @@
 #define TestHostResourceQueryOption_h
 
 #include <string>
+#include <HostResourceQueryOption.h>
 
 class TestHostResourceQueryOption : public HostResourceQueryOption {
 public:
+	TestHostResourceQueryOption(const UserIdType &userId = INVALID_USER_ID);
+
 	std::string callGetServerIdColumnName(void) const
 	{
 		return getServerIdColumnName();
 	}
 
-	static std::string callMakeConditionServer(
+	std::string callMakeConditionServer(
 	  const ServerIdSet &serverIdSet, const std::string &serverIdColumnName)
 	{
 		return makeConditionServer(serverIdSet, serverIdColumnName);

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -27,34 +27,20 @@ class TestHostResourceQueryOption : public HostResourceQueryOption {
 public:
 	TestHostResourceQueryOption(const UserIdType &userId = INVALID_USER_ID);
 
-	std::string callGetServerIdColumnName(void) const
-	{
-		return getServerIdColumnName();
-	}
+	std::string callGetServerIdColumnName(void) const;
 
 	std::string callMakeConditionServer(
-	  const ServerIdSet &serverIdSet, const std::string &serverIdColumnName)
-	{
-		return makeConditionServer(serverIdSet, serverIdColumnName);
-	}
+	  const ServerIdSet &serverIdSet,
+	  const std::string &serverIdColumnName) const;
 
-	static std::string callMakeCondition(
+	std::string callMakeCondition(
 	  const ServerHostGrpSetMap &srvHostGrpSetMap,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
 	  const std::string &hostIdColumnName,
-	  uint32_t targetServerId = ALL_SERVERS,
-	  uint64_t targetHostgroupId = ALL_HOST_GROUPS,
-	  uint64_t targetHostId = ALL_HOSTS)
-	{
-		return makeCondition(srvHostGrpSetMap,
-		                     serverIdColumnName,
-		                     hostgroupIdColumnName,
-		                     hostIdColumnName,
-		                     targetServerId,
-		                     targetHostgroupId,
-		                     targetHostId);
-	}
+	  const ServerIdType &targetServerId = ALL_SERVERS,
+	  const HostgroupIdType &targetHostgroupId = ALL_HOST_GROUPS,
+	  const HostIdType &targetHostId = ALL_HOSTS) const;
 };
 
 #endif // TestHostResourceQueryOption_h

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -455,8 +455,9 @@ void test_makeConditionServer(void)
 	for (size_t i = 0; i < numServerIds; i++)
 		svIdSet.insert(serverIds[i]);
 
-	string actual = TestHostResourceQueryOption::callMakeConditionServer(
-	                  svIdSet, serverIdColumnName);
+	TestHostResourceQueryOption option;
+	string actual =
+	  option.callMakeConditionServer(svIdSet, serverIdColumnName);
 
 	// check
 	string expectHead = serverIdColumnName;
@@ -484,8 +485,8 @@ void test_makeConditionServer(void)
 void test_makeConditionServerWithEmptyIdSet(void)
 {
 	ServerIdSet svIdSet;
-	string actual = TestHostResourceQueryOption::callMakeConditionServer(
-	                  svIdSet, "meet");
+	TestHostResourceQueryOption option;
+	string actual = option.callMakeConditionServer(svIdSet, "meet");
 	cppcut_assert_equal(DBHatohol::getAlwaysFalseCondition(), actual);
 }
 

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -167,18 +167,14 @@ static const string hostIdColumnName = "host_id";
 // FIXME: Change order of parameter.
 static void _assertMakeCondition(
   const ServerHostGrpSetMap &srvHostGrpSetMap, const string &expect,
-  const ServerIdType targetServerId = ALL_SERVERS,
-  const HostIdType targetHostId = ALL_HOSTS,
-  const HostgroupIdType targetHostgroupId = ALL_HOST_GROUPS)
+  const ServerIdType &targetServerId = ALL_SERVERS,
+  const HostIdType &targetHostId = ALL_HOSTS,
+  const HostgroupIdType &targetHostgroupId = ALL_HOST_GROUPS)
 {
-	string cond = TestHostResourceQueryOption::callMakeCondition(
-			srvHostGrpSetMap,
-			serverIdColumnName,
-			hostgroupIdColumnName,
-			hostIdColumnName,
-			targetServerId,
-			targetHostgroupId,
-			targetHostId);
+	TestHostResourceQueryOption option;
+	string cond = option.callMakeCondition(
+	  srvHostGrpSetMap, serverIdColumnName, hostgroupIdColumnName,
+	  hostIdColumnName, targetServerId, targetHostgroupId, targetHostId);
 	cppcut_assert_equal(expect, cond);
 }
 #define assertMakeCondition(M, ...) \
@@ -228,7 +224,8 @@ static string makeExpectedConditionForUser(
 	  nameBuilder(TEST_PRIMARY_TABLE_NAME, hostIdColumnName);
 	// TODO: consider that the following way (using a part of test
 	//       target method) is good.
-	const string exp = TestHostResourceQueryOption::callMakeCondition(
+	TestHostResourceQueryOption option;
+	const string exp = option.callMakeCondition(
 	  srvHostGrpSetMap, svIdColName, hgrpIdColName, hostIdColName);
 	return exp;
 }


### PR DESCRIPTION
Generating a part of an SQL string depends on the DB being used.
So direct reference of the DBTermCodec instance defind statically
is not undesirable.
