### PR TITLE
Fix invalid access in the parameter check.

### DIFF
--- a/server/test/ZabbixAPIEmulator.cc
+++ b/server/test/ZabbixAPIEmulator.cc
@@ -252,8 +252,10 @@ void ZabbixAPIEmulator::handlerAPI
 	}
 }
 
-bool ZabbixAPIEmulator::hasParameter
-  (APIHandlerArg &arg, const string &paramName, const string &expectedValue)
+template <typename T>
+static bool hasParameterTempl(
+  ZabbixAPIEmulator::APIHandlerArg &arg,
+  const string &paramName, const T &expectedValue)
 {
 	string request(arg.msg->request_body->data,
 	               arg.msg->request_body->length);
@@ -264,26 +266,21 @@ bool ZabbixAPIEmulator::hasParameter
 	if (!parser.startObject("params"))
 		return false;
 
-	string value;
+	T value;
 	parser.read(paramName, value);
 	return value == expectedValue;
 }
 
-bool ZabbixAPIEmulator::hasParameter
-  (APIHandlerArg &arg, const string &paramName, const int64_t &expectedValue)
+bool ZabbixAPIEmulator::hasParameter(
+  APIHandlerArg &arg, const string &paramName, const string &expectedValue)
 {
-	string request(arg.msg->request_body->data,
-	               arg.msg->request_body->length);
-	JSONParser parser(request);
-	if (parser.hasError())
-		THROW_HATOHOL_EXCEPTION("Failed to parse: %s", request.c_str());
+	return hasParameterTempl<string>(arg, paramName, expectedValue);
+}
 
-	if (!parser.startObject("params"))
-		return false;
-
-	int64_t value;
-	parser.read(paramName, value);
-	return value == expectedValue;
+bool ZabbixAPIEmulator::hasParameter(
+  APIHandlerArg &arg, const string &paramName, const int64_t &expectedValue)
+{
+	return hasParameterTempl<int64_t>(arg, paramName, expectedValue);
 }
 
 string ZabbixAPIEmulator::generateAuthToken(void)

--- a/server/test/ZabbixAPIEmulator.cc
+++ b/server/test/ZabbixAPIEmulator.cc
@@ -267,7 +267,8 @@ static bool hasParameterTempl(
 		return false;
 
 	T value;
-	parser.read(paramName, value);
+	if (!parser.read(paramName, value))
+		return false;
 	return value == expectedValue;
 }
 


### PR DESCRIPTION
If the targert paramter doesn't exist, 'value' that is not initialized
is use the comparison.