### PR TITLE
Use DBTermCStringProvider.

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -27,6 +27,7 @@
 #include "Params.h"
 #include "ItemGroupStream.h"
 #include "DBClientJoinBuilder.h"
+#include "DBTermCStringProvider.h"
 
 // TODO: rmeove the followin two include files!
 // This class should not be aware of it.
@@ -1234,14 +1235,14 @@ string TriggersQueryOption::getCondition(void) const
 	}
 
 	if (m_impl->targetId != ALL_TRIGGERS) {
-		const DBTermCodec *dbTermCodec = getDBTermCodec();
+		DBTermCStringProvider dbTerm(*getDBTermCodec());
 		if (!condition.empty())
 			condition += " AND ";
 		condition += StringUtils::sprintf(
 			"%s.%s=%s",
 			DBTablesMonitoring::TABLE_NAME_TRIGGERS,
 			COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_ID].columnName,
-			dbTermCodec->enc(m_impl->targetId).c_str());
+			dbTerm(m_impl->targetId));
 	}
 
 	if (m_impl->minSeverity != TRIGGER_SEVERITY_UNKNOWN) {
@@ -1369,38 +1370,36 @@ string ItemsQueryOption::getCondition(void) const
 	}
 
 	if (m_impl->targetId != ALL_ITEMS) {
-		const DBTermCodec *dbTermCodec = getDBTermCodec();
+		DBTermCStringProvider dbTerm(*getDBTermCodec());
 		if (!condition.empty())
 			condition += " AND ";
 		condition += StringUtils::sprintf(
 			"%s.%s=%s",
 			DBTablesMonitoring::TABLE_NAME_ITEMS,
 			COLUMN_DEF_ITEMS[IDX_ITEMS_ID].columnName,
-			dbTermCodec->enc(m_impl->targetId).c_str());
+			dbTerm(m_impl->targetId));
 	}
 
 	if (!m_impl->itemGroupName.empty()) {
+		DBTermCStringProvider dbTerm(*getDBTermCodec());
 		if (!condition.empty())
 			condition += " AND ";
-		string escaped = StringUtils::replace(m_impl->itemGroupName,
-						      "'", "''");
 		condition += StringUtils::sprintf(
-			"%s.%s='%s'",
+			"%s.%s=%s",
 			DBTablesMonitoring::TABLE_NAME_ITEMS,
 			COLUMN_DEF_ITEMS[IDX_ITEMS_ITEM_GROUP_NAME].columnName,
-			escaped.c_str());
+			dbTerm(m_impl->itemGroupName));
 	}
 
 	if (!m_impl->appName.empty()){
+		DBTermCStringProvider dbTerm(*getDBTermCodec());
 		if (!condition.empty())
 			condition += " AND ";
-		string escapedAppName = StringUtils::replace(m_impl->appName,
-						      "'", "''");
 		condition += StringUtils::sprintf(
-			"%s.%s='%s'",
+			"%s.%s=%s",
 			DBTablesMonitoring::TABLE_NAME_ITEMS,
 			COLUMN_DEF_ITEMS[IDX_ITEMS_ITEM_GROUP_NAME].columnName,
-			escapedAppName.c_str());
+			dbTerm(m_impl->appName));
 	}
 
 	return condition;
@@ -1764,11 +1763,10 @@ void DBTablesMonitoring::setTriggerInfoList(
 		{
 			// TODO: This way is too rough and inefficient.
 			//       We should update only the changed triggers.
-			const DBTermCodec *dbTermCodec =
-			  dbAgent.getDBTermCodec();
+			DBTermCStringProvider dbTerm(*dbAgent.getDBTermCodec());
 			deleteArg.condition = StringUtils::sprintf("%s=%s",
 			  COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].columnName,
-			  dbTermCodec->enc(serverId).c_str());
+			  dbTerm(serverId));
 			return true;
 		}
 
@@ -1786,14 +1784,14 @@ void DBTablesMonitoring::setTriggerInfoList(
 
 int DBTablesMonitoring::getLastChangeTimeOfTrigger(const ServerIdType &serverId)
 {
-	const DBTermCodec *dbTermCodec = getDBAgent().getDBTermCodec();
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	DBAgent::SelectExArg arg(tableProfileTriggers);
 	string stmt = StringUtils::sprintf("coalesce(max(%s), 0)",
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_LAST_CHANGE_TIME_SEC].columnName);
 	arg.add(stmt, COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].type);
 	arg.condition = StringUtils::sprintf("%s=%s AND %s < %" FMT_TRIGGER_ID,
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].columnName,
-	    dbTermCodec->enc(serverId).c_str(),
+	    dbTerm(serverId),
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_ID].columnName,
 	    FAILED_SELF_TRIGGER_ID_TERMINATION);
 
@@ -2178,14 +2176,14 @@ void DBTablesMonitoring::updateHosts(const HostInfoList &hostInfoList,
 
 EventIdType DBTablesMonitoring::getLastEventId(const ServerIdType &serverId)
 {
-	const DBTermCodec *dbTermCodec = getDBAgent().getDBTermCodec();
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	DBAgent::SelectExArg arg(tableProfileEvents);
 	string stmt = StringUtils::sprintf("coalesce(max(%s), -1)",
 	    COLUMN_DEF_EVENTS[IDX_EVENTS_ID].columnName);
 	arg.add(stmt, COLUMN_DEF_EVENTS[IDX_EVENTS_ID].type);
 	arg.condition = StringUtils::sprintf("%s=%s",
 	    COLUMN_DEF_EVENTS[IDX_EVENTS_SERVER_ID].columnName,
-	    dbTermCodec->enc(serverId).c_str());
+	    dbTerm(serverId));
 
 	getDBAgent().runTransaction(arg);
 
@@ -2234,18 +2232,18 @@ SmartTime DBTablesMonitoring::getTimeOfLastEvent(
 
 	// First get the event ID.
 	// TODO: Get it with the one statemetn by using sub query.
-	const DBTermCodec *dbTermCodec = getDBAgent().getDBTermCodec();
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	const ColumnDef &colDefUniId = COLUMN_DEF_EVENTS[IDX_EVENTS_UNIFIED_ID];
 	const string stmt = sprintf("max(%s)", colDefUniId.columnName);
 	trx.argId.add(stmt, colDefUniId.type);
 
 	trx.argId.condition = sprintf("%s=%s",
 	    COLUMN_DEF_EVENTS[IDX_EVENTS_SERVER_ID].columnName,
-	    dbTermCodec->enc(serverId).c_str());
+	    dbTerm(serverId));
 	if (triggerId != ALL_TRIGGERS) {
 		trx.argId.condition += sprintf(" AND %s=%s",
 		    COLUMN_DEF_EVENTS[IDX_EVENTS_TRIGGER_ID].columnName,
-		    dbTermCodec->enc(triggerId).c_str());
+		    dbTerm(triggerId));
 	}
 
 	// Then get the time of the event ID.
@@ -2762,7 +2760,7 @@ HatoholError DBTablesMonitoring::getIncidentInfoVect(
 uint64_t DBTablesMonitoring::getLastUpdateTimeOfIncidents(
   const IncidentTrackerIdType &trackerId)
 {
-	const DBTermCodec *dbTermCodec = getDBAgent().getDBTermCodec();
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	DBAgent::SelectExArg arg(tableProfileIncidents);
 	string stmt = StringUtils::sprintf("coalesce(max(%s), 0)",
 	    COLUMN_DEF_INCIDENTS[IDX_INCIDENTS_UPDATED_AT_SEC].columnName);
@@ -2770,7 +2768,7 @@ uint64_t DBTablesMonitoring::getLastUpdateTimeOfIncidents(
 	if (trackerId != ALL_INCIDENT_TRACKERS) {
 		arg.condition = StringUtils::sprintf("%s=%s",
 		    COLUMN_DEF_INCIDENTS[IDX_INCIDENTS_TRACKER_ID].columnName,
-		    dbTermCodec->enc(trackerId).c_str());
+		    dbTerm(trackerId));
 	}
 
 	getDBAgent().runTransaction(arg);
@@ -2892,12 +2890,12 @@ void DBTablesMonitoring::addHostgroupElementWithoutTransaction(
   DBAgent &dbAgent, const HostgroupElement &hostgroupElement)
 {
 	// TODO: create the condition outside of the transaction.
-	const DBTermCodec *dbTermCodec = dbAgent.getDBTermCodec();
+	DBTermCStringProvider dbTerm(*dbAgent.getDBTermCodec());
 	string condition = StringUtils::sprintf(
 	  "server_id=%s AND host_id=%s AND host_group_id=%s",
-	  dbTermCodec->enc(hostgroupElement.serverId).c_str(),
-	  dbTermCodec->enc(hostgroupElement.hostId).c_str(),
-	  dbTermCodec->enc(hostgroupElement.groupId).c_str());
+	  dbTerm(hostgroupElement.serverId),
+	  dbTerm(hostgroupElement.hostId),
+	  dbTerm(hostgroupElement.groupId));
 
 	if (!dbAgent.isRecordExisting(TABLE_NAME_MAP_HOSTS_HOSTGROUPS,
 	                              condition)) {

--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -798,7 +798,7 @@ HatoholError DBTablesUser::deleteAccessInfo(const AccessInfoIdType id,
 bool DBTablesUser::getUserInfo(UserInfo &userInfo, const UserIdType userId)
 {
 	UserInfoList userInfoList;
-	string condition = StringUtils::sprintf("%s='%" FMT_USER_ID "'",
+	string condition = StringUtils::sprintf("%s=%" FMT_USER_ID,
 	  COLUMN_DEF_USERS[IDX_USERS_ID].columnName, userId);
 	getUserInfoList(userInfoList, condition);
 	if (userInfoList.empty())

--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -22,6 +22,7 @@
 #include "DBTablesConfig.h"
 #include "ItemGroupStream.h"
 #include "DBHatohol.h"
+#include "DBTermCStringProvider.h"
 using namespace std;
 using namespace mlpl;
 
@@ -334,10 +335,11 @@ string UserQueryOption::getCondition(void) const
 	if (!m_impl->targetName.empty()) {
 		// The validity of 'targetName' has been checked in
 		// setTargetName().
+		DBTermCStringProvider dbTerm(*getDBTermCodec());
 		string nameCond =
-		  StringUtils::sprintf("%s='%s'",
+		  StringUtils::sprintf("%s=%s",
 		    COLUMN_DEF_USERS[IDX_USERS_NAME].columnName,
-		   m_impl->targetName.c_str());
+		    dbTerm(m_impl->targetName));
 		DataQueryOption::addCondition(condition, nameCond);
 	}
 	return condition;
@@ -515,13 +517,14 @@ HatoholError DBTablesUser::addUserInfo(
 
 		bool preproc(DBAgent &dbAgent) override
 		{
+			DBTermCStringProvider dbTerm(*dbAgent.getDBTermCodec());
 			arg.add(AUTO_INCREMENT_VALUE);
 			arg.add(userInfo.name);
 			arg.add(Utils::sha256(userInfo.password));
 			arg.add(userInfo.flags);
-			dupCheckCond = StringUtils::sprintf("%s='%s'",
+			dupCheckCond = StringUtils::sprintf("%s=%s",
 			  COLUMN_DEF_USERS[IDX_USERS_NAME].columnName,
-			  userInfo.name.c_str());
+			  dbTerm(userInfo.name));
 			return true;
 		}
 
@@ -603,13 +606,18 @@ HatoholError DBTablesUser::updateUserInfo(
 			arg.condition = StringUtils::sprintf("%s=%" FMT_USER_ID,
 			  COLUMN_DEF_USERS[IDX_USERS_ID].columnName,
 			  userInfo.id);
+		}
 
+		bool preproc(DBAgent &dbAgent) override
+		{
+			DBTermCStringProvider dbTerm(*dbAgent.getDBTermCodec());
 			dupCheckCond = StringUtils::sprintf(
-			  "(%s='%s' and %s<>%" FMT_USER_ID ")",
+			  "(%s=%s and %s<>%" FMT_USER_ID ")",
 			  COLUMN_DEF_USERS[IDX_USERS_NAME].columnName,
-			  userInfo.name.c_str(),
+			  dbTerm(userInfo.name),
 			  COLUMN_DEF_USERS[IDX_USERS_ID].columnName,
 			  userInfo.id);
+			return true;
 		}
 
 		bool hasRecord(DBAgent &dbAgent, const string &condition)
@@ -716,11 +724,12 @@ UserIdType DBTablesUser::getUserId(const string &user, const string &password)
 	if (isValidPassword(password) != HTERR_OK)
 		return INVALID_USER_ID;
 
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	DBAgent::SelectExArg arg(tableProfileUsers);
 	arg.add(IDX_USERS_ID);
 	arg.add(IDX_USERS_PASSWORD);
-	arg.condition = StringUtils::sprintf("%s='%s'",
-	  COLUMN_DEF_USERS[IDX_USERS_NAME].columnName, user.c_str());
+	arg.condition = StringUtils::sprintf("%s=%s",
+	  COLUMN_DEF_USERS[IDX_USERS_NAME].columnName, dbTerm(user));
 	getDBAgent().runTransaction(arg);
 
 	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
@@ -979,10 +988,12 @@ HatoholError DBTablesUser::addUserRoleInfo(UserRoleInfo &userRoleInfo,
 			err = HTERR_OK;
 		}
 	} trx(userRoleInfo);
+
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	trx.dupChkCond = StringUtils::sprintf(
-	  "(%s='%s' or %s=%" FMT_OPPRVLG ")",
+	  "(%s=%s or %s=%" FMT_OPPRVLG ")",
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_NAME].columnName,
-	  StringUtils::replace(userRoleInfo.name, "'", "''").c_str(),
+	  dbTerm(userRoleInfo.name),
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_FLAGS].columnName,
 	  userRoleInfo.flags);
 	getDBAgent().runTransaction(trx);
@@ -1043,10 +1054,11 @@ HatoholError DBTablesUser::updateUserRoleInfo(
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_ID].columnName,
 	  userRoleInfo.id);
 
+	DBTermCStringProvider dbTerm(*getDBAgent().getDBTermCodec());
 	trx.dupChkCond = StringUtils::sprintf(
-	  "((%s='%s' or %s=%" FMT_OPPRVLG ") and %s<>%" FMT_USER_ROLE_ID ")",
+	  "((%s=%s or %s=%" FMT_OPPRVLG ") and %s<>%" FMT_USER_ROLE_ID ")",
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_NAME].columnName,
-	  StringUtils::replace(userRoleInfo.name, "'", "''").c_str(),
+	  dbTerm(userRoleInfo.name),
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_FLAGS].columnName,
 	  userRoleInfo.flags,
 	  COLUMN_DEF_USER_ROLES[IDX_USER_ROLES_ID].columnName,


### PR DESCRIPTION
DBTermCStringProvider is a wrapper for DBTermCodec::enc().
Using this, the code becomes simple.

It also removes quotations of value of RHS in SQL statements.
As a result, we can write an condition of an SQL statement
independent of the type of the RHS value.
