### PR TITLE
[client][test][feature] Reduce wait msec magic number

### DIFF
--- a/client/test/feature/feature_test_utils.js
+++ b/client/test/feature/feature_test_utils.js
@@ -38,7 +38,7 @@ function moveToServersPage(test) {
       test.assertExists(x("//a[normalize-space(text())='監視サーバー']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_servers/, function() {
       test.assertUrlMatch(/.*ajax_servers/, "Move into servers page.");
     });
   });
@@ -163,7 +163,7 @@ function moveToIncidentSettingsPage(test) {
       test.assertExists(x("//a[normalize-space(text())='インシデント管理']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_incident_settings/, function() {
       test.assertUrlMatch(/.*ajax_incident_settings/,
                           "Move into incident settings page.");
     });
@@ -333,7 +333,7 @@ function moveToDashboardPage(test) {
     this.click(x("//a[normalize-space(text())='ダッシュボード']"));
   });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_dashboard/, function() {
       test.assertUrlMatch(/.*ajax_dashboard/, "Move into dashboard page.");
     });
   });
@@ -350,7 +350,7 @@ function moveToLogSearchSystemPage(test) {
       test.assertExists(x("//a[normalize-space(text())='ログ検索システム']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_log_search_system/, function() {
       test.assertUrlMatch(/.*ajax_log_search_system/,
                           "Move into logsearch system page.");
     });

--- a/client/test/feature/feature_test_utils.js
+++ b/client/test/feature/feature_test_utils.js
@@ -38,7 +38,7 @@ function moveToServersPage(test) {
       test.assertExists(x("//a[normalize-space(text())='監視サーバー']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_servers/, "Move into servers page.");
     });
   });
@@ -163,7 +163,7 @@ function moveToIncidentSettingsPage(test) {
       test.assertExists(x("//a[normalize-space(text())='インシデント管理']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_incident_settings/,
                           "Move into incident settings page.");
     });
@@ -333,7 +333,7 @@ function moveToDashboardPage(test) {
     this.click(x("//a[normalize-space(text())='ダッシュボード']"));
   });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_dashboard/, "Move into dashboard page.");
     });
   });
@@ -350,7 +350,7 @@ function moveToLogSearchSystemPage(test) {
       test.assertExists(x("//a[normalize-space(text())='ログ検索システム']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_log_search_system/,
                           "Move into logsearch system page.");
     });

--- a/client/test/feature/register_action_test.js
+++ b/client/test/feature/register_action_test.js
@@ -35,7 +35,7 @@ casper.test.begin('Register/Unregister action test', function(test) {
       test.assertExists(x("//a[normalize-space(text())='アクション']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_actions/, "Move into actions page.");
     });
   });

--- a/client/test/feature/register_action_test.js
+++ b/client/test/feature/register_action_test.js
@@ -35,7 +35,7 @@ casper.test.begin('Register/Unregister action test', function(test) {
       test.assertExists(x("//a[normalize-space(text())='アクション']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_actions/, function() {
       test.assertUrlMatch(/.*ajax_actions/, "Move into actions page.");
     });
   });

--- a/client/test/feature/register_redmine_test.js
+++ b/client/test/feature/register_redmine_test.js
@@ -23,7 +23,7 @@ casper.test.begin('Register/Unregister incident tracker(Redmine) test', function
       test.assertExists(x("//a[normalize-space(text())='インシデント管理']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_incident_settings/, function() {
       test.assertUrlMatch(/.*ajax_incident_settings/,
                           "Move into incident settings page.");
     });

--- a/client/test/feature/register_redmine_test.js
+++ b/client/test/feature/register_redmine_test.js
@@ -23,7 +23,7 @@ casper.test.begin('Register/Unregister incident tracker(Redmine) test', function
       test.assertExists(x("//a[normalize-space(text())='インシデント管理']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_incident_settings/,
                           "Move into incident settings page.");
     });

--- a/client/test/feature/register_server_test.js
+++ b/client/test/feature/register_server_test.js
@@ -23,7 +23,7 @@ casper.test.begin('Register/Unregister server test', function(test) {
       test.assertExists(x("//a[normalize-space(text())='監視サーバー']"));
     });
   casper.then(function() {
-    casper.waitForUrl(function() {
+    casper.waitForUrl(/.*ajax_servers/, function() {
       test.assertUrlMatch(/.*ajax_servers/, "Move into servers page.");
     });
   });

--- a/client/test/feature/register_server_test.js
+++ b/client/test/feature/register_server_test.js
@@ -23,7 +23,7 @@ casper.test.begin('Register/Unregister server test', function(test) {
       test.assertExists(x("//a[normalize-space(text())='監視サーバー']"));
     });
   casper.then(function() {
-    casper.wait(200, function() {
+    casper.waitForUrl(function() {
       test.assertUrlMatch(/.*ajax_servers/, "Move into servers page.");
     });
   });


### PR DESCRIPTION
Previous implementation uses 200 msec to wait response as magic number.
This pull request uses more abstract method to wait a response.

And it makes slightly faster feature test execution.

Before:

```log
PASS 71 tests executed in 18.101s, 71 passed, 0 failed, 0 dubious, 0 skipped.
```

After:

```log
PASS 71 tests executed in 16.774s, 71 passed, 0 failed, 0 dubious, 0 skipped. 
```