### PR TITLE
Add licence header.

### DIFF
--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -1,4 +1,22 @@
 #!/usr/bin/env python
+"""
+  Copyright (C) 2014-2015 Project Hatohol
+
+  This file is part of Hatohol.
+
+  Hatohol is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License, version 3
+  as published by the Free Software Foundation.
+
+  Hatohol is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Hatohol. If not, see
+  <http://www.gnu.org/licenses/>.
+"""
 import sys
 import os
 import argparse

--- a/server/tools/hatohol-server-type-util
+++ b/server/tools/hatohol-server-type-util
@@ -1,5 +1,22 @@
 #!/usr/bin/env python
+"""
+  Copyright (C) 2014-2015 Project Hatohol
 
+  This file is part of Hatohol.
+
+  Hatohol is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License, version 3
+  as published by the Free Software Foundation.
+
+  Hatohol is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Hatohol. If not, see
+  <http://www.gnu.org/licenses/>.
+"""
 import hatohol
 import json
 import argparse


### PR DESCRIPTION
Following files didn't display licence header.
So, I add licence header to following files.
- hatohol-db-initiator(.in)
- hatohol-server-type-util

If these file don't need to display licence header, please close this Pull Request.