### PR TITLE
[Experimental][client][server] set arbitrary http status code

### DIFF
--- a/client/hatohol/forwardview.py
+++ b/client/hatohol/forwardview.py
@@ -54,9 +54,12 @@ def jsonforward(request, path):
         encoded_query = urllib.urlencode(utf8_dict(request.GET))
         url += '?' + encoded_query
         req = urllib2.Request(url, headers=hdrs)
-    content = urllib2.urlopen(req)
+    try:
+        content = urllib2.urlopen(req)
 
-    response = HttpResponse(content, content_type='application/json')
+        response = HttpResponse(content, content_type='application/json')
+    except urllib2.URLError, e:
+        response = HttpResponse('{}', content_type='application/json', status=e.code)
 
     response['Pragma'] = 'no-cache'
     response['Cache-Control'] = 'no-cache'

--- a/client/hatohol/forwardview.py
+++ b/client/hatohol/forwardview.py
@@ -59,7 +59,7 @@ def jsonforward(request, path):
 
         response = HttpResponse(content, content_type='application/json')
     except urllib2.URLError, e:
-        response = HttpResponse('{}', content_type='application/json', status=e.code)
+        response = HttpResponse(e.read(), content_type='application/json', status=e.code)
 
     response['Pragma'] = 'no-cache'
     response['Cache-Control'] = 'no-cache'

--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -130,7 +130,9 @@ HatoholConnector.prototype.start = function(connectParams) {
       success: function(data) {
         parseLoginResult(data);
       },
-      error: connectError,
+      error:  function(data) {
+        parseLoginResult(data);
+      },
     });
   }
 

--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -130,8 +130,8 @@ HatoholConnector.prototype.start = function(connectParams) {
       success: function(data) {
         parseLoginResult(data);
       },
-      error:  function(data) {
-        parseLoginResult(data);
+      error: function(XMLHttpRequest, textStatus, errorThrown) {
+        formatLoginResultWithError(XMLHttpRequest, textStatus, errorThrown);
       },
     });
   }
@@ -147,6 +147,16 @@ HatoholConnector.prototype.start = function(connectParams) {
     HatoholSessionManager.set(sessionId);
     self.dialog.closeDialog();
     request();
+  }
+
+  function formatLoginResultWithError(XMLHttpRequest, textStatus, errorThrown) {
+    var status = XMLHttpRequest.status;
+    if (!(status >= 200 && status < 300)) {
+      var msg =
+        gettext("Failed to login. ") + gettext("Invalid user name or password.");
+      hatoholErrorMsgBox(msg);
+    return;
+    }
   }
 
   function request() {

--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -131,7 +131,7 @@ HatoholConnector.prototype.start = function(connectParams) {
         parseLoginResult(data);
       },
       error: function(XMLHttpRequest, textStatus, errorThrown) {
-        formatLoginResultWithError(XMLHttpRequest, textStatus, errorThrown);
+        parseLoginResultWithError(XMLHttpRequest, textStatus, errorThrown);
       },
     });
   }
@@ -149,13 +149,24 @@ HatoholConnector.prototype.start = function(connectParams) {
     request();
   }
 
-  function formatLoginResultWithError(XMLHttpRequest, textStatus, errorThrown) {
-    var status = XMLHttpRequest.status;
-    if (!(status >= 200 && status < 300)) {
-      var msg =
-        gettext("Failed to login. ") + gettext("Invalid user name or password.");
-      hatoholErrorMsgBox(msg);
-    return;
+  function parseLoginResultWithError(XMLHttpRequest, textStatus, errorThrown) {
+    var response = XMLHttpRequest.responseText;
+    var data = $.parseJSON(response);
+    if (data) {
+      var parser = new HatoholLoginReplyParser(data);
+      if (parser.getStatus() != REPLY_STATUS.OK) {
+        var msg = gettext("Failed to login. ") + parser.getMessage();
+        hatoholErrorMsgBox(msg);
+        return;
+      }
+    } else {
+      var status = XMLHttpRequest.status;
+      if (!(status >= 200 && status < 300)) {
+        var errorMsg = "Error: " + textStatus + ": " + errorThrown;
+        var unknownErrorMsg = gettext("Failed to login. ") + errorMsg;
+        hatoholErrorMsgBox(unknownErrorMsg);
+        return;
+      }
     }
   }
 

--- a/client/static/js/hatohol_reply_parser.js
+++ b/client/static/js/hatohol_reply_parser.js
@@ -40,7 +40,7 @@ var HatoholReplyParser = function(reply) {
     this.stat = REPLY_STATUS.NULL_OR_UNDEFINED;
     return;
   }
-  
+
   // API version
   if (!("apiVersion" in reply)) {
     this.stat = REPLY_STATUS.NOT_FOUND_API_VERSION;
@@ -153,4 +153,3 @@ HatoholLoginReplyParser.prototype.constructor = HatoholLoginReplyParser;
 HatoholLoginReplyParser.prototype.getSessionId = function() {
   return this.sessionId;
 };
-

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -557,7 +557,7 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	if (userId == INVALID_USER_ID) {
 		MLPL_INFO("Failed to authenticate: Client: %s, User: %s.\n",
 			  soup_client_context_get_host(job->m_client), user);
-		job->replyError(HTERR_AUTH_FAILED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
 		return;
 	}
 

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -828,10 +828,11 @@ uint64_t FaceRest::ResourceHandler::getResourceId(int nest)
 }
 
 void FaceRest::ResourceHandler::replyError(const HatoholErrorCode &errorCode,
-					   const string &optionMessage)
+					   const string &optionMessage,
+					   const guint &statusCode)
 {
 	HatoholError hatoholError(errorCode, optionMessage);
-	replyError(hatoholError);
+	replyError(hatoholError, statusCode);
 }
 
 static string wrapForJSONP(const string &jsonBody,
@@ -844,7 +845,8 @@ static string wrapForJSONP(const string &jsonBody,
 	return jsonp;
 }
 
-void FaceRest::ResourceHandler::replyError(const HatoholError &hatoholError)
+void FaceRest::ResourceHandler::replyError(const HatoholError &hatoholError,
+					   const guint &statusCode)
 {
 	string error
 	  = StringUtils::sprintf("%d", hatoholError.getCode());
@@ -872,7 +874,7 @@ void FaceRest::ResourceHandler::replyError(const HatoholError &hatoholError)
 	                                      MIME_JSON, NULL);
 	soup_message_body_append(m_message->response_body, SOUP_MEMORY_COPY,
 	                         response.c_str(), response.size());
-	soup_message_set_status(m_message, SOUP_STATUS_OK);
+	soup_message_set_status(m_message, statusCode);
 
 	m_replyIsPrepared = true;
 }
@@ -883,7 +885,8 @@ void FaceRest::ResourceHandler::replyHttpStatus(const guint &statusCode)
 	m_replyIsPrepared = true;
 }
 
-void FaceRest::ResourceHandler::replyJSONData(JSONBuilder &agent)
+void FaceRest::ResourceHandler::replyJSONData(JSONBuilder &agent,
+					      const guint &statusCode)
 {
 	string response = agent.generate();
 	if (!m_jsonpCallbackName.empty())
@@ -892,7 +895,7 @@ void FaceRest::ResourceHandler::replyJSONData(JSONBuilder &agent)
 	                                      m_mimeType, NULL);
 	soup_message_body_append(m_message->response_body, SOUP_MEMORY_COPY,
 	                         response.c_str(), response.size());
-	soup_message_set_status(m_message, SOUP_STATUS_OK);
+	soup_message_set_status(m_message, statusCode);
 
 	m_replyIsPrepared = true;
 }

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -541,14 +541,14 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	gchar *user = (gchar *)g_hash_table_lookup(job->m_query, "user");
 	if (!user) {
 		MLPL_INFO("Not found: user\n");
-		job->replyError(HTERR_AUTH_FAILED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
 		return;
 	}
 	gchar *password
 	  = (gchar *)g_hash_table_lookup(job->m_query, "password");
 	if (!password) {
 		MLPL_INFO("Not found: password\n");
-		job->replyError(HTERR_AUTH_FAILED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
 		return;
 	}
 

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -60,11 +60,13 @@ public:
 	std::string getResourceIdString(int nest = 0);
 	uint64_t    getResourceId(int nest = 0);
 
-	void replyError(const HatoholError &hatoholError);
+	void replyError(const HatoholError &hatoholError,
+			const guint &statusCode = SOUP_STATUS_OK);
 	void replyError(const HatoholErrorCode &errorCode,
-			const std::string &optionMessage = "");
+			const std::string &optionMessage = "",
+			const guint &statusCode = SOUP_STATUS_OK);
 	void replyHttpStatus(const guint &statusCode);
-	void replyJSONData(JSONBuilder &agent);
+	void replyJSONData(JSONBuilder &agent, const guint &statusCode = SOUP_STATUS_OK);
 	void addServersMap(JSONBuilder &agent,
 			   TriggerBriefMaps *triggerMaps = NULL,
 			   bool lookupTriggerBrief = false);

--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -227,6 +227,12 @@ JSONParser *getResponseAsJSONParser(RequestArg &arg)
 	return parser;
 }
 
+void getServerResponseAsFailure(RequestArg &arg)
+{
+	getServerResponse(arg);
+	cut_assert_false(SOUP_STATUS_IS_SUCCESSFUL(arg.httpStatusCode));
+}
+
 void _assertValueInParser(JSONParser *parser,
 			  const string &member, const bool expected)
 {

--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -227,10 +227,38 @@ JSONParser *getResponseAsJSONParser(RequestArg &arg)
 	return parser;
 }
 
-void getServerResponseAsFailure(RequestArg &arg)
+JSONParser *getServerResponseAsJSONParserWithFailure(RequestArg &arg)
 {
 	getServerResponse(arg);
 	cut_assert_false(SOUP_STATUS_IS_SUCCESSFUL(arg.httpStatusCode));
+
+	// if JSONP, check the callback name
+	if (!arg.callbackName.empty()) {
+		size_t lenCallbackName = arg.callbackName.size();
+		size_t minimumLen = lenCallbackName + 2; // +2 for ''(' and ')'
+		cppcut_assert_equal(true, arg.response.size() > minimumLen,
+		  cut_message("length: %zd, minmumLen: %zd\n%s",
+		              arg.response.size(), minimumLen,
+		              arg.response.c_str()));
+
+		cut_assert_equal_substring(
+		  arg.callbackName.c_str(), arg.response.c_str(),
+		  lenCallbackName);
+		cppcut_assert_equal(')', arg.response[arg.response.size()-1]);
+		arg.response = string(arg.response, lenCallbackName+1,
+		                      arg.response.size() - minimumLen);
+	}
+
+	// check the JSON body
+	if (isVerboseMode())
+		cut_notify("<<response>>\n%s\n", arg.response.c_str());
+	JSONParser *parser = new JSONParser(arg.response);
+	if (parser->hasError()) {
+		string parserErrMsg = parser->getErrorMessage();
+		delete parser;
+		cut_fail("%s\n%s", parserErrMsg.c_str(), arg.response.c_str());
+	}
+	return parser;
 }
 
 void _assertValueInParser(JSONParser *parser,

--- a/server/test/FaceRestTestUtils.h
+++ b/server/test/FaceRestTestUtils.h
@@ -61,6 +61,7 @@ std::string makeSessionIdHeader(const std::string &sessionId);
 
 void getServerResponse(RequestArg &arg);
 JSONParser *getResponseAsJSONParser(RequestArg &arg);
+void getServerResponseAsFailure(RequestArg &arg);
 
 void _assertValueInParser(JSONParser *parser,
 			  const std::string &member,

--- a/server/test/FaceRestTestUtils.h
+++ b/server/test/FaceRestTestUtils.h
@@ -61,7 +61,7 @@ std::string makeSessionIdHeader(const std::string &sessionId);
 
 void getServerResponse(RequestArg &arg);
 JSONParser *getResponseAsJSONParser(RequestArg &arg);
-void getServerResponseAsFailure(RequestArg &arg);
+JSONParser *getServerResponseAsJSONParserWithFailure(RequestArg &arg);
 
 void _assertValueInParser(JSONParser *parser,
 			  const std::string &member,

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -52,6 +52,25 @@ void _assertLogin(
 }
 #define assertLogin(U, P, ...) cut_trace(_assertLogin(U, P, ##__VA_ARGS__))
 
+void _assertLoginFailure(
+  const string &user, const string &password,
+  const HatoholErrorCode &expectCode = HTERR_OK,
+  string *sessionId = NULL)
+{
+	startFaceRest();
+
+	StringMap query;
+	if (!user.empty())
+		query["user"] = user;
+	if (!password.empty())
+		query["password"] = password;
+	RequestArg arg("/login", "cbname");
+	arg.parameters = query;
+	getServerResponseAsFailure(arg);
+}
+#define assertLoginFailure(U, P, ...) \
+  cut_trace(_assertLoginFailure(U, P, ##__VA_ARGS__))
+
 namespace testFaceRestUser {
 
 void cut_setup(void)

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -66,7 +66,12 @@ void _assertLoginFailure(
 		query["password"] = password;
 	RequestArg arg("/login", "cbname");
 	arg.parameters = query;
-	getServerResponseAsFailure(arg);
+	unique_ptr<JSONParser> parserPtr(getServerResponseAsJSONParserWithFailure(arg));
+	assertErrorCode(parserPtr.get(), expectCode);
+	if (sessionId) {
+		cppcut_assert_equal(true, parserPtr.get()->read("sessionId",
+		                                                *sessionId));
+	}
 }
 #define assertLoginFailure(U, P, ...) \
   cut_trace(_assertLoginFailure(U, P, ##__VA_ARGS__))
@@ -196,7 +201,7 @@ void test_login(void)
 void test_loginFailure(void)
 {
 	assertLoginFailure(testUserInfo[1].name, testUserInfo[0].password,
-	                   HTERR_AUTH_FAILED);
+			   HTERR_AUTH_FAILED);
 }
 
 void test_loginNoUserName(void)

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -195,8 +195,8 @@ void test_login(void)
 
 void test_loginFailure(void)
 {
-	assertLogin(testUserInfo[1].name, testUserInfo[0].password,
-	            HTERR_AUTH_FAILED);
+	assertLoginFailure(testUserInfo[1].name, testUserInfo[0].password,
+	                   HTERR_AUTH_FAILED);
 }
 
 void test_loginNoUserName(void)

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -201,17 +201,17 @@ void test_loginFailure(void)
 
 void test_loginNoUserName(void)
 {
-	assertLogin("", testUserInfo[0].password, HTERR_AUTH_FAILED);
+	assertLoginFailure("", testUserInfo[0].password, HTERR_AUTH_FAILED);
 }
 
 void test_loginNoPassword(void)
 {
-	assertLogin(testUserInfo[0].name, "", HTERR_AUTH_FAILED);
+	assertLoginFailure(testUserInfo[0].name, "", HTERR_AUTH_FAILED);
 }
 
 void test_loginNoUserNameAndPassword(void)
 {
-	assertLogin("", "", HTERR_AUTH_FAILED);
+	assertLoginFailure("", "", HTERR_AUTH_FAILED);
 }
 
 void test_logout(void)


### PR DESCRIPTION
This pull request contains *experimental feature* for improving testability, as follows:

* `FaceRest::ResourceHandler::replyJSONData` and `FaceRest::ResourceHandler::replyError` can accept arbitrary HTTP status code such as **401 (Unauthorized)**, **403 (Forbidden)**, ... and so on.
  * Default HTTP status is **200 (OK)**.
* Hatohol client can handle non-200 response from Hatohol server.
* Try to send response which is non-200 status code in user authentication.

Here is failing user authentication senario:

 When failing to user authenticate, Hatohol server send **401 (Unauthorized)** response to Hatohol client(WebUI). Hatohol client just passes through Hatohol server response. Nevertheless non-200 status response from Hatohol server.
 Finally, user's browser receives **401 (Unauthorized)** response from Hatohol client(WebUI).