### PR TITLE
[experimental] wercker: Try to add Wercker to build CentOS 6.x series

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,8 @@
+box: wercker-labs/docker
+build:
+  steps:
+    - script:
+        name: Build a CentOS 6.6 Docker Hatohol image box
+        code: |
+          docker -v
+          docker build -t centos66/build-hatohol wercker/

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -12,6 +12,8 @@ RUN wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 RUN yum install -y json-glib-devel qpid-cpp-server-devel
 RUN yum groupinstall -y 'Development tools'
 RUN yum install -y Django
+RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm
+RUN yum install -y cutter
 # git clone
 RUN git clone https://github.com/project-hatohol/hatohol.git ~/hatohol
 # build

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -1,0 +1,20 @@
+from centos:6.6
+
+maintainer hatohol project
+
+# install libraries for Hatohol
+RUN yum install -y glib2-devel libsoup-devel sqlite-devel mysql-devel libuuid-devel \
+  qpid-cpp-client-devel MySQL-python httpd mod_wsgi python-argparse
+
+RUN rpm -ivh --force http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+RUN yum install -y librabbitmq-devel wget
+RUN wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
+RUN yum install -y json-glib-devel qpid-cpp-server-devel
+RUN yum groupinstall -y 'Development tools'
+RUN yum install -y Django
+# git clone
+RUN git clone https://github.com/project-hatohol/hatohol.git ~/hatohol
+# build
+RUN cd ~/hatohol && libtoolize && autoreconf -i
+RUN cd ~/hatohol && ./configure
+RUN cd ~/hatohol && make -j `cat /proc/cpuinfo | grep processor | wc -l`

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -6,15 +6,12 @@ maintainer hatohol project
 RUN yum install -y glib2-devel libsoup-devel sqlite-devel mysql-devel mysql-server \
   libuuid-devel qpid-cpp-client-devel MySQL-python httpd mod_wsgi python-argparse
 # setup mysql
-RUN chkconfig --level 2345 mysqld on
-RUN service mysqld start
+RUN echo "NETWORKING=yes" > /etc/sysconfig/network
 RUN rpm -ivh --force http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN yum install -y librabbitmq-devel wget
 RUN wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 RUN yum install -y json-glib-devel qpid-cpp-server-devel
 # setup qpid
-RUN chkconfig --level 2345 qpidd on
-RUN service qpidd start
 RUN yum groupinstall -y 'Development tools'
 RUN yum install -y Django
 RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -3,13 +3,18 @@ from centos:6.6
 maintainer hatohol project
 
 # install libraries for Hatohol
-RUN yum install -y glib2-devel libsoup-devel sqlite-devel mysql-devel libuuid-devel \
-  qpid-cpp-client-devel MySQL-python httpd mod_wsgi python-argparse
-
+RUN yum install -y glib2-devel libsoup-devel sqlite-devel mysql-devel mysql-server \
+  libuuid-devel qpid-cpp-client-devel MySQL-python httpd mod_wsgi python-argparse
+# setup mysql
+RUN chkconfig --level 2345 mysqld on
+RUN service mysqld start
 RUN rpm -ivh --force http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN yum install -y librabbitmq-devel wget
 RUN wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 RUN yum install -y json-glib-devel qpid-cpp-server-devel
+# setup qpid
+RUN chkconfig --level 2345 qpidd on
+RUN service qpidd start
 RUN yum groupinstall -y 'Development tools'
 RUN yum install -y Django
 RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm


### PR DESCRIPTION
This pull request contains **experimental feature** for CI with CentOS 6.x series.

I found that `Wercker` supports Docker backend. ref: http://devcenter.wercker.com/articles/docker/
Docker backend makes for us to running various containers under `Wercker` CI environment!
That is, CentOS 6.x Docker container can run under `Wercker` Docker backend. :laughing: 

CI with Docker container (CentOS6.6) runs like this:
https://app.wercker.com/#build/54fd95a782ba1add4201ae34

`Wercker`'s worker running limit is 25 minutes.
So this wercker.yml and Dockerfile is only for building `Hatohol` server and web frontend.

For now, `Wercker`'s Docker feature seems to be *beta* feature, though. :<