### PR TITLE
Use dbterm cstr provider 2

### DIFF
--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -798,7 +798,7 @@ HatoholError DBTablesUser::deleteAccessInfo(const AccessInfoIdType id,
 bool DBTablesUser::getUserInfo(UserInfo &userInfo, const UserIdType userId)
 {
 	UserInfoList userInfoList;
-	string condition = StringUtils::sprintf("%s='%" FMT_USER_ID "'",
+	string condition = StringUtils::sprintf("%s=%" FMT_USER_ID,
 	  COLUMN_DEF_USERS[IDX_USERS_ID].columnName, userId);
 	getUserInfoList(userInfoList, condition);
 	if (userInfoList.empty())

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -134,8 +134,6 @@ public:
 	 */
 	const bool &getFilterForDataOfDefunctServers(void) const;
 
-	virtual const DBTermCodec *getDBTermCodec(void) const override;
-
 	std::string getJoinClause(void) const;
 
 protected:
@@ -143,23 +141,23 @@ protected:
 	std::string getHostgroupIdColumnName(void) const;
 	std::string getHostIdColumnName(void) const;
 
-	static std::string makeCondition(
+	std::string makeCondition(
 	  const ServerHostGrpSetMap &srvHostGrpSetMap,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
 	  const std::string &hostIdColumnName,
 	  ServerIdType targetServerId = ALL_SERVERS,
 	  HostgroupIdType targetHostgroup = ALL_HOST_GROUPS,
-	  HostIdType targetHostId = ALL_HOSTS);
-	static std::string makeConditionServer(
+	  HostIdType targetHostId = ALL_HOSTS) const;
+	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,
-	  const std::string &serverIdColumnName);
-	static std::string makeConditionServer(
+	  const std::string &serverIdColumnName) const;
+	std::string makeConditionServer(
 	  const ServerIdType &serverId,
 	  const HostgroupIdSet &hostgroupIdSet,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
-	  const HostgroupIdType &hostgroupId = ALL_HOST_GROUPS);
+	  const HostgroupIdType &hostgroupId = ALL_HOST_GROUPS) const;
 	static std::string makeConditionHostgroup(
 	  const HostgroupIdSet &hostgroupIdSet,
 	  const std::string &hostgroupIdColumnName);

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -47,7 +47,7 @@ testHatohol_la_SOURCES = \
 	testHatoholThreadBase.cc \
 	testHatoholDBUtils.cc \
 	testHostInfoCache.cc \
-	TestHostResourceQueryOption.h \
+	TestHostResourceQueryOption.cc TestHostResourceQueryOption.h \
 	testHostResourceQueryOption.cc \
 	testHostResourceQueryOptionSubClasses.cc \
 	testDBAgent.cc \

--- a/server/test/TestHostResourceQueryOption.cc
+++ b/server/test/TestHostResourceQueryOption.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestHostResourceQueryOption.h"
+#include "DBAgentTest.h"
+
+using namespace std;
+
+// This is just to pass the build and won't work.
+static HostResourceQueryOption::Synapse synapse(
+  tableProfileTest, 0, 0,
+  tableProfileTest, 0, false,
+  tableProfileTest, 0, 0, 0);
+
+TestHostResourceQueryOption::TestHostResourceQueryOption(const UserIdType &userId)
+: HostResourceQueryOption(synapse, userId)
+{
+}
+
+string TestHostResourceQueryOption::callGetServerIdColumnName(void) const
+{
+	return getServerIdColumnName();
+}
+
+string TestHostResourceQueryOption::callMakeConditionServer(
+  const ServerIdSet &serverIdSet, const string &serverIdColumnName) const
+{
+	return makeConditionServer(serverIdSet, serverIdColumnName);
+}
+
+string TestHostResourceQueryOption::callMakeCondition(
+  const ServerHostGrpSetMap &srvHostGrpSetMap,
+  const string &serverIdColumnName,
+  const string &hostgroupIdColumnName,
+  const string &hostIdColumnName,
+  const ServerIdType &targetServerId,
+  const HostgroupIdType &targetHostgroupId,
+  const HostIdType &targetHostId) const
+{
+	return makeCondition(srvHostGrpSetMap,
+	                     serverIdColumnName,
+	                     hostgroupIdColumnName,
+	                     hostIdColumnName,
+	                     targetServerId,
+	                     targetHostgroupId,
+	                     targetHostId);
+}

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -21,37 +21,26 @@
 #define TestHostResourceQueryOption_h
 
 #include <string>
+#include <HostResourceQueryOption.h>
 
 class TestHostResourceQueryOption : public HostResourceQueryOption {
 public:
-	std::string callGetServerIdColumnName(void) const
-	{
-		return getServerIdColumnName();
-	}
+	TestHostResourceQueryOption(const UserIdType &userId = INVALID_USER_ID);
 
-	static std::string callMakeConditionServer(
-	  const ServerIdSet &serverIdSet, const std::string &serverIdColumnName)
-	{
-		return makeConditionServer(serverIdSet, serverIdColumnName);
-	}
+	std::string callGetServerIdColumnName(void) const;
 
-	static std::string callMakeCondition(
+	std::string callMakeConditionServer(
+	  const ServerIdSet &serverIdSet,
+	  const std::string &serverIdColumnName) const;
+
+	std::string callMakeCondition(
 	  const ServerHostGrpSetMap &srvHostGrpSetMap,
 	  const std::string &serverIdColumnName,
 	  const std::string &hostgroupIdColumnName,
 	  const std::string &hostIdColumnName,
-	  uint32_t targetServerId = ALL_SERVERS,
-	  uint64_t targetHostgroupId = ALL_HOST_GROUPS,
-	  uint64_t targetHostId = ALL_HOSTS)
-	{
-		return makeCondition(srvHostGrpSetMap,
-		                     serverIdColumnName,
-		                     hostgroupIdColumnName,
-		                     hostIdColumnName,
-		                     targetServerId,
-		                     targetHostgroupId,
-		                     targetHostId);
-	}
+	  const ServerIdType &targetServerId = ALL_SERVERS,
+	  const HostgroupIdType &targetHostgroupId = ALL_HOST_GROUPS,
+	  const HostIdType &targetHostId = ALL_HOSTS) const;
 };
 
 #endif // TestHostResourceQueryOption_h

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -167,18 +167,14 @@ static const string hostIdColumnName = "host_id";
 // FIXME: Change order of parameter.
 static void _assertMakeCondition(
   const ServerHostGrpSetMap &srvHostGrpSetMap, const string &expect,
-  const ServerIdType targetServerId = ALL_SERVERS,
-  const HostIdType targetHostId = ALL_HOSTS,
-  const HostgroupIdType targetHostgroupId = ALL_HOST_GROUPS)
+  const ServerIdType &targetServerId = ALL_SERVERS,
+  const HostIdType &targetHostId = ALL_HOSTS,
+  const HostgroupIdType &targetHostgroupId = ALL_HOST_GROUPS)
 {
-	string cond = TestHostResourceQueryOption::callMakeCondition(
-			srvHostGrpSetMap,
-			serverIdColumnName,
-			hostgroupIdColumnName,
-			hostIdColumnName,
-			targetServerId,
-			targetHostgroupId,
-			targetHostId);
+	TestHostResourceQueryOption option;
+	string cond = option.callMakeCondition(
+	  srvHostGrpSetMap, serverIdColumnName, hostgroupIdColumnName,
+	  hostIdColumnName, targetServerId, targetHostgroupId, targetHostId);
 	cppcut_assert_equal(expect, cond);
 }
 #define assertMakeCondition(M, ...) \
@@ -228,7 +224,8 @@ static string makeExpectedConditionForUser(
 	  nameBuilder(TEST_PRIMARY_TABLE_NAME, hostIdColumnName);
 	// TODO: consider that the following way (using a part of test
 	//       target method) is good.
-	const string exp = TestHostResourceQueryOption::callMakeCondition(
+	TestHostResourceQueryOption option;
+	const string exp = option.callMakeCondition(
 	  srvHostGrpSetMap, svIdColName, hgrpIdColName, hostIdColName);
 	return exp;
 }
@@ -455,8 +452,9 @@ void test_makeConditionServer(void)
 	for (size_t i = 0; i < numServerIds; i++)
 		svIdSet.insert(serverIds[i]);
 
-	string actual = TestHostResourceQueryOption::callMakeConditionServer(
-	                  svIdSet, serverIdColumnName);
+	TestHostResourceQueryOption option;
+	string actual =
+	  option.callMakeConditionServer(svIdSet, serverIdColumnName);
 
 	// check
 	string expectHead = serverIdColumnName;
@@ -484,8 +482,8 @@ void test_makeConditionServer(void)
 void test_makeConditionServerWithEmptyIdSet(void)
 {
 	ServerIdSet svIdSet;
-	string actual = TestHostResourceQueryOption::callMakeConditionServer(
-	                  svIdSet, "meet");
+	TestHostResourceQueryOption option;
+	string actual = option.callMakeConditionServer(svIdSet, "meet");
 	cppcut_assert_equal(DBHatohol::getAlwaysFalseCondition(), actual);
 }
 


### PR DESCRIPTION
This patches mainly use DBTermCStringProvider that is a helper
class of DBTermCodec. Its instance is named 'rhs' that means
Right Hand Side of a condition equation in an SQL statement.
The name also aims to avoid readers from being confused.
In this project, instances of DBTables
and the child classes have been named dbXXXX such as
dbMonitoring and dbHost.

The name 'rhs' seems to be a too short and meaningless.  However,
lines to generate an SQL statement tend to be a long. So I believe
the short name makes the code simple after all.