### PR TITLE
Use dbterm cstr provider 3

### DIFF
--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -798,7 +798,7 @@ HatoholError DBTablesUser::deleteAccessInfo(const AccessInfoIdType id,
 bool DBTablesUser::getUserInfo(UserInfo &userInfo, const UserIdType userId)
 {
 	UserInfoList userInfoList;
-	string condition = StringUtils::sprintf("%s='%" FMT_USER_ID "'",
+	string condition = StringUtils::sprintf("%s=%" FMT_USER_ID,
 	  COLUMN_DEF_USERS[IDX_USERS_ID].columnName, userId);
 	getUserInfoList(userInfoList, condition);
 	if (userInfoList.empty())


### PR DESCRIPTION
This patches mainly use DBTermCStringProvider that is a helper
class of DBTermCodec. Its instance is named 'rhs' that means
Right Hand Side of a condition equation in an SQL statement.
The name also aims to avoid readers from being confused.
In this project, instances of DBTables
and the child classes have been named dbXXXX such as
dbMonitoring and dbHost.

The name 'rhs' seems to be a too short and meaningless. However,
lines to generate an SQL statement tend to be a long. So I believe
the short name makes the code simple after all.
