### PR TITLE
[Issue 189][FaceRest][ConfigManager] Add a setting of the number of FaceRest worker threads.

### DIFF
--- a/server/data/hatohol.conf
+++ b/server/data/hatohol.conf
@@ -2,3 +2,6 @@
 database=hatohol
 user=hatohol
 password=hatohol
+
+[FaceRest]
+workers=4

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -35,7 +35,7 @@ enum {
 	CONF_MGR_ERROR_INVALID_PORT,
 	CONF_MGR_ERROR_INVALID_LOG_LEVEL,
 	CONF_MGR_ERROR_INTERNAL,
-	CONF_MGR_ERROR_INVALID_WORKERS,
+	CONF_MGR_ERROR_INVALID_NUM_WORKERS,
 };
 
 const char *ConfigManager::HATOHOL_DB_DIR_ENV_VAR_NAME = "HATOHOL_DB_DIR";
@@ -79,7 +79,7 @@ static void showVersion(void)
 	       VERSION, __DATE__, __TIME__);
 }
 
-static gboolean parseFaceRestWorkers(
+static gboolean parseFaceRestNumWorkers(
   const gchar *option_name, const gchar *value,
   gpointer data, GError **error)
 {
@@ -93,14 +93,14 @@ static gboolean parseFaceRestWorkers(
 		return FALSE;
 	}
 
-	int n = atoi(value);
-	if (n <= 0) {
-		g_set_error(error, quark, CONF_MGR_ERROR_INVALID_WORKERS,
-		            "value: %s, %d.", value, n);
+	int numWorkers = atoi(value);
+	if (numWorkers <= 0) {
+		g_set_error(error, quark, CONF_MGR_ERROR_INVALID_NUM_WORKERS,
+		            "value: %s, %d.", value, numWorkers);
 		return FALSE;
 	}
 
-	obj->faceRestWorkers = n;
+	obj->faceRestNumWorkers = numWorkers;
 
 	return TRUE;
 }
@@ -122,7 +122,7 @@ CommandLineOptions::CommandLineOptions(void)
   disableCopyOnDemand(FALSE),
   loadOldEvents(FALSE),
   faceRestPort(-1),
-  faceRestWorkers(0)
+  faceRestNumWorkers(0)
 {
 }
 
@@ -145,7 +145,7 @@ struct ConfigManager::Impl {
 	string                user;
 	string                pidFilePath;
 	bool                  loadOldEvents;
-	int                   faceRestWorkers;
+	int                   faceRestNumWorkers;
 
 	// methods
 	Impl(void)
@@ -156,7 +156,7 @@ struct ConfigManager::Impl {
 	  copyOnDemand(UNKNOWN),
 	  faceRestPort(0),
 	  pidFilePath(DEFAULT_PID_FILE_PATH),
-	  faceRestWorkers(0)
+	  faceRestNumWorkers(0)
 	{
 	}
 
@@ -243,8 +243,8 @@ struct ConfigManager::Impl {
 			user = cmdLineOpts.user;
 		if (cmdLineOpts.loadOldEvents)
 			loadOldEvents = cmdLineOpts.loadOldEvents;
-		if (cmdLineOpts.faceRestWorkers > 0)
-			faceRestWorkers = cmdLineOpts.faceRestWorkers;
+		if (cmdLineOpts.faceRestNumWorkers > 0)
+			faceRestNumWorkers = cmdLineOpts.faceRestNumWorkers;
 	}
 
 private:
@@ -277,7 +277,7 @@ private:
 		gint num = g_key_file_get_integer(keyFile, group,
 						  "workers", NULL);
 		if (num > 0) {
-			getInstance()->setFaceRestWorkers(num);
+			getInstance()->setFaceRestNumWorkers(num);
 			MLPL_INFO("ConfigFile: [FaceRest] workers=%d\n", num);
 		} else {
 			MLPL_WARN("ConfigFile: [FaceRest] workers=%d: Invalid value. Ignored.\n", num);
@@ -342,7 +342,7 @@ bool ConfigManager::parseCommandLine(gint *argc, gchar ***argv,
 		 &cmdLineOpts->loadOldEvents,
 		 "Load old events when adding new monitoring server.", NULL},
 		{"face-rest-workers",
-		 'T', 0, G_OPTION_ARG_CALLBACK, (gpointer)parseFaceRestWorkers,
+		 'T', 0, G_OPTION_ARG_CALLBACK, (gpointer)parseFaceRestNumWorkers,
 		 "Number of FaceRest worker threads", NULL},
 		{ NULL }
 	};
@@ -509,14 +509,14 @@ bool ConfigManager::getLoadOldEvents(void) const
 	return m_impl->loadOldEvents;
 }
 
-int ConfigManager::getFaceRestWorkers(void) const
+int ConfigManager::getFaceRestNumWorkers(void) const
 {
-	return m_impl->faceRestWorkers;
+	return m_impl->faceRestNumWorkers;
 }
 
-void ConfigManager::setFaceRestWorkers(const int &num)
+void ConfigManager::setFaceRestNumWorkers(const int &num)
 {
-	m_impl->faceRestWorkers = num;
+	m_impl->faceRestNumWorkers = num;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -37,7 +37,7 @@ struct CommandLineOptions {
 	gboolean  disableCopyOnDemand;
 	gboolean  loadOldEvents;
 	gint      faceRestPort;
-	gint      faceRestWorkers;
+	gint      faceRestNumWorkers;
 
 	CommandLineOptions(void);
 };
@@ -128,9 +128,9 @@ public:
 
 	bool getLoadOldEvents(void) const;
 
-	int getFaceRestWorkers(void) const;
+	int getFaceRestNumWorkers(void) const;
 
-	void setFaceRestWorkers(const int &num);
+	void setFaceRestNumWorkers(const int &num);
 
 protected:
 	void loadConfFile(void);

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -37,6 +37,7 @@ struct CommandLineOptions {
 	gboolean  disableCopyOnDemand;
 	gboolean  loadOldEvents;
 	gint      faceRestPort;
+	gint      faceRestWorkers;
 
 	CommandLineOptions(void);
 };
@@ -126,6 +127,11 @@ public:
 	std::string getUser(void) const;
 
 	bool getLoadOldEvents(void) const;
+
+	int getFaceRestWorkers(void) const;
+
+	void setFaceRestWorkers(const int &num);
+
 protected:
 	void loadConfFile(void);
 	static gboolean parseLogLevel(

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -251,7 +251,7 @@ FaceRest::FaceRest(FaceRestParam *param)
 			m_impl->port = port;
 	}
 
-	int num = ConfigManager::getInstance()->getFaceRestWorkers();
+	int num = ConfigManager::getInstance()->getFaceRestNumWorkers();
 	if (num > 0) {
 		setNumberOfPreLoadWorkers(num);
 	}

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -251,7 +251,13 @@ FaceRest::FaceRest(FaceRestParam *param)
 			m_impl->port = port;
 	}
 
-	MLPL_INFO("started face-rest, port: %d\n", m_impl->port);
+	int num = ConfigManager::getInstance()->getFaceRestWorkers();
+	if (num > 0) {
+		setNumberOfPreLoadWorkers(num);
+	}
+
+	MLPL_INFO("started face-rest, port: %d, workers: %lu\n",
+		  m_impl->port, m_impl->numPreLoadWorkers);
 }
 
 FaceRest::~FaceRest()

--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -245,4 +245,65 @@ void test_parseLogLevel(gconstpointer data)
 	cppcut_assert_equal(level, string(currEnv));
 }
 
+void test_parseFaceRestWorkersDefault(void)
+{
+	int actual = ConfigManager::getInstance()->getFaceRestWorkers();
+	if (actual > 0) {
+		cppcut_assert_equal(4, actual);
+	} else {
+		cppcut_assert_equal(0, actual);
+	}
+}
+
+void data_parseFaceRestWorkers(void)
+{
+	int expect = ConfigManager::getInstance()->getFaceRestWorkers();
+	gcut_add_datum("Negative",
+		       "data", G_TYPE_INT, -1,
+		       "expect", G_TYPE_INT, expect,
+		       NULL);
+	gcut_add_datum("Zero",
+		       "data", G_TYPE_INT, 0,
+		       "expect", G_TYPE_INT, expect,
+		       NULL);
+	gcut_add_datum("One",
+		       "data", G_TYPE_INT, 1,
+		       "expect", G_TYPE_INT, 1,
+		       NULL);
+}
+
+void test_parseFaceRestWorkers(gconstpointer data)
+{
+	int val = gcut_data_get_int(data, "data");
+	string str = StringUtils::sprintf("%d", val);
+	int expect = gcut_data_get_int(data, "expect");
+
+	CommandArgHelper cmds;
+	cmds << "--face-rest-workers";
+	cmds << str.c_str();
+	cmds.activate();
+
+	cppcut_assert_equal(
+		ConfigManager::getInstance()->getFaceRestWorkers(),
+		expect);
+}
+
+void test_setFaceRestWorkers(void)
+{
+	const int n = 10;
+	ConfigManager *mng = ConfigManager::getInstance();
+	mng->setFaceRestWorkers(n);
+	cppcut_assert_equal(n, mng->getFaceRestWorkers());
+}
+
+void test_getFaceRestWorkers(void)
+{
+	ConfigManager *mng = ConfigManager::getInstance();
+	int n = mng->getFaceRestWorkers();
+	int expect = n + 5;
+	mng->setFaceRestWorkers(expect);
+	int actual = mng->getFaceRestWorkers();
+	cppcut_assert_equal(expect, actual);
+}
+
 } // namespace testConfigManager

--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -245,9 +245,9 @@ void test_parseLogLevel(gconstpointer data)
 	cppcut_assert_equal(level, string(currEnv));
 }
 
-void test_parseFaceRestWorkersDefault(void)
+void test_parseFaceRestNumWorkersDefault(void)
 {
-	int actual = ConfigManager::getInstance()->getFaceRestWorkers();
+	int actual = ConfigManager::getInstance()->getFaceRestNumWorkers();
 	if (actual > 0) {
 		cppcut_assert_equal(4, actual);
 	} else {
@@ -255,9 +255,9 @@ void test_parseFaceRestWorkersDefault(void)
 	}
 }
 
-void data_parseFaceRestWorkers(void)
+void data_parseFaceRestNumWorkers(void)
 {
-	int expect = ConfigManager::getInstance()->getFaceRestWorkers();
+	int expect = ConfigManager::getInstance()->getFaceRestNumWorkers();
 	gcut_add_datum("Negative",
 		       "data", G_TYPE_INT, -1,
 		       "expect", G_TYPE_INT, expect,
@@ -272,7 +272,7 @@ void data_parseFaceRestWorkers(void)
 		       NULL);
 }
 
-void test_parseFaceRestWorkers(gconstpointer data)
+void test_parseFaceRestNumWorkers(gconstpointer data)
 {
 	int val = gcut_data_get_int(data, "data");
 	string str = StringUtils::sprintf("%d", val);
@@ -284,25 +284,25 @@ void test_parseFaceRestWorkers(gconstpointer data)
 	cmds.activate();
 
 	cppcut_assert_equal(
-		ConfigManager::getInstance()->getFaceRestWorkers(),
+		ConfigManager::getInstance()->getFaceRestNumWorkers(),
 		expect);
 }
 
-void test_setFaceRestWorkers(void)
+void test_setFaceRestNumWorkers(void)
 {
-	const int n = 10;
+	const int numWorker = 10;
 	ConfigManager *mng = ConfigManager::getInstance();
-	mng->setFaceRestWorkers(n);
-	cppcut_assert_equal(n, mng->getFaceRestWorkers());
+	mng->setFaceRestNumWorkers(numWorker);
+	cppcut_assert_equal(numWorker, mng->getFaceRestNumWorkers());
 }
 
-void test_getFaceRestWorkers(void)
+void test_getFaceRestNumWorkers(void)
 {
 	ConfigManager *mng = ConfigManager::getInstance();
-	int n = mng->getFaceRestWorkers();
-	int expect = n + 5;
-	mng->setFaceRestWorkers(expect);
-	int actual = mng->getFaceRestWorkers();
+	int numWorker = mng->getFaceRestNumWorkers();
+	int expect = numWorker + 5;
+	mng->setFaceRestNumWorkers(expect);
+	int actual = mng->getFaceRestNumWorkers();
 	cppcut_assert_equal(expect, actual);
 }
 


### PR DESCRIPTION
FaceRestのワーカー数を設定する機能を追加しました。

Command line option:
-T, --face-rest-workers
0以下の値が指定された場合はエラーで終了

Config file:
[FaceRest]
workers=4
0以下の値が指定された場合はワーニング表示をしてデフォルト値(4)で起動

両方指定された場合はコマンドラインを優先します。
