### PR TITLE
[Issue 839] Fix wrong link about nagios WebUI

### DIFF
--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -218,15 +218,10 @@ var ServersView = function(userProfile) {
            ">" + escapeHTML(gettext("Checking")) + "</td>";
       s += "<td>" + getServerTypeLabel(o["type"]) + "</td>";
       if (serverURL) {
-        if (o["type"] == hatohol.MONITORING_SYSTEM_NAGIOS) {
-          s += "<td>" + escapeHTML(o["hostName"]) + "</td>";
-          s += "<td>" + escapeHTML(ip) + "</td>";
-	} else {
-          s += "<td><a href='" + serverURL + "' target='_blank'>"
-            + escapeHTML(o["hostName"])  + "</a></td>";
-          s += "<td><a href='" + serverURL + "' target='_blank'>"
-            + escapeHTML(ip) + "</a></td>";
-        }
+        s += "<td><a href='" + serverURL + "' target='_blank'>"
+             + escapeHTML(o["hostName"])  + "</a></td>";
+        s += "<td><a href='" + serverURL + "' target='_blank'>"
+             + escapeHTML(ip) + "</a></td>";
       } else if (o["type"] == hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER){
         s += "<td>" + escapeHTML(o["hostName"])  + "</td>";
         s += "<td>N/A</td>";

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -218,10 +218,16 @@ var ServersView = function(userProfile) {
            ">" + escapeHTML(gettext("Checking")) + "</td>";
       s += "<td>" + getServerTypeLabel(o["type"]) + "</td>";
       if (serverURL) {
-        s += "<td><a href='" + serverURL + "' target='_blank'>"
-             + escapeHTML(o["hostName"])  + "</a></td>";
-        s += "<td><a href='" + serverURL + "' target='_blank'>"
-             + escapeHTML(ip) + "</a></td>";
+        if (o["type"] == hatohol.MONITORING_SYSTEM_NAGIOS ||
+	    o["type"] == hatohol.MONITORING_SYSTEM_HAPI_NAGIOS) {
+          s += "<td>" + escapeHTML(o["hostName"]) + "</td>";
+          s += "<td>" + escapeHTML(ip) + "</td>";
+	} else {
+          s += "<td><a href='" + serverURL + "' target='_blank'>"
+            + escapeHTML(o["hostName"])  + "</a></td>";
+          s += "<td><a href='" + serverURL + "' target='_blank'>"
+            + escapeHTML(ip) + "</a></td>";
+        }
       } else if (o["type"] == hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER){
         s += "<td>" + escapeHTML(o["hostName"])  + "</td>";
         s += "<td>N/A</td>";

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -218,8 +218,7 @@ var ServersView = function(userProfile) {
            ">" + escapeHTML(gettext("Checking")) + "</td>";
       s += "<td>" + getServerTypeLabel(o["type"]) + "</td>";
       if (serverURL) {
-        if (o["type"] == hatohol.MONITORING_SYSTEM_NAGIOS ||
-	    o["type"] == hatohol.MONITORING_SYSTEM_HAPI_NAGIOS) {
+        if (o["type"] == hatohol.MONITORING_SYSTEM_NAGIOS) {
           s += "<td>" + escapeHTML(o["hostName"]) + "</td>";
           s += "<td>" + escapeHTML(ip) + "</td>";
 	} else {

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -127,7 +127,7 @@ function getServerLocation(server) {
     url += "/zabbix/";
     break;
   case hatohol.MONITORING_SYSTEM_NAGIOS:
-    url = undefined;
+    url = undefined;    // issue-839
     break;
   case hatohol.MONITORING_SYSTEM_HAPI_ZABBIX:
     url += "/zabbix/";

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -127,7 +127,7 @@ function getServerLocation(server) {
     url += "/zabbix/";
     break;
   case hatohol.MONITORING_SYSTEM_NAGIOS:
-    url += "/nagios/";
+    url = undefined;
     break;
   case hatohol.MONITORING_SYSTEM_HAPI_ZABBIX:
     url += "/zabbix/";

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -99,12 +99,28 @@ describe('EventsView', function() {
 
   function testTableContents(serverURL, hostURL, dummyServerInfo){
     var view = new EventsView(getOperator());
-    var expected =
-      '<td><a href="' + escapeHTML(serverURL) + '" target="_blank">Server</a></td>' +
+    var expected;
+
+    if (serverURL) {
+      expected =
+        '<td><a href="' + escapeHTML(serverURL) + '" target="_blank">Server</a></td>';
+    } else {
+      expected = '<td>Server</td>';
+    }
+
+    expected +=
       '<td data-sort-value="1415749496">' +
       formatDate(1415749496) +
-      '</td>' +
-      '<td><a href="' + escapeHTML(hostURL) + '" target="_blank">Host</a></td>' +
+      '</td>';
+
+    if (hostURL) {
+      expected =
+	'<td><a href="' + escapeHTML(hostURL) + '" target="_blank">Host</a></td>';
+    } else {
+      expected = '<td>Host</td>';
+    }
+
+    expected +=
       '<td>Test discription.</td>' +
       '<td class="status1" data-sort-value="1">Problem</td>' +
       '<td class="severity1" data-sort-value="1">Information</td>';
@@ -195,9 +211,12 @@ describe('EventsView', function() {
   });
 
   it('new with fake nagios data', function() {
-    var nagiosURL = "http://192.168.1.100/nagios/";
-    var nagiosStatusURL =
-      "http://192.168.1.100/nagios/cgi-bin/status.cgi?host=Host";
+    // issue #839
+    //var nagiosURL = "http://192.168.1.100/nagios/";
+    //var nagiosStatusURL =
+    //  "http://192.168.1.100/nagios/cgi-bin/status.cgi?host=Host";
+    var nagiosURL = undefined;
+    var nagiosStatusURL = undefined;
     testTableContents(nagiosURL, nagiosStatusURL, getDummyServerInfo(1));
   });
 

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -40,7 +40,9 @@ describe('getServerLocation', function() {
       "ipAddress": "127.0.0.1",
       "name": "localhost"
     };
-    var expected = "http://127.0.0.1/nagios/";
+    // issue #839
+    //var expected = "http://127.0.0.1/nagios/";
+    var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
   });
 
@@ -51,7 +53,9 @@ describe('getServerLocation', function() {
       "name": "localhost",
       "port": 8080
     };
-    var expected = "http://127.0.0.1:8080/nagios/";
+    // issue #839
+    //var expected = "http://127.0.0.1:8080/nagios/";
+    var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
   });
 
@@ -61,7 +65,9 @@ describe('getServerLocation', function() {
       "ipAddress": "::1",
       "name": "localhost"
     };
-    var expected = "http://[::1]/nagios/";
+    // issue #839
+    //var expected = "http://[::1]/nagios/";
+    var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
   });
 


### PR DESCRIPTION
監視サーバ一覧で、サーバタイプがNatios及びNagios(HAPI)の場合は、NagiosのWeb画面へのリンクを生成しないようにしました。