### PR TITLE
[FaceRest] Avoid an invalid memory access on a condition.

### DIFF
--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -970,6 +970,12 @@ static string getTriggerBrief(
 	triggersQueryOption.setTargetServerId(serverId);
 	triggersQueryOption.setTargetId(triggerId);
 	dataStore->getTriggerList(triggerInfoList, triggersQueryOption);
+	if (triggerInfoList.empty()) {
+		MLPL_WARN("Failed to getTriggerInfo (Not found trigger): "
+		          "%" FMT_SERVER_ID ", %" FMT_TRIGGER_ID "\n",
+		          serverId, triggerId);
+		return "";
+	}
 
 	TriggerInfoListIterator it = triggerInfoList.begin();
 	TriggerInfo &firstTriggerInfo = *it;

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -309,6 +309,18 @@ TriggerInfo testTriggerInfo[] =
 	"",                       // extendedInfo
 	TRIGGER_VALID,          // validity
 },{
+	2,                        // serverId
+	0xfedcba9876543210,       // id
+	TRIGGER_STATUS_OK,        // status
+	TRIGGER_SEVERITY_WARNING, // severity
+	{1362951234,0},           // lastChangeTime
+	10,                       // globalHostId,
+	"9920249034889494527",    // hostIdInServer,
+	"hostQ1",                 // hostName,
+	"TEST Trigger Action 2",  // brief,
+	"",                       // extendedInfo
+	TRIGGER_VALID,          // validity
+},{
 	// This entry is used for testHatoholArmPluginGate.
 	12345,                    // serverId
 	2468,                     // id

--- a/server/test/testFaceRestAction.cc
+++ b/server/test/testFaceRestAction.cc
@@ -181,6 +181,7 @@ void data_actionsJSONP(void)
 
 void test_actionsJSONP(gconstpointer data)
 {
+	loadTestDBTriggers();
 	loadTestDBAction();
 
 	const ActionType actionType


### PR DESCRIPTION
If the requested trigger is not found, the code refers
the invalid iterator. So this patch make it return immediately.

In addition, this patch also avoids such situation on the test.