### PR TITLE
[HatoholDBInitiator] Show MySQL error message.

### DIFF
--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -150,9 +150,14 @@ def start(args):
     add_sql_directory(args, sql_file_list)
     check_sql_file(args, sql_file_list)
 
-    db = MySQLdb.connect(host=args.host,
-                         user=args.db_user, passwd=args.db_password)
-    cursor = db.cursor()
+    try:
+        db = MySQLdb.connect(host=args.host,
+                             user=args.db_user, passwd=args.db_password)
+        cursor = db.cursor()
+    except MySQLdb.Error as e:
+        print 'MySQL Error [%d]: %s' % (e[0], e[1])
+        sys.exit(os.EX_DATAERR)
+
     create_db_if_needed(cursor, args)
     create_hatohol_tables(args)
 

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -154,8 +154,8 @@ def start(args):
         db = MySQLdb.connect(host=args.host,
                              user=args.db_user, passwd=args.db_password)
         cursor = db.cursor()
-    except MySQLdb.Error as e:
-        print 'MySQL Error [%d]: %s' % (e[0], e[1])
+    except MySQLdb.Error as (errno, msg):
+        print 'MySQL Error [%d]: %s' % (errno, msg)
         sys.exit(os.EX_DATAERR)
 
     create_db_if_needed(cursor, args)


### PR DESCRIPTION
Previously, ```hatohol-db-initiator``` shows following message when user input (or write to config file) fault value for connecting to  MySQL server.

(Example: Input wrong password for ```root``` user.)
Before:
``` bash
$ hatohol-db-initiator --db_name hatohol --db_user root --db_password hatohol
Traceback (most recent call last):
  File "/usr/local/bin/hatohol-db-initiator", line 221, in <module>
    start(args)
  File "/usr/local/bin/hatohol-db-initiator", line 154, in start
    user=args.db_user, passwd=args.db_password)
  File "/usr/local/lib/python2.7/dist-packages/MySQLdb/__init__.py", line 81, in Connect
    return Connection(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/MySQLdb/connections.py", line 187, in __init__
    super(Connection, self).__init__(*args, **kwargs2)
_mysql_exceptions.OperationalError: (1045, "Access denied for user 'root'@'localhost' (using password: YES)")
```

User can understand contents of the error at last line in output.
But, I think this behavior is not good for the user.
So, I modified to show only error message for MySQL.

After:
``` bash
$ hatohol-db-initiator --db_name hatohol --db_user root --db_password hatohol
MySQL Error [1045]: Access denied for user 'root'@'localhost' (using password: YES)
```