### PR TITLE
[test][ConfigManager] Don't load the config file after calling setupTestDB()

### DIFF
--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -375,12 +375,14 @@ bool ConfigManager::parseCommandLine(gint *argc, gchar ***argv,
 	return true;
 }
 
-void ConfigManager::reset(const CommandLineOptions *cmdLineOpts)
+void ConfigManager::reset(const CommandLineOptions *cmdLineOpts,
+			  bool loadConfigFile)
 {
 	delete Impl::instance;
 	Impl::instance = NULL;
 	ConfigManager *confMgr = getInstance();
-	confMgr->loadConfFile();
+	if (loadConfigFile)
+		confMgr->loadConfFile();
 
 	confMgr->m_impl->actionCommandDirectory =
 	  StringUtils::sprintf("%s/%s/action", LIBEXECDIR, PACKAGE);

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -68,7 +68,8 @@ public:
 	static bool parseCommandLine(gint *argc, gchar ***argv,
 	                             CommandLineOptions *cmdLineOpt);
 
-	static void reset(const CommandLineOptions *cmdLineOpt = NULL);
+	static void reset(const CommandLineOptions *cmdLineOpt = NULL,
+			  bool loadConfigFile = true);
 
 	void getTargetServers(MonitoringServerInfoList &monitoringServers,
 	                      ServerQueryOption &option);

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -1442,7 +1442,8 @@ bool CommandArgHelper::activate(void)
 	const bool succeeded =
 	  ConfigManager::parseCommandLine(&argc, (gchar ***)&argv,
 	                                  &cmdLineOpts);
-	ConfigManager::reset(&cmdLineOpts);
+	bool loadConfigFile = true;
+	ConfigManager::reset(&cmdLineOpts, !loadConfigFile);
 	return succeeded;
 }
 


### PR DESCRIPTION
Otherwise some tests will fail if the config file is already
installed.