### PR TITLE
[testFaceRestHost] Fix invalid memory access in test_overview()

### DIFF
--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -199,6 +199,15 @@ MonitoringServerStatus testServerStatus[] =
 },{
 	3,                        // id
 	1.3,                      // nvps
+},{
+	4,                        // id
+	10.4,                     // nvps
+},{
+	211,                      // id
+	10.5,                     // nvps
+},{
+	222,                      // id
+	0.00051234,               // nvps
 }};
 size_t NumTestServerStatus = ARRAY_SIZE(testServerStatus);
 

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -484,8 +484,12 @@ static void _assertOverviewInParser(JSONParser *parser, RequestArg &arg)
 				    getNumberOfTestTriggers(svInfo.id));
 		assertValueInParser(parser, "numberOfUsers", 0);
 		assertValueInParser(parser, "numberOfOnlineUsers", 0);
-		MonitoringServerStatus &serverStatus = testServerStatus[i];
-		string nvps = StringUtils::sprintf("%.2f", serverStatus.nvps);
+		string nvps = "0.00";
+		if (i < NumTestServerStatus) {
+			MonitoringServerStatus &serverStatus
+			  = testServerStatus[i];
+			nvps = StringUtils::sprintf("%.2f", serverStatus.nvps);
+		}
 		assertValueInParser(parser, "numberOfMonitoredItemsPerSecond", nvps);
 		assertHostgroupsInParser(parser, svInfo.id, hostgroupIdSet);
 		assertSystemStatusInParser(parser, svInfo.id, hostgroupIdSet);


### PR DESCRIPTION
Number of testServerInfo & testServerStatus are mismatched.