### PR TITLE
[RestResourceAction] Fix an invalid error message

### DIFF
--- a/server/src/RestResourceAction.cc
+++ b/server/src/RestResourceAction.cc
@@ -268,8 +268,10 @@ static HatoholError parseActionParameter(FaceRest::ResourceHandler *job,
 		}
 		if (!(cond.triggerSeverityCompType == CMP_EQ ||
 		      cond.triggerSeverityCompType == CMP_EQ_GT)) {
-			return HatoholError(HTERR_INVALID_PARAMETER,
-			                    "type: " + cond.triggerSeverityCompType);
+			string message =
+			  StringUtils::sprintf(
+			    "type: %d", cond.triggerSeverityCompType);
+			return HatoholError(HTERR_INVALID_PARAMETER, message);
 		}
 	}
 


### PR DESCRIPTION
RestResourceAction.cc:272:33: warning: adding 'ComparisonType' to a string does not append to the string [-Wstring-plus-int]
                                            "type: " + cond.triggerSeverityCompType);
                                            ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~