### PR TITLE
[server] Change the type of Trigger ID to a string.

### DIFF
--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -208,7 +208,8 @@ struct HapiArmInfo {
 } __attribute__((__packed__));
 
 struct HapiParamTimeOfLastEvent {
-	uint64_t triggerId;
+	uint16_t triggerIdLength; // Not include the NULL terminator
+	uint16_t triggerIdOffset; // from the top of this structure
 } __attribute__((__packed__));
 
 struct HapiResponseHeader {

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -74,8 +74,8 @@ typedef uint64_t ItemIdType;
 typedef uint64_t ItemCategoryIdType;
 #define FMT_ITEM_CATEGORY_ID PRIu64
 
-typedef uint64_t TriggerIdType;
-#define FMT_TRIGGER_ID PRIu64
+typedef std::string TriggerIdType;
+#define FMT_TRIGGER_ID "s"
 
 typedef std::string HostgroupIdType;
 #define FMT_HOST_GROUP_ID "s"
@@ -112,16 +112,25 @@ static const HostgroupIdType ALL_HOST_GROUPS = "*";
 static const IncidentTrackerIdType ALL_INCIDENT_TRACKERS = -1;
 
 // Special Trigger IDs ========================================================
-static const TriggerIdType ALL_TRIGGERS                    = -1;
+#define SPECIAL_TRIGGER_ID_PREFIX "__"
+static const TriggerIdType ALL_TRIGGERS                    = "*";
 
-static const TriggerIdType FAILED_CONNECT_ZABBIX_TRIGGER_ID     = -1000;
-static const TriggerIdType FAILED_CONNECT_MYSQL_TRIGGER_ID      = -1001;
-static const TriggerIdType FAILED_INTERNAL_ERROR_TRIGGER_ID     = -1002;
-static const TriggerIdType FAILED_PARSER_JSON_DATA_TRIGGER_ID   = -1003;
-static const TriggerIdType FAILED_CONNECT_BROKER_TRIGGER_ID     = -1004;
-static const TriggerIdType FAILED_CONNECT_HAP_TRIGGER_ID        = -1005;
-static const TriggerIdType FAILED_HAP_INTERNAL_ERROR_TRIGGER_ID = -1006;
-static const TriggerIdType FAILED_SELF_TRIGGER_ID_TERMINATION   = -1007;
+static const TriggerIdType FAILED_CONNECT_ZABBIX_TRIGGER_ID     =
+  SPECIAL_TRIGGER_ID_PREFIX "CON_ZBX";
+static const TriggerIdType FAILED_CONNECT_MYSQL_TRIGGER_ID      =
+  SPECIAL_TRIGGER_ID_PREFIX "CON_MYSQL";
+static const TriggerIdType FAILED_INTERNAL_ERROR_TRIGGER_ID     =
+  SPECIAL_TRIGGER_ID_PREFIX "INTERNAL_ERR";
+static const TriggerIdType FAILED_PARSER_JSON_DATA_TRIGGER_ID   =
+  SPECIAL_TRIGGER_ID_PREFIX "PARSE_JSON";
+static const TriggerIdType FAILED_CONNECT_BROKER_TRIGGER_ID     =
+  SPECIAL_TRIGGER_ID_PREFIX "CON_BROKER";
+static const TriggerIdType FAILED_CONNECT_HAP_TRIGGER_ID        =
+  SPECIAL_TRIGGER_ID_PREFIX "CON_HAP";
+static const TriggerIdType FAILED_HAP_INTERNAL_ERROR_TRIGGER_ID =
+  SPECIAL_TRIGGER_ID_PREFIX "HAP_INTERNAL_ERR";
+static const TriggerIdType FAILED_SELF_TRIGGER_ID_TERMINATION   =
+  SPECIAL_TRIGGER_ID_PREFIX "TERM";
 
 // Special Event IDs ==========================================================
 static const EventIdType EVENT_NOT_FOUND = -1;

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -344,8 +344,8 @@ ItemTablePtr ZabbixAPI::mergePlainTriggersAndExpandedDescriptions(
 	for (; expandedDescGrpItr != expandedDescriptionGrpList.end(); ++expandedDescGrpItr) {
 		const ItemGroup *itemGroup = *expandedDescGrpItr;
 		ItemGroupPtr expandedDescGrpPtr = *expandedDescGrpItr;
-		uint64_t expandedItemGrpId =
-		  static_cast<uint64_t>(*expandedDescGrpPtr->getItem(ITEM_ID_ZBX_TRIGGERS_TRIGGERID));
+		const TriggerIdType &expandedItemGrpId =
+		  *expandedDescGrpPtr->getItem(ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
 		expandedTrigIdGrpMap.insert(
 		  pair<TriggerIdType, ItemGroupPtr>(expandedItemGrpId, itemGroup));
 	}
@@ -353,7 +353,7 @@ ItemTablePtr ZabbixAPI::mergePlainTriggersAndExpandedDescriptions(
 	VariableItemTablePtr mergedTablePtr;
 	for (; trigGrpItr != trigGrpList.end(); ++trigGrpItr) {
 		ItemGroupPtr trigItemGrpPtr = *trigGrpItr;
-		uint64_t trigItemGrpId =
+		const TriggerIdType &trigItemGrpId =
 		  *trigItemGrpPtr->getItem(ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
 		TriggerIdItemGrpMapConstIterator it =
 		  expandedTrigIdGrpMap.find(trigItemGrpId);
@@ -1059,7 +1059,7 @@ void ZabbixAPI::parseAndPushTriggerData(
 {
 	startElement(parser, index);
 	VariableItemGroupPtr grp;
-	pushUint64(parser, grp, "triggerid",   ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
+	pushString(parser, grp, "triggerid",   ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
 	pushString(parser, grp, "expression",  ITEM_ID_ZBX_TRIGGERS_EXPRESSION);
 	pushString(parser, grp, "description", ITEM_ID_ZBX_TRIGGERS_DESCRIPTION);
 	pushString(parser, grp, "url",         ITEM_ID_ZBX_TRIGGERS_URL);
@@ -1101,7 +1101,7 @@ void ZabbixAPI::parseAndPushTriggerExpandedDescriptionData(
 {
 	startElement(parser, index);
 	VariableItemGroupPtr grp;
-	pushUint64(parser, grp, "triggerid",   ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
+	pushString(parser, grp, "triggerid",   ITEM_ID_ZBX_TRIGGERS_TRIGGERID);
 	pushString(parser, grp, "description", ITEM_ID_ZBX_TRIGGERS_EXPANDED_DESCRIPTION);
 	tablePtr->add(grp);
 	parser.endElement();
@@ -1324,7 +1324,7 @@ void ZabbixAPI::parseAndPushEventsData(
 	pushUint64(parser, grp, "eventid",      ITEM_ID_ZBX_EVENTS_EVENTID);
 	pushInt   (parser, grp, "source",       ITEM_ID_ZBX_EVENTS_SOURCE);
 	pushInt   (parser, grp, "object",       ITEM_ID_ZBX_EVENTS_OBJECT);
-	pushUint64(parser, grp, "objectid",     ITEM_ID_ZBX_EVENTS_OBJECTID);
+	pushString(parser, grp, "objectid",     ITEM_ID_ZBX_EVENTS_OBJECTID);
 	pushInt   (parser, grp, "clock",        ITEM_ID_ZBX_EVENTS_CLOCK);
 	pushInt   (parser, grp, "value",        ITEM_ID_ZBX_EVENTS_VALUE);
 	pushInt   (parser, grp, "acknowledged",

--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -617,7 +617,7 @@ string  HapProcessCeilometer::getHistoryQueryOption(
 HatoholError HapProcessCeilometer::getAlarmHistory(const unsigned int &index)
 {
 	const char *alarmId = m_impl->acquireCtx.alarmIds[index].c_str();
-	const SmartTime lastTime = getTimeOfLastEvent(generateHashU64(alarmId));
+	const SmartTime lastTime = getTimeOfLastEvent(alarmId);
 	string url = StringUtils::sprintf(
 	               "%s/v2/alarms/%s/history%s",
 	               m_impl->ceilometerEP.publicURL.c_str(),

--- a/server/hap/HatoholArmPluginBase.cc
+++ b/server/hap/HatoholArmPluginBase.cc
@@ -281,8 +281,11 @@ SmartTime HatoholArmPluginBase::getTimeOfLastEvent(
 	HapiParamTimeOfLastEvent *param = 
 	  setupCommandHeader<HapiParamTimeOfLastEvent>(
 	    cmdBuf, HAPI_CMD_GET_TIME_OF_LAST_EVENT,
-	    sizeof(HapiParamTimeOfLastEvent));
-	param->triggerId = triggerId;
+	    sizeof(HapiParamTimeOfLastEvent) + triggerId.size() + 1);
+	char *buf = reinterpret_cast<char *>(param + 1);
+	buf = putString(buf, param, triggerId,
+	                &param->triggerIdOffset, &param->triggerIdLength);
+	cmdBuf.printBuffer();
 	send(cmdBuf, cb);
 	cb->wait();
 	if (!cb->getSucceeded()) {

--- a/server/src/ActionManager.cc
+++ b/server/src/ActionManager.cc
@@ -508,7 +508,7 @@ static bool shouldSkipIncidentSender(
 			 "Trigger:%" FMT_TRIGGER_ID " because "
 			 "IncidentSenderAction:%" FMT_ACTION_ID " has "
 			 "higher priority.",
-			 actionDef.id, eventInfo.triggerId,
+			 actionDef.id, eventInfo.triggerId.c_str(),
 			 incidentSenderActionId);
 		return true;
 	}
@@ -759,8 +759,7 @@ void ActionManager::execCommandAction(const ActionDef &actionDef,
 	  eventInfo.time.tv_sec, eventInfo.time.tv_nsec));
 	argVect.push_back(StringUtils::sprintf("%" PRIu64, eventInfo.id));
 	argVect.push_back(StringUtils::sprintf("%d", eventInfo.type));
-	argVect.push_back(StringUtils::sprintf("%" PRIu64,
-	   eventInfo.triggerId));
+	argVect.push_back(eventInfo.triggerId);
 	argVect.push_back(StringUtils::sprintf("%d", eventInfo.status));
 	argVect.push_back(StringUtils::sprintf("%d", eventInfo.severity));
 
@@ -1541,13 +1540,13 @@ void ActionManager::postProcSpawnFailure(
 	  "%s, action ID: %d, log ID: %" PRIu64 ", "
 	  "server ID: %d, event ID: %" PRIu64 ", "
 	  "time: %ld.%09ld, type: %s, "
-	  "trigger ID: %" PRIu64 ", status: %s, severity: %s, "
+	  "trigger ID: %" FMT_TRIGGER_ID ", status: %s, severity: %s, "
 	  "host ID: %" FMT_LOCAL_HOST_ID "\n",
 	  error->message, actionDef.id, actorInfo->logId,
 	  eventInfo.serverId, eventInfo.id,
 	  eventInfo.time.tv_sec, eventInfo.time.tv_nsec,
 	  LabelUtils::getEventTypeLabel(eventInfo.type).c_str(),
-	  eventInfo.triggerId,
+	  eventInfo.triggerId.c_str(),
 	  LabelUtils::getTriggerStatusLabel(eventInfo.status).c_str(),
 	  LabelUtils::getTriggerSeverityLabel(eventInfo.severity).c_str(),
 	  eventInfo.hostIdInServer.c_str());
@@ -1573,8 +1572,9 @@ void ActionManager::fillTriggerInfoInEventInfo(EventInfo &eventInfo)
 		eventInfo.hostName = triggerInfo.hostName;
 		eventInfo.brief    = triggerInfo.brief;
 	} else {
-		MLPL_ERR("Not found: svID: %" PRIu32 ", trigID: %" PRIu64 "\n",
-		         eventInfo.serverId, eventInfo.triggerId);
+		MLPL_ERR("Not found: svID: %" PRIu32 ", "
+		         "trigID: %" FMT_TRIGGER_ID "\n",
+		         eventInfo.serverId, eventInfo.triggerId.c_str());
 		eventInfo.severity = TRIGGER_SEVERITY_UNKNOWN;
 		eventInfo.globalHostId = INVALID_HOST_ID;
 		eventInfo.hostIdInServer.clear();

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -156,6 +156,7 @@ struct ConfigManager::Impl {
 	  copyOnDemand(UNKNOWN),
 	  faceRestPort(0),
 	  pidFilePath(DEFAULT_PID_FILE_PATH),
+	  loadOldEvents(false),
 	  faceRestNumWorkers(0)
 	{
 	}

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -111,8 +111,8 @@ static const ColumnDef COLUMN_DEF_ACTIONS[] = {
 	NULL,                              // defaultValue
 }, {
 	"trigger_id",                      // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	true,                              // canBeNull
 	SQL_KEY_IDX,                       // keyType
@@ -1131,7 +1131,7 @@ string ActionsQueryOption::Impl::makeConditionTemplate(void)
 	const ColumnDef &colDefTrigId =
 	   COLUMN_DEF_ACTIONS[IDX_ACTIONS_TRIGGER_ID];
 	cond += StringUtils::sprintf(
-	  "((%s IS NULL) OR (%s=%%" PRIu64 "))",
+	  "((%s IS NULL) OR (%s=%%s))",
 	  colDefTrigId.columnName, colDefTrigId.columnName);
 	cond += " AND ";
 
@@ -1308,7 +1308,7 @@ string ActionsQueryOption::getCondition(void) const
 	                       eventInfo->serverId,
 	                       rhs(triggerInfo.hostIdInServer),
 	                       rhs(hostgroupIdList),
-	                       eventInfo->triggerId,
+	                       rhs(eventInfo->triggerId),
 	                       eventInfo->status,
 	                       triggerInfo.severity,
 	                       triggerInfo.severity);

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -57,7 +57,7 @@ struct ActionCondition {
 	ServerIdType serverId;
 	LocalHostIdType hostIdInServer;
 	uint64_t hostgroupId;
-	uint64_t triggerId;
+	TriggerIdType triggerId;
 	int      triggerStatus;
 	int      triggerSeverity;
 	ComparisonType triggerSeverityCompType;
@@ -71,7 +71,7 @@ struct ActionCondition {
 
 	ActionCondition(uint32_t _enableBits, const ServerIdType &_serverId,
 	                const LocalHostIdType _hostIdInServer,
-	                uint64_t _hostgroupId, uint64_t _triggerId,
+	                uint64_t _hostgroupId, const TriggerIdType & _triggerId,
 	                int _triggerStatus, int _triggerSeverity,
 	                ComparisonType _triggerSeverityCompType)
 	: enableBits(_enableBits),

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1763,8 +1763,9 @@ void DBTablesMonitoring::updateTrigger(const TriggerInfoList &triggerInfoList,
 		TriggerIdInfoMapIterator currTriggerItr = validTriggerId.find(newTriggerInfo.id);
 		if (currTriggerItr != validTriggerId.end()) {
 			const TriggerInfo &currTrigger = currTriggerItr->second;
+			const TriggerValidity validity = currTrigger.validity;
 			validTriggerId.erase(currTriggerItr);
-			if (currTrigger.validity == TRIGGER_VALID)
+			if (validity == TRIGGER_VALID)
 				continue;
 		}
 		updateTriggerList.push_back(newTriggerInfo);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -55,6 +55,8 @@ const char *DBTablesMonitoring::TABLE_NAME_INCIDENTS  = "incidents";
 // -> 1.0
 //   * remove IDX_TRIGGERS_HOST_ID,
 //   * add IDX_TRIGGERS_GLOBAL_HOST_ID and IDX_TRIGGERS_HOST_ID_IN_SERVER
+//   * triggers.id -> VARCHAR
+//   * events.trigger_id -> VARCHAR
 const int DBTablesMonitoring::MONITORING_DB_VERSION =
   DBTables::Version::getPackedVer(0, 1, 0);
 
@@ -100,8 +102,8 @@ static const ColumnDef COLUMN_DEF_TRIGGERS[] = {
 	NULL,                              // defaultValue
 }, {
 	"id",                              // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_IDX,                       // keyType
@@ -291,8 +293,8 @@ static const ColumnDef COLUMN_DEF_EVENTS[] = {
 	NULL,                              // defaultValue
 }, {
 	"trigger_id",                      // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_IDX,                       // keyType
@@ -807,8 +809,8 @@ static const ColumnDef COLUMN_DEF_INCIDENTS[] = {
 	NULL,                              // defaultValue
 }, {
 	"trigger_id",                      // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_IDX,                       // keyType
@@ -987,7 +989,7 @@ void initEventInfo(EventInfo &eventInfo)
 	eventInfo.time.tv_sec = 0;
 	eventInfo.time.tv_nsec = 0;
 	eventInfo.type = EVENT_TYPE_UNKNOWN;
-	eventInfo.triggerId = 0;
+	eventInfo.triggerId.clear();
 	eventInfo.status = TRIGGER_STATUS_UNKNOWN;
 	eventInfo.severity = TRIGGER_SEVERITY_UNKNOWN;
 	eventInfo.globalHostId = INVALID_HOST_ID;
@@ -1092,12 +1094,13 @@ string EventsQueryOption::getCondition(void) const
 	}
 
 	if (m_impl->triggerId != ALL_TRIGGERS) {
+		DBTermCStringProvider rhs(*getDBTermCodec());
 		if (!condition.empty())
 			condition += " AND ";
 		condition += StringUtils::sprintf(
-			"%s=%" FMT_TRIGGER_ID,
+			"%s=%s",
 			getColumnName(IDX_EVENTS_TRIGGER_ID).c_str(),
-			m_impl->triggerId);
+			rhs(m_impl->triggerId));
 	}
 
 	return condition;
@@ -1717,11 +1720,12 @@ int DBTablesMonitoring::getLastChangeTimeOfTrigger(const ServerIdType &serverId)
 	string stmt = StringUtils::sprintf("coalesce(max(%s), 0)",
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_LAST_CHANGE_TIME_SEC].columnName);
 	arg.add(stmt, COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].type);
-	arg.condition = StringUtils::sprintf("%s=%s AND %s < %" FMT_TRIGGER_ID,
+	arg.condition = StringUtils::sprintf(
+	    "%s=%s AND %s!=%d",
 	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SERVER_ID].columnName,
 	    rhs(serverId),
-	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_ID].columnName,
-	    FAILED_SELF_TRIGGER_ID_TERMINATION);
+	    COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_VALIDITY].columnName,
+	    TRIGGER_VALID_SELF_MONITORING);
 
 	getDBAgent().runTransaction(arg);
 

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -961,7 +961,8 @@ static void addHostsMap(
 }
 
 static string getTriggerBrief(
-  FaceRest::ResourceHandler *job, const ServerIdType serverId, const TriggerIdType triggerId)
+  FaceRest::ResourceHandler *job, const ServerIdType &serverId,
+  const TriggerIdType &triggerId)
 {
 	string triggerBrief;
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
@@ -981,7 +982,7 @@ static string getTriggerBrief(
 		} else {
 			MLPL_WARN("Failed to getTriggerInfo: "
 			          "%" FMT_SERVER_ID ", %" FMT_TRIGGER_ID "\n",
-			          serverId, triggerId);
+			          serverId, triggerId.c_str());
 		}
 	}
 
@@ -1005,7 +1006,7 @@ static void addTriggersIdBriefHash(
 			triggerBrief = getTriggerBrief(job,
 						       serverId,
 						       triggerId);
-		agent.startObject(StringUtils::toString(triggerId));
+		agent.startObject(triggerId);
 		agent.add("brief", triggerBrief);
 		agent.endObject();
 	}

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -799,7 +799,10 @@ void HatoholArmPluginGate::cmdHandlerGetTimeOfLastEvent(
 	HATOHOL_ASSERT(cmdBuf, "Current buffer: NULL");
 	HapiParamTimeOfLastEvent *param =
 	  getCommandBody<HapiParamTimeOfLastEvent>(*cmdBuf);
-	const TriggerIdType triggerId = LtoN(param->triggerId);
+	
+	const TriggerIdType triggerId =
+	   getString(*cmdBuf, param,
+	             param->triggerIdOffset, param->triggerIdLength);
 
 	// Make a response buffer.
 	SmartBuffer resBuf;

--- a/server/src/IncidentSender.cc
+++ b/server/src/IncidentSender.cc
@@ -329,7 +329,7 @@ string IncidentSender::buildDescription(const EventInfo &event,
 		  "Trigger ID: %" FMT_TRIGGER_ID "\n"
 		  "    Status:     \"%d (%s)\"\n"
 		  "    Severity:   \"%d (%s)\"\n",
-		  event.triggerId,
+		  event.triggerId.c_str(),
 		  event.status,
 		  LabelUtils::getTriggerStatusLabel(event.status).c_str(),
 		  event.severity,

--- a/server/src/IncidentSenderRedmine.cc
+++ b/server/src/IncidentSenderRedmine.cc
@@ -137,7 +137,7 @@ string IncidentSenderRedmine::buildURLMonitoringServerEvent(
 		  "/zabbix/tr_events.php"
 		  "?triggerid=%" FMT_TRIGGER_ID
 		  "&eventid=%" FMT_EVENT_ID,
-		  event.triggerId,
+		  event.triggerId.c_str(),
 		  event.id);
 		break;
 	}
@@ -209,7 +209,7 @@ string IncidentSenderRedmine::buildDescription(
 	    "}}\n"
 	    "\n",
 	    event.hostIdInServer.c_str(),
-	    event.triggerId,
+	    event.triggerId.c_str(),
 	    event.id);
 
 	string monitoringServerEventPage

--- a/server/src/ResidentCommunicator.cc
+++ b/server/src/ResidentCommunicator.cc
@@ -115,7 +115,8 @@ void ResidentCommunicator::setNotifyEventBody(
 	const size_t lenNullTerm = 1;
 	const uint32_t bodySize =
 	  RESIDENT_PROTO_EVENT_BODY_BASE_LEN +
-	  eventInfo.hostIdInServer.size() + lenNullTerm;
+	  eventInfo.hostIdInServer.size() + lenNullTerm +
+	  eventInfo.triggerId.size()      + lenNullTerm;
 	size_t bodyIdx =
 	  RESIDENT_PROTO_HEADER_LEN + RESIDENT_PROTO_EVENT_BODY_BASE_LEN;
 	setHeader(bodySize,
@@ -127,7 +128,7 @@ void ResidentCommunicator::setNotifyEventBody(
 	m_impl->sbuf.add32(eventInfo.time.tv_nsec);
 	m_impl->sbuf.add64(eventInfo.id); // Event ID
 	m_impl->sbuf.add16(eventInfo.type);
-	m_impl->sbuf.add64(eventInfo.triggerId);
+	bodyIdx = m_impl->sbuf.insertString(eventInfo.triggerId, bodyIdx);
 	m_impl->sbuf.add16(eventInfo.status);
 	m_impl->sbuf.add16(eventInfo.severity);
 	m_impl->sbuf.add(sessionId.c_str(), HATOHOL_SESSION_ID_LEN);

--- a/server/src/ResidentProtocol.h
+++ b/server/src/ResidentProtocol.h
@@ -161,7 +161,7 @@ struct ResidentNotifyEventArg {
 	timespec time;
 	uint64_t eventId;
 	uint16_t eventType;
-	uint64_t triggerId;
+	const char *triggerId;
 	uint16_t triggerStatus;
 	uint16_t triggerSeverity;
 	char sessionId[HATOHOL_SESSION_ID_LEN+1]; // +1 means NULL terminator

--- a/server/src/RestResourceAction.cc
+++ b/server/src/RestResourceAction.cc
@@ -121,8 +121,7 @@ void RestResourceAction::handleGet(void)
 		  agent, cond, "hostgroupId", ACTCOND_HOST_GROUP_ID,
 		   cond.hostgroupId);
 		setActionCondition<std::string>(
-		  agent, cond, "triggerId", ACTCOND_TRIGGER_ID,
-		  StringUtils::toString(cond.triggerId));
+		  agent, cond, "triggerId", ACTCOND_TRIGGER_ID, cond.triggerId);
 		setActionCondition<uint32_t>(
 		  agent, cond, "triggerStatus", ACTCOND_TRIGGER_STATUS,
 		  cond.triggerStatus);
@@ -232,8 +231,9 @@ static HatoholError parseActionParameter(FaceRest::ResourceHandler *job,
 		cond.enable(ACTCOND_HOST_GROUP_ID);
 
 	// triggerId
-	succeeded = getParamWithErrorReply<uint64_t>(
-	              job, "triggerId", "%" PRIu64, cond.triggerId, &exist);
+	succeeded = getParamWithErrorReply<TriggerIdType>(
+	              job, "triggerId", "%" FMT_TRIGGER_ID,
+	              cond.triggerId, &exist);
 	if (!succeeded)
 		return HatoholError(HTERR_NOT_FOUND_PARAMETER, "triggerId");
 	if (exist)

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -557,7 +557,7 @@ void RestResourceHost::handlerGetTrigger(void)
 		                                      extendedInfoValue);
 
 		agent.startObject();
-		agent.add("id",       StringUtils::toString(triggerInfo.id));
+		agent.add("id",       triggerInfo.id);
 		agent.add("status",   triggerInfo.status);
 		agent.add("severity", triggerInfo.severity);
 		agent.add("lastChangeTime",
@@ -663,7 +663,7 @@ void RestResourceHost::handlerGetEvent(void)
 		agent.add("serverId",  eventInfo.serverId);
 		agent.add("time",      eventInfo.time.tv_sec);
 		agent.add("type",      eventInfo.type);
-		agent.add("triggerId", StringUtils::toString(eventInfo.triggerId));
+		agent.add("triggerId", eventInfo.triggerId);
 		agent.add("status",    eventInfo.status);
 		agent.add("severity",  eventInfo.severity);
 		agent.add("hostId",    eventInfo.hostIdInServer);

--- a/server/src/hatoholResidentYard.cc
+++ b/server/src/hatoholResidentYard.cc
@@ -106,7 +106,8 @@ static void gotNotifyEventBodyCb(GIOStatus stat, mlpl::SmartBuffer &sbuf,
 	arg.time.tv_nsec    = *sbuf.getPointerAndIncIndex<uint32_t>();
 	arg.eventId         = *sbuf.getPointerAndIncIndex<uint64_t>();
 	arg.eventType       = *sbuf.getPointerAndIncIndex<uint16_t>();
-	arg.triggerId       = *sbuf.getPointerAndIncIndex<uint64_t>();
+	const string triggerId = sbuf.extractStringAndIncIndex();
+	arg.triggerId       = triggerId.c_str();
 	arg.triggerStatus   = *sbuf.getPointerAndIncIndex<uint16_t>();
 	arg.triggerSeverity = *sbuf.getPointerAndIncIndex<uint16_t>();
 	memcpy(arg.sessionId, sbuf.getPointer<char>(), HATOHOL_SESSION_ID_LEN);

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -205,7 +205,7 @@ size_t NumTestServerStatus = ARRAY_SIZE(testServerStatus);
 TriggerInfo testTriggerInfo[] =
 {{
 	1,                        // serverId
-	1,                        // id
+	"1",                      // id
 	TRIGGER_STATUS_OK,        // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957197,0},           // lastChangeTime
@@ -217,7 +217,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	1,                        // serverId
-	2,                        // id
+	"2",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957198,0},           // lastChangeTime
@@ -229,7 +229,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	1,                        // serverId
-	3,                        // id
+	"3",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957117,0},           // lastChangeTime
@@ -241,7 +241,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	1,                        // serverId
-	4,                        // id
+	"4",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957197,0},           // lastChangeTime
@@ -253,7 +253,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	1,                        // serverId
-	5,                        // id
+	"5",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957198,0},           // lastChangeTime
@@ -265,7 +265,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	3,                        // serverId
-	2,                        // id
+	"2",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
 	{1362957200,0},           // lastChangeTime
@@ -277,7 +277,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	3,                        // serverId
-	3,                        // id
+	"3",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362951000,0},           // lastChangeTime
@@ -289,7 +289,7 @@ TriggerInfo testTriggerInfo[] =
 	TRIGGER_VALID,          // validity
 },{
 	2,                        // serverId
-	0xfedcba987654321,        // id
+	"1147797409030816545", // 0xfedcba987654321 // id
 	TRIGGER_STATUS_OK,        // status
 	TRIGGER_SEVERITY_WARNING, // severity
 	{1362951000,0},           // lastChangeTime
@@ -302,7 +302,7 @@ TriggerInfo testTriggerInfo[] =
 },{
 	// This entry is used for testHatoholArmPluginGate.
 	12345,                    // serverId
-	2468,                     // id
+	"2468",                   // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957117,0},           // lastChangeTime
@@ -315,7 +315,7 @@ TriggerInfo testTriggerInfo[] =
 },{
 	// This entry is for tests with a defunct server
 	defunctServerId1,         // serverId
-	3,                        // id
+	"3",                      // id
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	{1362957117,0},           // lastChangeTime
@@ -339,7 +339,7 @@ const EventInfo testEventInfo[] = {
 	1,                        // id
 	{1362957200,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	2,                        // triggerId
+	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
 	4,                        // globalHostId,
@@ -352,7 +352,7 @@ const EventInfo testEventInfo[] = {
 	2,                        // id
 	{1362958000,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	3,                        // triggerId
+	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	6,                        // globalHostId,
@@ -365,7 +365,7 @@ const EventInfo testEventInfo[] = {
 	1,                        // id
 	{1363123456,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	2,                        // triggerId
+	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	1,                        // globalHostId,
@@ -378,7 +378,7 @@ const EventInfo testEventInfo[] = {
 	2,                        // id
 	{1378900022,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	1,                        // triggerId
+	"1",                      // triggerId
 	TRIGGER_STATUS_OK,        // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	1,                        // globalHostId,
@@ -391,7 +391,7 @@ const EventInfo testEventInfo[] = {
 	3,                        // id
 	{1389123457,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	3,                        // triggerId
+	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	2,                        // globalHostId,
@@ -404,7 +404,7 @@ const EventInfo testEventInfo[] = {
 	3,                        // id
 	{1390000000,123456789},   // time
 	EVENT_TYPE_BAD,           // type
-	2,                        // triggerId
+	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
 	4,                        // globalHostId,
@@ -418,7 +418,7 @@ const EventInfo testEventInfo[] = {
 	1,                        // id
 	trigInfoDefunctSv1.lastChangeTime, // time
 	EVENT_TYPE_BAD,                    // type
-	3,                                 // triggerId
+	"3",                               // triggerId
 	trigInfoDefunctSv1.status,         // status
 	trigInfoDefunctSv1.severity,       // severity
 	trigInfoDefunctSv1.globalHostId,   // globalHostId,
@@ -439,7 +439,7 @@ EventInfo testDupEventInfo[] = {
 	DISCONNECT_SERVER_EVENT_ID, // id
 	{1362957200,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	2,                        // triggerId
+	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
 	4,                        // globalHostId,
@@ -452,7 +452,7 @@ EventInfo testDupEventInfo[] = {
 	DISCONNECT_SERVER_EVENT_ID, // id
 	{1362951000,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	3,                        // triggerId
+	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	6,                        // globalHostId,
@@ -465,7 +465,7 @@ EventInfo testDupEventInfo[] = {
 	DISCONNECT_SERVER_EVENT_ID, // id
 	{1362951000,0},           // time
 	EVENT_TYPE_GOOD,          // type
-	3,                        // triggerId
+	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
 	6,                        // globalHostId,
@@ -538,7 +538,7 @@ ActionDef testActionDef[] = {
 	  1,                        // serverId
 	  "10",                     // hostIdInServer
 	  5,                        // hostgroupId
-	  3,                        // triggerId
+	  "3",                      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_INFO,    // triggerSeverity
 	  CMP_INVALID               // triggerSeverityCompType;
@@ -556,7 +556,7 @@ ActionDef testActionDef[] = {
 	  0,                        // serverId
 	  "0",                      // hostIdInServer
 	  0,                        // hostgroupId
-	  0x12345,                  // triggerId
+	  "74565", // 0x12345,      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
 	  CMP_EQ_GT                 // triggerSeverityCompType;
@@ -574,7 +574,7 @@ ActionDef testActionDef[] = {
 	  100,                      // serverIdInServer
 	  "9223372036854775807",    // hostIdInServer (0x7fffffffffffffff)
 	  0x8000000000000000,       // hostgroupId
-	  0xfedcba9876543210,       // triggerId
+	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
 	  CMP_EQ                    // triggerSeverityCompType;
@@ -593,7 +593,7 @@ ActionDef testActionDef[] = {
 	  2,                        // serverId
 	  "9920249034889494527",    // hostIdInServer
 	  0x8000000000000000,       // hostGroupId
-	  0xfedcba9876543210,       // triggerId
+	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
 	  CMP_EQ_GT                 // triggerSeverityCompType;
@@ -612,7 +612,7 @@ ActionDef testActionDef[] = {
 	  100001,                   // serverId
 	  "100001",                 // hostIdInServer
 	  100001,                   // hostgroupId
-	  0x12345,                  // triggerId
+	  "74565", // 0x12345,      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
 	  CMP_EQ                    // triggerSeverityCompType;
@@ -630,7 +630,7 @@ ActionDef testActionDef[] = {
 	  101,                      // serverId
 	  "9223372036854775807",    // hostIdInServer (0x7fffffffffffffff)
 	  0x8000000000000000,       // hostgroupId
-	  0xfedcba9876543210,       // triggerId
+	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
 	  CMP_EQ                    // triggerSeverityCompType;
@@ -648,7 +648,7 @@ ActionDef testActionDef[] = {
 	  1,                        // serverId
 	  "10",                     // hostIdInServer
 	  5,                        // hostgroupId
-	  0,                        // triggerId
+	  "0",                      // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
 	  CMP_INVALID               // triggerSeverityCompType;
@@ -672,7 +672,7 @@ ActionDef testUpdateActionDef = {
 		2,                        // serverId
 		"1001",                   // hostIdInServer
 		2001,                     // hostGroupId
-		14000,                    // triggerId
+		"14000",                  // triggerId
 		TRIGGER_STATUS_OK,        // triggerStatus
 		TRIGGER_SEVERITY_WARNING, // triggerSeverity
 		CMP_EQ_GT                 // triggerSeverityCompType;
@@ -980,7 +980,7 @@ IncidentInfo testIncidentInfo[] = {
 	3,                        // trackerId
 	1,                        // serverId
 	1,                        // eventId
-	2,                        // triggerId
+	"2",                      // triggerId
 	"100",                    // identifier
 	"http://localhost:44444/issues/100", // location
 	"New",                    // status
@@ -996,7 +996,7 @@ IncidentInfo testIncidentInfo[] = {
 	3,                        // trackerId
 	1,                        // serverId
 	2,                        // eventId
-	1,                        // triggerId
+	"1",                      // triggerId
 	"101",                    // identifier
 	"http://localhost:44444/issues/101", // location
 	"New",                    // status
@@ -1012,7 +1012,7 @@ IncidentInfo testIncidentInfo[] = {
 	5,                        // trackerId
 	2,                        // serverId
 	2,                        // eventId
-	3,                        // triggerId
+	"3",                      // triggerId
 	"123",                    // identifier
 	"http://localhost/issues/123", // location
 	"New",                    // status
@@ -1342,8 +1342,8 @@ const TriggerInfo &searchTestTriggerInfo(const EventInfo &eventInfo)
 			continue;
 		return trigInfo;
 	}
-	cut_fail("Not found: server ID: %u, trigger ID: %" PRIu64,
-	         eventInfo.serverId, eventInfo.triggerId);
+	cut_fail("Not found: server ID: %u, trigger ID: %" FMT_TRIGGER_ID,
+	         eventInfo.serverId, eventInfo.triggerId.c_str());
 	return *(new TriggerInfo()); // never exectuted, just to pass build
 }
 
@@ -1409,7 +1409,7 @@ SmartTime findTimeOfLastEvent(
 }
 
 void getTestTriggersIndexes(
-  map<ServerIdType, map<uint64_t, size_t> > &indexMap,
+  ServerIdTriggerIdIdxMap &indexMap,
   const ServerIdType &serverId, const LocalHostIdType &hostIdInServer)
 {
 	for (size_t i = 0; i < NumTestTriggerInfo; i++) {

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -116,8 +116,15 @@ extern const size_t NumTestHostgroupMember;
  * @param hostIdInServer
  * A host ID in a server. ALL_LOCAL_HOSTS can be specified.
  */
+
+typedef std::map<TriggerIdType, size_t> TriggerIdIdxMap;
+typedef TriggerIdIdxMap::iterator       TriggerIdIdxMapIterator;
+
+typedef std::map<ServerIdType, TriggerIdIdxMap> ServerIdTriggerIdIdxMap;
+typedef ServerIdTriggerIdIdxMap::iterator       ServerIdTriggerIdIdxMapIterator;
+
 void getTestTriggersIndexes(
-  std::map<ServerIdType, std::map<uint64_t, size_t> > &indexMap,
+  ServerIdTriggerIdIdxMap &indexMap,
   const ServerIdType &serverId, const LocalHostIdType &hostIdInServer);
 size_t getNumberOfTestTriggers(
   const ServerIdType &serverId,

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -464,10 +464,10 @@ string makeTriggerOutput(const TriggerInfo &triggerInfo)
 {
 	string expectedOut =
 	  StringUtils::sprintf(
-	    "%" FMT_SERVER_ID "|%" PRIu64 "|%d|%d|%ld|%lu|"
+	    "%" FMT_SERVER_ID "|%" FMT_TRIGGER_ID "|%d|%d|%ld|%lu|"
 	    "%" FMT_HOST_ID "|%" FMT_LOCAL_HOST_ID "|%s|%s|%s|%d\n",
 	    triggerInfo.serverId,
-	    triggerInfo.id,
+	    triggerInfo.id.c_str(),
 	    triggerInfo.status, triggerInfo.severity,
 	    triggerInfo.lastChangeTime.tv_sec,
 	    triggerInfo.lastChangeTime.tv_nsec,
@@ -488,7 +488,7 @@ string makeEventOutput(const EventInfo &eventInfo)
 	    "|%d|%u|%" FMT_HOST_ID "|%" FMT_LOCAL_HOST_ID "|%s|%s\n",
 	    eventInfo.serverId, eventInfo.id,
 	    eventInfo.time.tv_sec, eventInfo.time.tv_nsec,
-	    eventInfo.type, eventInfo.triggerId,
+	    eventInfo.type, eventInfo.triggerId.c_str(),
 	    eventInfo.status, eventInfo.severity,
 	    eventInfo.globalHostId,
 	    eventInfo.hostIdInServer.c_str(),
@@ -508,7 +508,7 @@ string makeIncidentOutput(const IncidentInfo &incidentInfo)
 	    incidentInfo.trackerId,
 	    incidentInfo.serverId,
 	    incidentInfo.eventId,
-	    incidentInfo.triggerId,
+	    incidentInfo.triggerId.c_str(),
 	    incidentInfo.identifier.c_str(),
 	    incidentInfo.location.c_str(),
 	    incidentInfo.status.c_str(),

--- a/server/test/ZabbixAPIEmulator.cc
+++ b/server/test/ZabbixAPIEmulator.cc
@@ -252,8 +252,10 @@ void ZabbixAPIEmulator::handlerAPI
 	}
 }
 
-bool ZabbixAPIEmulator::hasParameter
-  (APIHandlerArg &arg, const string &paramName, const string &expectedValue)
+template <typename T>
+static bool hasParameterTempl(
+  ZabbixAPIEmulator::APIHandlerArg &arg,
+  const string &paramName, const T &expectedValue)
 {
 	string request(arg.msg->request_body->data,
 	               arg.msg->request_body->length);
@@ -264,28 +266,22 @@ bool ZabbixAPIEmulator::hasParameter
 	if (!parser.startObject("params"))
 		return false;
 
-	string value;
+	T value;
 	if (!parser.read(paramName, value));
 		return false;
 	return value == expectedValue;
 }
 
-bool ZabbixAPIEmulator::hasParameter
-  (APIHandlerArg &arg, const string &paramName, const int64_t &expectedValue)
+bool ZabbixAPIEmulator::hasParameter(
+  APIHandlerArg &arg, const string &paramName, const int64_t &expectedValue)
 {
-	string request(arg.msg->request_body->data,
-	               arg.msg->request_body->length);
-	JSONParser parser(request);
-	if (parser.hasError())
-		THROW_HATOHOL_EXCEPTION("Failed to parse: %s", request.c_str());
+	return hasParameterTempl<int64_t>(arg, paramName, expectedValue);
+}
 
-	if (!parser.startObject("params"))
-		return false;
-
-	int64_t value;
-	if (!parser.read(paramName, value));
-		return false;
-	return value == expectedValue;
+bool ZabbixAPIEmulator::hasParameter(
+  APIHandlerArg &arg, const string &paramName, const string &expectedValue)
+{
+	return hasParameterTempl<string>(arg, paramName, expectedValue);
 }
 
 string ZabbixAPIEmulator::generateAuthToken(void)

--- a/server/test/ZabbixAPIEmulator.cc
+++ b/server/test/ZabbixAPIEmulator.cc
@@ -265,7 +265,8 @@ bool ZabbixAPIEmulator::hasParameter
 		return false;
 
 	string value;
-	parser.read(paramName, value);
+	if (!parser.read(paramName, value));
+		return false;
 	return value == expectedValue;
 }
 
@@ -282,7 +283,8 @@ bool ZabbixAPIEmulator::hasParameter
 		return false;
 
 	int64_t value;
-	parser.read(paramName, value);
+	if (!parser.read(paramName, value));
+		return false;
 	return value == expectedValue;
 }
 

--- a/server/test/residentTest.cc
+++ b/server/test/residentTest.cc
@@ -159,6 +159,7 @@ static uint32_t notifyEvent(ResidentNotifyEventArg *arg)
 		crash();
 	ctx.notifyEvent = *arg;
 	ctx.notifyEvent.hostIdInServer = TEST_HOST_ID_REPLY_MAGIC_CODE;
+	ctx.notifyEvent.triggerId      = TEST_TRIGGER_ID_REPLY_MAGIC_CODE;
 	ctx.countNotified++;
 	if (ctx.sendEventInfo) {
 		sendEventInfo(&ctx);

--- a/server/test/residentTest.h
+++ b/server/test/residentTest.h
@@ -33,5 +33,6 @@ static const int RESIDENT_TEST_REPLY_GET_EVENT_INFO_BODY_LEN =
 
 #define TEST_HOST_ID_STRING "Test HOST ID in server !!!"
 const char *TEST_HOST_ID_REPLY_MAGIC_CODE = (const char *)0x12345678;
+const char *TEST_TRIGGER_ID_REPLY_MAGIC_CODE = (const char *)0x122333;
 
 #endif // residentTest_h

--- a/server/test/testActionManager.cc
+++ b/server/test/testActionManager.cc
@@ -495,8 +495,7 @@ void _assertActionLogJustAfterExec(
 	  evInf.time.tv_sec, evInf.time.tv_nsec));
 	expectedArgs.push_back(StringUtils::sprintf("%" PRIu64, evInf.id));
 	expectedArgs.push_back(StringUtils::sprintf("%d", evInf.type));
-	expectedArgs.push_back(
-	  StringUtils::sprintf("%" PRIu64, evInf.triggerId));
+	expectedArgs.push_back(evInf.triggerId);
 	expectedArgs.push_back(StringUtils::sprintf("%d", evInf.status));
 	expectedArgs.push_back(StringUtils::sprintf("%d", evInf.severity));
 	getArguments(ctx, expectedArgs);
@@ -735,7 +734,8 @@ static void replyEventInfoCb(GIOStatus stat, mlpl::SmartBuffer &sbuf,
 	cppcut_assert_equal(expected.time.tv_nsec, eventArg->time.tv_nsec);
 	cppcut_assert_equal(expected.id, eventArg->eventId);
 	cppcut_assert_equal(expected.type, (EventType)eventArg->eventType);
-	cppcut_assert_equal(expected.triggerId, eventArg->triggerId);
+	cppcut_assert_equal(TEST_TRIGGER_ID_REPLY_MAGIC_CODE,
+	                    eventArg->triggerId);
 	cppcut_assert_equal(expected.status,
 	                    (TriggerStatusType)eventArg->triggerStatus);
 	cppcut_assert_equal(expected.severity,
@@ -1386,7 +1386,7 @@ void test_checkEventsWithMultipleIncidentSender(void)
 	    0,                        // serverId
 	    "",                       // hostId
 	    0,                        // hostgroupId
-	    0,                        // triggerId
+	    "",                       // triggerId
 	    TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	    TRIGGER_SEVERITY_INFO,    // triggerSeverity
 	    CMP_EQ_GT                 // triggerSeverityCompType;

--- a/server/test/testArmZabbixAPI.cc
+++ b/server/test/testArmZabbixAPI.cc
@@ -773,8 +773,22 @@ void test_sessionErrorAuthToken(void)
 
 }
 
+static void addDummyFirstEvent(void)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	EventInfo eventInfo = testEventInfo[0];
+	eventInfo.serverId = 1;
+	eventInfo.id = 0;
+	eventInfo.time.tv_sec = 0;
+	eventInfo.time.tv_nsec = 0;
+	dbMonitoring.addEventInfo(&eventInfo);
+}
+
 void test_verifyEventsObtanedBySplitWay(void)
 {
+	addDummyFirstEvent();
+
 	ArmZabbixAPITestee armZbxApiTestee(setupServer());
 	armZbxApiTestee.testOpenSession();
 
@@ -816,6 +830,8 @@ void test_oneNewEvent(void)
 // (can't get events when the first event ID is bigger than 1000)
 void test_getStubbedEventList(void)
 {
+	addDummyFirstEvent();
+
 	MonitoringServerInfo serverInfo = setupServer();
 	ArmZabbixAPITestee armZbxApiTestee(serverInfo);
 	armZbxApiTestee.testOpenSession();
@@ -830,8 +846,9 @@ void test_getStubbedEventList(void)
 	EventInfoList eventList;
 	EventsQueryOption option(USER_ID_SYSTEM);
 	dbMonitoring.getEventInfoList(eventList, option);
+	size_t actualSize = eventList.size() - 1; // subtract a dummy event
 	cppcut_assert_equal(expectedLastEventId - expectedFirstEventId + 1,
-			    static_cast<uint64_t>(eventList.size()));
+			    static_cast<uint64_t>(actualSize));
 }
 
 } // namespace testArmZabbixAPI

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -51,7 +51,8 @@ static string makeExpectedString(const ActionDef &actDef, int expectedId)
 	            StringUtils::sprintf("%" PRIu64 "|", cond.hostgroupId) :
 	            DBCONTENT_MAGIC_NULL "|";
 	expect += cond.isEnable(ACTCOND_TRIGGER_ID) ?
-	             StringUtils::sprintf("%" PRIu64 "|", cond.triggerId) :
+	             StringUtils::sprintf("%" FMT_TRIGGER_ID "|",
+	                                  cond.triggerId.c_str()) :
 	            DBCONTENT_MAGIC_NULL "|";
 	expect += cond.isEnable(ACTCOND_TRIGGER_STATUS) ?
 	            StringUtils::sprintf("%d|", cond.triggerStatus) :
@@ -767,7 +768,10 @@ static void _assertGetActionWithSeverity(
 	eventInfo.time.tv_sec  = 1378339653;
 	eventInfo.time.tv_nsec = 6889;
 	eventInfo.type      = EVENT_TYPE_BAD;
-	eventInfo.triggerId = condTarget.triggerId ? : 1;
+	if (!condTarget.triggerId.empty())
+		eventInfo.triggerId = condTarget.triggerId;
+	else
+		eventInfo.triggerId = "1";
 	eventInfo.status    = (TriggerStatusType) condTarget.triggerStatus;
 	eventInfo.severity = severity;
 	// TODO: eventInfo.globalHostId = ???
@@ -1037,12 +1041,13 @@ void test_withEventInfo(void)
 	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
 	    // test with empty hostgroups
 	    "((host_group_id IS NULL) OR host_group_id IN ('0')) AND "
-	    "((trigger_id IS NULL) OR (trigger_id=%" FMT_TRIGGER_ID ")) AND "
+	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
 	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
 	    "((trigger_severity IS NULL) OR "
 	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
 	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
-	    id, event.serverId, event.hostIdInServer.c_str(), event.triggerId,
+	    id, event.serverId, event.hostIdInServer.c_str(),
+	    event.triggerId.c_str(),
 	    event.status, event.severity, event.severity);
 	cppcut_assert_equal(expected, option.getCondition());
 }

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -378,7 +378,7 @@ void test_getTriggerInfoNotFound(void)
 	loadTestDBTriggers();
 
 	const UserIdType invalidSvId = -1;
-	const TriggerIdType invalidTrigId = -1;
+	const TriggerIdType invalidTrigId;
 	TriggerInfo triggerInfo;
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
 	TriggersQueryOption option(invalidSvId);
@@ -743,7 +743,7 @@ void test_getTimeOfLastEventWithTriggerId(void)
 
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
 	const ServerIdType serverId = 3;
-	const TriggerIdType triggerId = 3;
+	const TriggerIdType triggerId = "3";
 	cppcut_assert_equal(
 	  findTimeOfLastEvent(serverId, triggerId),
 	  dbMonitoring.getTimeOfLastEvent(serverId, triggerId));

--- a/server/test/testFaceRestAction.cc
+++ b/server/test/testFaceRestAction.cc
@@ -133,7 +133,7 @@ static void _assertActions(const string &path, const string &callbackName = "",
 		  uint64_t, cond.hostgroupId);
 		asssertActionCondition(
 		  g_parser, cond, "triggerId", ACTCOND_TRIGGER_ID,
-		  string, StringUtils::toString(cond.triggerId));
+		  string, cond.triggerId);
 		asssertActionCondition(
 		  g_parser, cond, "triggerStatus", ACTCOND_TRIGGER_STATUS,
 		  uint32_t, cond.triggerStatus);

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -176,9 +176,9 @@ static void _assertTriggers(
 	DataQueryContextPtr dqCtxPtr(new DataQueryContext(arg.userId), false);
 
 	// calculate the expected test triggers
-	map<ServerIdType, map<uint64_t, size_t> > indexMap;
-	map<ServerIdType, map<uint64_t, size_t> >::iterator indexMapIt;
-	map<uint64_t, size_t>::iterator trigIdIdxIt;
+	ServerIdTriggerIdIdxMap         indexMap;
+	ServerIdTriggerIdIdxMapIterator indexMapIt;
+	TriggerIdIdxMapIterator         trigIdIdxIt;
 	getTestTriggersIndexes(indexMap, serverId, hostIdInServer);
 	size_t expectedNumTrig = 0;
 	indexMapIt = indexMap.begin();
@@ -217,10 +217,8 @@ static void _assertTriggers(
 		const ServerIdType actSvId =
 		  static_cast<ServerIdType>(var64);
 
-		string trigIdString;
-		cppcut_assert_equal(true, parser->read("id", trigIdString));
-		uint64_t actTrigId = StringUtils::toUint64(trigIdString);
-
+		string actTrigId;
+		cppcut_assert_equal(true, parser->read("id", actTrigId));
 		trigIdIdxIt = indexMap[actSvId].find(actTrigId);
 		cppcut_assert_equal(
 		  true, trigIdIdxIt != indexMap[actSvId].end());
@@ -277,7 +275,7 @@ static void _assertEvents(const string &path, const string &callbackName = "")
 		assertValueInParser(parser, "serverId", eventInfo.serverId);
 		assertValueInParser(parser, "time", eventInfo.time);
 		assertValueInParser(parser, "type", eventInfo.type);
-		assertValueInParser(parser, "triggerId", StringUtils::toString(eventInfo.triggerId));
+		assertValueInParser(parser, "triggerId", (eventInfo.triggerId));
 		assertValueInParser(parser, "status",    eventInfo.status);
 		assertValueInParser(parser, "severity",  eventInfo.severity);
 		assertValueInParser(parser, "hostId",    eventInfo.hostIdInServer);

--- a/server/test/testFaceRestNoInit.cc
+++ b/server/test/testFaceRestNoInit.cc
@@ -32,6 +32,8 @@ using namespace mlpl;
 // ---------------------------------------------------------------------------
 namespace testFaceRestNoInit {
 
+static const char *FORCE_EMPTY_STRING = "#__EMPTY__";
+
 class TestFaceRestNoInit : public RestResourceHost {
 public:
 	static HatoholError callParseEventParameter(
@@ -68,6 +70,8 @@ void _assertParseEventParameterTempl(
 	string expectStr;
 	if (forceValueStr.empty())
 		expectStr = format<PARAM_TYPE>(expectValue, fmt);
+	else if (forceValueStr == FORCE_EMPTY_STRING)
+		expectStr = "";
 	else
 		expectStr = forceValueStr;
 	g_hash_table_insert(query,
@@ -480,16 +484,15 @@ void test_parseEventParameterNoTriggerId(void)
 
 void test_parseEventParameterTriggerId(void)
 {
-	TriggerIdType triggerId = 3;
+	TriggerIdType triggerId = "3";
 	assertParseEventParameterTriggerId(triggerId);
 }
 
 void test_parseEventParameterInvalidTriggerId(void)
 {
-	TriggerIdType triggerId = 3;
+	TriggerIdType triggerId = "3";
 	assertParseEventParameterTriggerId(
-	  triggerId, "problem",
-	  HTERR_INVALID_PARAMETER);
+	  triggerId, FORCE_EMPTY_STRING, HTERR_INVALID_PARAMETER);
 }
 
 } // namespace testFaceRestNoInit

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -219,10 +219,10 @@ void data_triggersQueryOptionWithTargetId(void)
 void test_triggersQueryOptionWithTargetId(gconstpointer data)
 {
 	TriggersQueryOption option(USER_ID_SYSTEM);
-	TriggerIdType expectedId = 634;
+	TriggerIdType expectedId = "634";
 	option.setTargetId(expectedId);
 	string expected = StringUtils::sprintf(
-		"triggers.id=%" FMT_TRIGGER_ID, expectedId);
+		"triggers.id='%" FMT_TRIGGER_ID "'", expectedId.c_str());
 	fixupForFilteringDefunctServer(data, expected, option);
 	cppcut_assert_equal(expectedId, option.getTargetId());
 	cppcut_assert_equal(expected, option.getCondition());

--- a/server/test/testIncidentSenderRedmine.cc
+++ b/server/test/testIncidentSenderRedmine.cc
@@ -162,7 +162,7 @@ string expectedJSON(const EventInfo &event, const IncidentTrackerInfo &tracker)
 	    LabelUtils::getTriggerSeverityLabel(event.severity).c_str(),
 	    server.id,
 	    event.hostIdInServer.c_str(),
-	    event.triggerId,
+	    event.triggerId.c_str(),
 	    event.id,
 	    eventsURL.c_str());
 	return expected;

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -46,10 +46,11 @@ static const string triggerSeverityToString(TriggerSeverityType type)
 static string dumpTriggerInfo(const TriggerInfo &info)
 {
 	return StringUtils::sprintf(
-		"%" PRIu32 "|%" PRIu64 "|%s|%s|%lu|%ld|%" FMT_LOCAL_HOST_ID
+		"%" FMT_SERVER_ID "|%" FMT_TRIGGER_ID "|%s|%s"
+		"|%lu|%ld|%" FMT_LOCAL_HOST_ID
 		"|%s|%s\n",
 		info.serverId,
-		info.id,
+		info.id.c_str(),
 		triggerStatusToString(info.status).c_str(),
 		triggerSeverityToString(info.severity).c_str(),
 		info.lastChangeTime.tv_sec,


### PR DESCRIPTION
This change is also for supporting a variety of monitoring systems including OpenStack's ceilometer.