### PR TITLE
Event id to string 2

### DIFF
--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -250,7 +250,9 @@ struct HapiResTimestampOfLastTrigger {
 } __attribute__((__packed__));
 
 struct HapiResLastEventId {
-	uint64_t lastEventId;
+	uint16_t lastEventIdLength;  // Not include the NULL terminator
+	uint16_t lastEventIdOffset;  // from the top of this structure
+	// Body of lastEventId (including NULL terminator)
 } __attribute__((__packed__));
 
 struct HapiResTimeOfLastEvent {

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -111,7 +111,7 @@ struct EventInfo {
 	// 'unifiedId' is the unique ID in the event table of Hatohol cache DB.
 	// 'id' is the unique in a 'serverId'. It is typically the same as
 	// the event ID of a monitroing system such as ZABBIX and Nagios.
-	uint64_t            unifiedId;
+	UnifiedEventIdType  unifiedId;
 	ServerIdType        serverId;
 	EventIdType         id;
 	timespec            time;
@@ -134,7 +134,7 @@ typedef std::list<EventInfo>          EventInfoList;
 typedef EventInfoList::iterator       EventInfoListIterator;
 typedef EventInfoList::const_iterator EventInfoListConstIterator;
 
-static const EventIdType DISCONNECT_SERVER_EVENT_ID = 0;
+static const EventIdType DISCONNECT_SERVER_EVENT_ID = "";
 
 enum ItemInfoValueType {
 	ITEM_INFO_VALUE_TYPE_UNKNOWN,

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -83,6 +83,9 @@ typedef std::string HostgroupIdType;
 typedef int IncidentTrackerIdType;
 #define FMT_INCIDENT_TRACKER_ID "d"
 
+typedef uint64_t ActionLogIdType;
+#define FMT_ACTION_LOG_ID PRIu64
+
 // Special Server IDs =========================================================
 static const ServerIdType ALL_SERVERS       = -1;
 static const ServerIdType INVALID_SERVER_ID = -2;

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -65,8 +65,11 @@ typedef int AccessInfoIdType;
 typedef int UserRoleIdType;
 #define FMT_USER_ROLE_ID "d"
 
-typedef uint64_t EventIdType;
-#define FMT_EVENT_ID PRIu64
+typedef uint64_t UnifiedEventIdType;
+#define FMT_UNIFIED_EVENT_ID PRIu64
+
+typedef std::string EventIdType;
+#define FMT_EVENT_ID "s"
 
 typedef uint64_t ItemIdType;
 #define FMT_ITEM_ID PRIu64
@@ -136,7 +139,7 @@ static const TriggerIdType FAILED_SELF_TRIGGER_ID_TERMINATION   =
   SPECIAL_TRIGGER_ID_PREFIX "TERM";
 
 // Special Event IDs ==========================================================
-static const EventIdType EVENT_NOT_FOUND = -1;
+static const EventIdType EVENT_NOT_FOUND = "";
 
 // Special Item IDs ===========================================================
 static const ItemIdType ALL_ITEMS    = -1;

--- a/server/common/Utils.cc
+++ b/server/common/Utils.cc
@@ -474,7 +474,7 @@ void Utils::conv(uint64_t &dest, const string &src)
 	}
 }
 
-uint64_t Utils::add(const string &num0, const uint64_t num1)
+uint64_t Utils::sum(const string &num0, const uint64_t num1)
 {
 	uint64_t n;
 	conv(n, num0);

--- a/server/common/Utils.cc
+++ b/server/common/Utils.cc
@@ -474,6 +474,13 @@ void Utils::conv(uint64_t &dest, const string &src)
 	}
 }
 
+uint64_t Utils::add(const string &num0, const uint64_t num1)
+{
+	uint64_t n;
+	conv(n, num0);
+	return n + num1;
+}
+
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------

--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -259,14 +259,14 @@ public:
 	static void conv(uint64_t &dest, const std::string &src);
 
 	/**
-	 * Calculate addition with the number as a string.
+	 * Sum two variables of which one is a string.
 	 *
 	 * @param num0 A number represented by a string.
 	 * @param num1 An another number.
 	 *
 	 * @return A calculated result.
 	 */
-	static uint64_t add(const std::string &num0, const uint64_t num1);
+	static uint64_t sum(const std::string &num0, const uint64_t num1);
 
 protected:
 	static std::string makeDemangledStackTraceString(

--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -258,6 +258,16 @@ public:
 	 */
 	static void conv(uint64_t &dest, const std::string &src);
 
+	/**
+	 * Calculate addition with the number as a string.
+	 *
+	 * @param num0 A number represented by a string.
+	 * @param num1 An another number.
+	 *
+	 * @return A calculated result.
+	 */
+	static uint64_t add(const std::string &num0, const uint64_t num1);
+
 protected:
 	static std::string makeDemangledStackTraceString(
 	  const std::string &stackTraceLine);

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -1321,7 +1321,7 @@ void ZabbixAPI::parseAndPushEventsData(
 {
 	startElement(parser, index);
 	VariableItemGroupPtr grp;
-	pushUint64(parser, grp, "eventid",      ITEM_ID_ZBX_EVENTS_EVENTID);
+	pushString(parser, grp, "eventid",      ITEM_ID_ZBX_EVENTS_EVENTID);
 	pushInt   (parser, grp, "source",       ITEM_ID_ZBX_EVENTS_SOURCE);
 	pushInt   (parser, grp, "object",       ITEM_ID_ZBX_EVENTS_OBJECT);
 	pushString(parser, grp, "objectid",     ITEM_ID_ZBX_EVENTS_OBJECTID);

--- a/server/hap/HapProcessZabbixAPI.cc
+++ b/server/hap/HapProcessZabbixAPI.cc
@@ -122,7 +122,7 @@ void HapProcessZabbixAPI::workOnEvents(void)
 	  HatoholArmPluginBase::getLastEventId();
 	uint64_t eventIdOffset = 0;
 	if (lastEventIdOfHatohol != EVENT_NOT_FOUND)
-		eventIdOffset = Utils::add(lastEventIdOfHatohol, 1);
+		eventIdOffset = Utils::sum(lastEventIdOfHatohol, 1);
 
 	while (eventIdOffset < lastEventIdOfZbxSv) {
 		const uint64_t eventIdTill =

--- a/server/hap/HapProcessZabbixAPI.cc
+++ b/server/hap/HapProcessZabbixAPI.cc
@@ -118,10 +118,11 @@ void HapProcessZabbixAPI::workOnEvents(void)
 	// TOOD: we should exit immediately if the Zabbix server does not
 	// have any events at all.
 
-	uint64_t lastEventIdOfHatohol = HatoholArmPluginBase::getLastEventId();
+	const EventIdType lastEventIdOfHatohol =
+	  HatoholArmPluginBase::getLastEventId();
 	uint64_t eventIdOffset = 0;
 	if (lastEventIdOfHatohol != EVENT_NOT_FOUND)
-		eventIdOffset = lastEventIdOfHatohol + 1;
+		eventIdOffset = Utils::add(lastEventIdOfHatohol, 1);
 
 	while (eventIdOffset < lastEventIdOfZbxSv) {
 		const uint64_t eventIdTill =

--- a/server/hap/HatoholArmPluginBase.cc
+++ b/server/hap/HatoholArmPluginBase.cc
@@ -218,8 +218,7 @@ EventIdType HatoholArmPluginBase::getLastEventId(void)
 		EventIdType eventId;
 
 		Callback(HatoholArmPluginBase *obj)
-		: SyncCommand(obj),
-		  eventId(INVALID_EVENT_ID)
+		: SyncCommand(obj)
 		{
 		}
 
@@ -231,7 +230,9 @@ EventIdType HatoholArmPluginBase::getLastEventId(void)
 			const HapiResLastEventId *body =
 			  getObject()->getResponseBody
 			    <HapiResLastEventId>(replyBuf);
-			eventId = body->lastEventId;
+			eventId = getString(replyBuf, body,
+			                    body->lastEventIdOffset,
+			                    body->lastEventIdLength);
 			setSucceeded();
 		}
 	} *cb = new Callback(this);

--- a/server/hap/HatoholArmPluginBase.cc
+++ b/server/hap/HatoholArmPluginBase.cc
@@ -285,7 +285,6 @@ SmartTime HatoholArmPluginBase::getTimeOfLastEvent(
 	char *buf = reinterpret_cast<char *>(param + 1);
 	buf = putString(buf, param, triggerId,
 	                &param->triggerIdOffset, &param->triggerIdLength);
-	cmdBuf.printBuffer();
 	send(cmdBuf, cb);
 	cb->wait();
 	if (!cb->getSucceeded()) {

--- a/server/src/ActionManager.cc
+++ b/server/src/ActionManager.cc
@@ -757,7 +757,7 @@ void ActionManager::execCommandAction(const ActionDef &actionDef,
 	argVect.push_back(eventInfo.hostIdInServer);
 	argVect.push_back(StringUtils::sprintf("%ld.%ld",
 	  eventInfo.time.tv_sec, eventInfo.time.tv_nsec));
-	argVect.push_back(StringUtils::sprintf("%" PRIu64, eventInfo.id));
+	argVect.push_back(eventInfo.id);
 	argVect.push_back(StringUtils::sprintf("%d", eventInfo.type));
 	argVect.push_back(eventInfo.triggerId);
 	argVect.push_back(StringUtils::sprintf("%d", eventInfo.status));
@@ -1537,13 +1537,13 @@ void ActionManager::postProcSpawnFailure(
 
 	// MLPL log
 	MLPL_ERR(
-	  "%s, action ID: %d, log ID: %" PRIu64 ", "
-	  "server ID: %d, event ID: %" PRIu64 ", "
+	  "%s, action ID: %d, log ID: %" FMT_ACTION_LOG_ID ", "
+	  "server ID: %" FMT_SERVER_ID ", event ID: %" FMT_EVENT_ID ", "
 	  "time: %ld.%09ld, type: %s, "
 	  "trigger ID: %" FMT_TRIGGER_ID ", status: %s, severity: %s, "
 	  "host ID: %" FMT_LOCAL_HOST_ID "\n",
 	  error->message, actionDef.id, actorInfo->logId,
-	  eventInfo.serverId, eventInfo.id,
+	  eventInfo.serverId, eventInfo.id.c_str(),
 	  eventInfo.time.tv_sec, eventInfo.time.tv_nsec,
 	  LabelUtils::getEventTypeLabel(eventInfo.type).c_str(),
 	  eventInfo.triggerId.c_str(),

--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -538,14 +538,21 @@ void ArmNagiosNDOUtils::addConditionForEventQuery(void)
 {
 	ThreadLocalDBCache cache;
 	const MonitoringServerInfo &svInfo = getServerInfo();
-	uint64_t lastEventId = cache.getMonitoring().getLastEventId(svInfo.id);
+	const EventIdType lastEventId =
+	  cache.getMonitoring().getLastEventId(svInfo.id);
 	string cond;
 	DBAgent::SelectExArg &arg = m_impl->selectEventBuilder.getSelectExArg();
 	arg.condition = m_impl->selectEventBaseCondition;
-	if (lastEventId == EVENT_NOT_FOUND)
+	if (lastEventId == EVENT_NOT_FOUND) {
 		cond = "0";
-	else
-		cond = StringUtils::sprintf("%" PRIu64, lastEventId+1);
+	} else {
+		if (!StringUtils::isNumber(lastEventId)) {
+			THROW_HATOHOL_EXCEPTION("Unexpected event ID: %s\n",
+			                        lastEventId.c_str());
+		}
+		const uint64_t eventId = Utils::add(lastEventId, 1);
+		cond = StringUtils::toString(eventId);
+	}
 	arg.condition += cond;
 }
 

--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -550,7 +550,7 @@ void ArmNagiosNDOUtils::addConditionForEventQuery(void)
 			THROW_HATOHOL_EXCEPTION("Unexpected event ID: %s\n",
 			                        lastEventId.c_str());
 		}
-		const uint64_t eventId = Utils::add(lastEventId, 1);
+		const uint64_t eventId = Utils::sum(lastEventId, 1);
 		cond = StringUtils::toString(eventId);
 	}
 	arg.condition += cond;

--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -646,7 +646,7 @@ string DBAgentMySQL::getColumnValueString(const ColumnDef *columnDef,
 	{ // bracket is used to avoid an error:
 	  // jump to case label
 		string src = itemData->getString();
-		char *escaped = new char[src.size() * 2 + 1]; 
+		char *escaped = new char[src.size() * 2 + 1];
 		mysql_real_escape_string(&m_impl->mysql, escaped, src.c_str(), src.size());
 		string val = sprintf("'%s'", escaped);
 		delete [] escaped;

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -775,7 +775,7 @@ uint64_t DBTablesAction::createActionLog(
 	arg.row->addNewItem(eventInfo.serverId);
 	arg.row->addNewItem(eventInfo.id);
 
-	uint64_t logId;
+	ActionLogIdType logId;
 	getDBAgent().runTransaction(arg, &logId);
 	return logId;
 }
@@ -786,7 +786,7 @@ void DBTablesAction::logEndExecAction(const LogEndExecActionArg &logArg)
 
 	const char *actionLogIdColumnName =
 	  COLUMN_DEF_ACTION_LOGS[IDX_ACTION_LOGS_ACTION_LOG_ID].columnName;
-	arg.condition = StringUtils::sprintf("%s=%" PRIu64,
+	arg.condition = StringUtils::sprintf("%s=%" FMT_ACTION_LOG_ID,
 	                                     actionLogIdColumnName,
 	                                     logArg.logId);
 	// status
@@ -804,13 +804,13 @@ void DBTablesAction::logEndExecAction(const LogEndExecActionArg &logArg)
 	getDBAgent().runTransaction(arg);
 }
 
-void DBTablesAction::updateLogStatusToStart(uint64_t logId)
+void DBTablesAction::updateLogStatusToStart(const ActionLogIdType &logId)
 {
 	DBAgent::UpdateArg arg(tableProfileActionLogs);
 
 	const char *actionLogIdColumnName =
 	  COLUMN_DEF_ACTION_LOGS[IDX_ACTION_LOGS_ACTION_LOG_ID].columnName;
-	arg.condition = StringUtils::sprintf("%s=%" PRIu64,
+	arg.condition = StringUtils::sprintf("%s=%" FMT_ACTION_LOG_ID,
 	                                     actionLogIdColumnName, logId);
 	arg.add(IDX_ACTION_LOGS_STATUS, ACTLOG_STAT_STARTED);
 	arg.add(IDX_ACTION_LOGS_START_TIME, CURR_DATETIME);
@@ -818,11 +818,11 @@ void DBTablesAction::updateLogStatusToStart(uint64_t logId)
 	getDBAgent().runTransaction(arg);
 }
 
-bool DBTablesAction::getLog(ActionLog &actionLog, uint64_t logId)
+bool DBTablesAction::getLog(ActionLog &actionLog, const ActionLogIdType &logId)
 {
 	const ColumnDef *def = COLUMN_DEF_ACTION_LOGS;
 	const char *idColName = def[IDX_ACTION_LOGS_ACTION_LOG_ID].columnName;
-	string condition = StringUtils::sprintf("%s=%" PRIu64,
+	string condition = StringUtils::sprintf("%s=%" FMT_ACTION_LOG_ID,
 	                                        idColName, logId);
 	return getLog(actionLog, condition);
 }

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -25,7 +25,7 @@
 #include "DBTables.h"
 #include "Params.h"
 
-const static uint64_t INVALID_ACTION_LOG_ID = -1;
+const static ActionLogIdType INVALID_ACTION_LOG_ID = -1;
 
 enum ActionType {
 	ACTION_USER_DEFINED = -2, // COMMAND & RESIDENT
@@ -262,7 +262,7 @@ class DBTablesAction : public DBTables {
 
 public:
 	struct LogEndExecActionArg {
-		uint64_t logId;
+		ActionLogIdType logId;
 		ActionLogStatus status;
 		int   exitCode;
 		ActionLogExecFailureCode failureCode;
@@ -312,7 +312,7 @@ public:
 	 *
 	 * @return a created action log ID.
 	 */
-	uint64_t createActionLog
+	ActionLogIdType createActionLog
 	  (const ActionDef &actionDef, const EventInfo &eventInfo,
 	   ActionLogExecFailureCode failureCode = ACTLOG_EXECFAIL_NONE,
 	   ActionLogStatus initialStatus = ACTLOG_STAT_STARTED);
@@ -335,7 +335,7 @@ public:
 	 *
 	 * @param logId A logID to be updated.
 	 */
-	void updateLogStatusToStart(uint64_t logId);
+	void updateLogStatusToStart(const ActionLogIdType &logId);
 
 	/**
 	 * Get the action log.
@@ -346,7 +346,7 @@ public:
 	 *
 	 * @return true if the log is found. Otherwise false.
 	 */
-	bool getLog(ActionLog &actionLog, uint64_t logId);
+	bool getLog(ActionLog &actionLog, const ActionLogIdType &logId);
 
 	/**
 	 * Get the event log.

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -272,7 +272,7 @@ public:
 		LogEndExecActionArg(void);
 	};
 
-	static int ACTION_DB_VERSION;
+	static const int ACTION_DB_VERSION;
 
 	static void init(void);
 	static void reset(void);
@@ -358,7 +358,7 @@ public:
 	 * @return true if the log is found. Otherwise false.
 	 */
 	bool getLog(ActionLog &actionLog, const ServerIdType &serverId,
-	            uint64_t eventId);
+	            const EventIdType &eventId);
 
 	/**
 	 * Check whether IncidentSender type action exists or not

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -372,10 +372,12 @@ void HatoholArmPluginGate::startOnDemandFetchHistory(
 	callback->historyUpdatedSignal.connect(closure);
 	callback->serverId = m_impl->serverInfo.id;
 
+	const size_t additionalSize =
+	  itemInfo.hostIdInServer.size() + 1; // +1: NULL term.
 	SmartBuffer cmdBuf;
 	HapiParamReqFetchHistory *body =
 	  setupCommandHeader<HapiParamReqFetchHistory>(
-	    cmdBuf, HAPI_CMD_REQ_FETCH_HISTORY);
+	    cmdBuf, HAPI_CMD_REQ_FETCH_HISTORY, additionalSize);
 	body->itemId    = NtoL(itemInfo.id);
 	body->valueType = NtoL(static_cast<uint16_t>(itemInfo.valueType));
 	body->beginTime = NtoL(beginTime);

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -796,12 +796,16 @@ void HatoholArmPluginGate::cmdHandlerGetTimestampOfLastTrigger(
 void HatoholArmPluginGate::cmdHandlerGetLastEventId(
   const HapiCommandHeader *header)
 {
+	ThreadLocalDBCache cache;
+	const EventIdType lastEventId =
+	  cache.getMonitoring().getLastEventId(m_impl->serverInfo.id);
+	const size_t additionalSize = lastEventId.size() + 1;
 	SmartBuffer resBuf;
 	HapiResLastEventId *body =
-	  setupResponseBuffer<HapiResLastEventId>(resBuf);
-	ThreadLocalDBCache cache;
-	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
-	body->lastEventId = dbMonitoring.getLastEventId(m_impl->serverInfo.id);
+	  setupResponseBuffer<HapiResLastEventId>(resBuf, additionalSize);
+	char *buf = reinterpret_cast<char *>(body + 1);
+	buf = putString(buf, body, lastEventId,
+	                &body->lastEventIdOffset, &body->lastEventIdLength);
 	reply(resBuf);
 }
 

--- a/server/src/IncidentSender.cc
+++ b/server/src/IncidentSender.cc
@@ -319,7 +319,7 @@ string IncidentSender::buildDescription(const EventInfo &event,
 		  "    Time:       \"%ld.%09ld (%s)\"\n"
 		  "    Type:       \"%d (%s)\"\n"
 		  "    Brief:      \"%s\"\n",
-		  event.id,
+		  event.id.c_str(),
 		  event.time.tv_sec, event.time.tv_nsec, timeString,
 		  event.type,
 		  LabelUtils::getEventTypeLabel(event.type).c_str(),

--- a/server/src/IncidentSenderManager.cc
+++ b/server/src/IncidentSenderManager.cc
@@ -127,7 +127,7 @@ void IncidentSenderManager::queue(
 	if (!sender) {
 		MLPL_ERR("Failed to queue sending an incident"
 			 " for the event: %" FMT_EVENT_ID "\n",
-			 eventInfo.id);
+			 eventInfo.id.c_str());
 		return;
 	}
 	sender->queue(eventInfo, callback, userData);

--- a/server/src/IncidentSenderRedmine.cc
+++ b/server/src/IncidentSenderRedmine.cc
@@ -138,7 +138,7 @@ string IncidentSenderRedmine::buildURLMonitoringServerEvent(
 		  "?triggerid=%" FMT_TRIGGER_ID
 		  "&eventid=%" FMT_EVENT_ID,
 		  event.triggerId.c_str(),
-		  event.id);
+		  event.id.c_str());
 		break;
 	}
 	case MONITORING_SYSTEM_NAGIOS:
@@ -210,7 +210,7 @@ string IncidentSenderRedmine::buildDescription(
 	    "\n",
 	    event.hostIdInServer.c_str(),
 	    event.triggerId.c_str(),
-	    event.id);
+	    event.id.c_str());
 
 	string monitoringServerEventPage
 	  = buildURLMonitoringServerEvent(event, server);

--- a/server/src/ResidentCommunicator.cc
+++ b/server/src/ResidentCommunicator.cc
@@ -116,6 +116,7 @@ void ResidentCommunicator::setNotifyEventBody(
 	const uint32_t bodySize =
 	  RESIDENT_PROTO_EVENT_BODY_BASE_LEN +
 	  eventInfo.hostIdInServer.size() + lenNullTerm +
+	  eventInfo.id.size()             + lenNullTerm +
 	  eventInfo.triggerId.size()      + lenNullTerm;
 	size_t bodyIdx =
 	  RESIDENT_PROTO_HEADER_LEN + RESIDENT_PROTO_EVENT_BODY_BASE_LEN;
@@ -126,7 +127,7 @@ void ResidentCommunicator::setNotifyEventBody(
 	bodyIdx = m_impl->sbuf.insertString(eventInfo.hostIdInServer, bodyIdx);
 	m_impl->sbuf.add64(eventInfo.time.tv_sec);
 	m_impl->sbuf.add32(eventInfo.time.tv_nsec);
-	m_impl->sbuf.add64(eventInfo.id); // Event ID
+	bodyIdx = m_impl->sbuf.insertString(eventInfo.id, bodyIdx);
 	m_impl->sbuf.add16(eventInfo.type);
 	bodyIdx = m_impl->sbuf.insertString(eventInfo.triggerId, bodyIdx);
 	m_impl->sbuf.add16(eventInfo.status);

--- a/server/src/ResidentProtocol.h
+++ b/server/src/ResidentProtocol.h
@@ -159,7 +159,7 @@ struct ResidentNotifyEventArg {
 	uint32_t serverId;
 	const char *hostIdInServer;
 	timespec time;
-	uint64_t eventId;
+	const char *eventId;
 	uint16_t eventType;
 	const char *triggerId;
 	uint16_t triggerStatus;

--- a/server/src/hatoholResidentYard.cc
+++ b/server/src/hatoholResidentYard.cc
@@ -104,7 +104,8 @@ static void gotNotifyEventBodyCb(GIOStatus stat, mlpl::SmartBuffer &sbuf,
 	arg.hostIdInServer  = hostIdInServer.c_str();
 	arg.time.tv_sec     = *sbuf.getPointerAndIncIndex<uint64_t>();
 	arg.time.tv_nsec    = *sbuf.getPointerAndIncIndex<uint32_t>();
-	arg.eventId         = *sbuf.getPointerAndIncIndex<uint64_t>();
+	const string eventId = sbuf.extractStringAndIncIndex();
+	arg.eventId         = eventId.c_str();
 	arg.eventType       = *sbuf.getPointerAndIncIndex<uint16_t>();
 	const string triggerId = sbuf.extractStringAndIncIndex();
 	arg.triggerId       = triggerId.c_str();

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -357,7 +357,7 @@ const EventInfo testEventInfo[] = {
 {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
-	1,                        // id
+	"1",                      // id
 	{1362957200,0},           // time
 	EVENT_TYPE_GOOD,          // type
 	"2",                      // triggerId
@@ -370,7 +370,7 @@ const EventInfo testEventInfo[] = {
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
-	2,                        // id
+	"2",                      // id
 	{1362958000,0},           // time
 	EVENT_TYPE_GOOD,          // type
 	"3",                      // triggerId
@@ -383,7 +383,7 @@ const EventInfo testEventInfo[] = {
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
-	1,                        // id
+	"1",                      // id
 	{1363123456,0},           // time
 	EVENT_TYPE_GOOD,          // type
 	"2",                      // triggerId
@@ -396,7 +396,7 @@ const EventInfo testEventInfo[] = {
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
-	2,                        // id
+	"2",                      // id
 	{1378900022,0},           // time
 	EVENT_TYPE_GOOD,          // type
 	"1",                      // triggerId
@@ -409,7 +409,7 @@ const EventInfo testEventInfo[] = {
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
-	3,                        // id
+	"3",                      // id
 	{1389123457,0},           // time
 	EVENT_TYPE_GOOD,          // type
 	"3",                      // triggerId
@@ -422,7 +422,7 @@ const EventInfo testEventInfo[] = {
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
-	3,                        // id
+	"3",                      // id
 	{1390000000,123456789},   // time
 	EVENT_TYPE_BAD,           // type
 	"2",                      // triggerId
@@ -436,7 +436,7 @@ const EventInfo testEventInfo[] = {
 	// This entry is for tests with a defunct server
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	trigInfoDefunctSv1.serverId, // serverId
-	1,                        // id
+	"1",                        // id
 	trigInfoDefunctSv1.lastChangeTime, // time
 	EVENT_TYPE_BAD,                    // type
 	"3",                               // triggerId
@@ -1004,7 +1004,7 @@ IncidentInfo testIncidentInfo[] = {
 {
 	3,                        // trackerId
 	1,                        // serverId
-	1,                        // eventId
+	"1",                      // eventId
 	"2",                      // triggerId
 	"100",                    // identifier
 	"http://localhost:44444/issues/100", // location
@@ -1020,7 +1020,7 @@ IncidentInfo testIncidentInfo[] = {
 {
 	3,                        // trackerId
 	1,                        // serverId
-	2,                        // eventId
+	"2",                      // eventId
 	"1",                      // triggerId
 	"101",                    // identifier
 	"http://localhost:44444/issues/101", // location
@@ -1036,7 +1036,7 @@ IncidentInfo testIncidentInfo[] = {
 {
 	5,                        // trackerId
 	2,                        // serverId
-	2,                        // eventId
+	"2",                      // eventId
 	"3",                      // triggerId
 	"123",                    // identifier
 	"http://localhost/issues/123", // location
@@ -1396,25 +1396,27 @@ SmartTime getTimestampOfLastTestTrigger(const ServerIdType &serverId)
 EventIdType findLastEventId(const ServerIdType &serverId)
 {
 	bool found = false;
-	EventIdType maxId = 0;
+	uint64_t maxId = 0;
 	for (size_t i = 0; i < NumTestEventInfo; i++) {
 		const EventInfo &eventInfo = testEventInfo[i];
 		if (eventInfo.serverId != serverId)
 			continue;
-		if (eventInfo.id >= maxId) {
-			maxId = eventInfo.id;
+		uint64_t eventId;
+		Utils::conv(eventId, eventInfo.id);
+		if (eventId >= maxId) {
+			maxId = eventId;
 			found = true;
 		}
 	}
 	if (!found)
 		return EVENT_NOT_FOUND;
-	return maxId;
+	return StringUtils::toString(maxId);
 }
 
 SmartTime findTimeOfLastEvent(
   const ServerIdType &serverId, const TriggerIdType &triggerId)
 {
-	EventIdType maxId = 0;
+	uint64_t maxId = 0;
 	const timespec *lastTime = NULL;
 	for (size_t i = 0; i < NumTestEventInfo; i++) {
 		const EventInfo &eventInfo = testEventInfo[i];
@@ -1423,8 +1425,10 @@ SmartTime findTimeOfLastEvent(
 		if (triggerId != ALL_TRIGGERS &&
 		    eventInfo.triggerId != triggerId)
 			continue;
-		if (eventInfo.id >= maxId) {
-			maxId = eventInfo.id;
+		uint64_t eventId;
+		Utils::conv(eventId, eventInfo.id);
+		if (eventId >= maxId) {
+			maxId = eventId;
 			lastTime = &eventInfo.time;
 		}
 	}
@@ -1914,7 +1918,7 @@ const ArmPluginInfo &getTestArmPluginInfo(const MonitoringSystemType &type)
 string makeEventIncidentMapKey(const EventInfo &eventInfo)
 {
 	return StringUtils::sprintf("%" FMT_SERVER_ID ":%" FMT_EVENT_ID,
-				    eventInfo.serverId, eventInfo.id);
+				    eventInfo.serverId, eventInfo.id.c_str());
 }
 
 void makeEventIncidentMap(map<string, IncidentInfo*> &eventIncidentMap)
@@ -1923,7 +1927,7 @@ void makeEventIncidentMap(map<string, IncidentInfo*> &eventIncidentMap)
 		string key = StringUtils::sprintf(
 			       "%" FMT_SERVER_ID ":%" FMT_EVENT_ID,
 			       testIncidentInfo[i].serverId,
-			       testIncidentInfo[i].eventId);
+			       testIncidentInfo[i].eventId.c_str());
 		eventIncidentMap[key] = &testIncidentInfo[i];
 	}
 }

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -487,7 +487,7 @@ string makeEventOutput(const EventInfo &eventInfo)
 	  mlpl::StringUtils::sprintf(
 	    "%" FMT_SERVER_ID "|%" FMT_EVENT_ID "|%ld|%ld|%d|%" FMT_TRIGGER_ID
 	    "|%d|%u|%" FMT_HOST_ID "|%" FMT_LOCAL_HOST_ID "|%s|%s\n",
-	    eventInfo.serverId, eventInfo.id,
+	    eventInfo.serverId, eventInfo.id.c_str(),
 	    eventInfo.time.tv_sec, eventInfo.time.tv_nsec,
 	    eventInfo.type, eventInfo.triggerId.c_str(),
 	    eventInfo.status, eventInfo.severity,
@@ -508,7 +508,7 @@ string makeIncidentOutput(const IncidentInfo &incidentInfo)
 	    "|%s|%d|%" PRIu64 "\n",
 	    incidentInfo.trackerId,
 	    incidentInfo.serverId,
-	    incidentInfo.eventId,
+	    incidentInfo.eventId.c_str(),
 	    incidentInfo.triggerId.c_str(),
 	    incidentInfo.identifier.c_str(),
 	    incidentInfo.location.c_str(),

--- a/server/test/ZabbixAPIEmulator.cc
+++ b/server/test/ZabbixAPIEmulator.cc
@@ -643,12 +643,12 @@ string ZabbixAPIEmulator::addJSONResponse(const string &slice,
 	return StringUtils::sprintf(fmt, slice.c_str(), arg.id);
 }
 
-void ZabbixAPIEmulator::setExpectedFirstEventId(const EventIdType &id)
+void ZabbixAPIEmulator::setExpectedFirstEventId(const uint64_t &id)
 {
 	m_ctx->expectedFirstEventId = id;
 }
 
-void ZabbixAPIEmulator::setExpectedLastEventId(const EventIdType &id)
+void ZabbixAPIEmulator::setExpectedLastEventId(const uint64_t &id)
 {
 	m_ctx->expectedLastEventId = id;
 }

--- a/server/test/ZabbixAPIEmulator.h
+++ b/server/test/ZabbixAPIEmulator.h
@@ -61,8 +61,8 @@ public:
 	void setOperationMode(OperationMode mode);
 	void setAPIVersion(APIVersion version);
 	std::string getAPIVersionString(void);
-	void setExpectedFirstEventId(const EventIdType &id);
-	void setExpectedLastEventId(const EventIdType &id);
+	void setExpectedFirstEventId(const uint64_t &id);
+	void setExpectedLastEventId(const uint64_t &id);
 
 	static std::string getAPIVersionString(APIVersion version);
 	static void loadHostInfoCache(HostInfoCache &hostInfoCache,

--- a/server/test/residentTest.cc
+++ b/server/test/residentTest.cc
@@ -159,6 +159,7 @@ static uint32_t notifyEvent(ResidentNotifyEventArg *arg)
 		crash();
 	ctx.notifyEvent = *arg;
 	ctx.notifyEvent.hostIdInServer = TEST_HOST_ID_REPLY_MAGIC_CODE;
+	ctx.notifyEvent.eventId        = TEST_EVENT_ID_REPLY_MAGIC_CODE;
 	ctx.notifyEvent.triggerId      = TEST_TRIGGER_ID_REPLY_MAGIC_CODE;
 	ctx.countNotified++;
 	if (ctx.sendEventInfo) {

--- a/server/test/residentTest.h
+++ b/server/test/residentTest.h
@@ -34,5 +34,6 @@ static const int RESIDENT_TEST_REPLY_GET_EVENT_INFO_BODY_LEN =
 #define TEST_HOST_ID_STRING "Test HOST ID in server !!!"
 const char *TEST_HOST_ID_REPLY_MAGIC_CODE = (const char *)0x12345678;
 const char *TEST_TRIGGER_ID_REPLY_MAGIC_CODE = (const char *)0x122333;
+const char *TEST_EVENT_ID_REPLY_MAGIC_CODE   = (const char *)0x76543210;
 
 #endif // residentTest_h

--- a/server/test/testActionManager.cc
+++ b/server/test/testActionManager.cc
@@ -493,7 +493,7 @@ void _assertActionLogJustAfterExec(
 	  "%" FMT_LOCAL_HOST_ID, evInf.hostIdInServer.c_str()));
 	expectedArgs.push_back(StringUtils::sprintf("%ld.%ld",
 	  evInf.time.tv_sec, evInf.time.tv_nsec));
-	expectedArgs.push_back(StringUtils::sprintf("%" PRIu64, evInf.id));
+	expectedArgs.push_back(evInf.id);
 	expectedArgs.push_back(StringUtils::sprintf("%d", evInf.type));
 	expectedArgs.push_back(evInf.triggerId);
 	expectedArgs.push_back(StringUtils::sprintf("%d", evInf.status));
@@ -732,7 +732,8 @@ static void replyEventInfoCb(GIOStatus stat, mlpl::SmartBuffer &sbuf,
 	                    eventArg->hostIdInServer);
 	cppcut_assert_equal(expected.time.tv_sec, eventArg->time.tv_sec);
 	cppcut_assert_equal(expected.time.tv_nsec, eventArg->time.tv_nsec);
-	cppcut_assert_equal(expected.id, eventArg->eventId);
+	cppcut_assert_equal(TEST_EVENT_ID_REPLY_MAGIC_CODE,
+	                    eventArg->eventId);
 	cppcut_assert_equal(expected.type, (EventType)eventArg->eventType);
 	cppcut_assert_equal(TEST_TRIGGER_ID_REPLY_MAGIC_CODE,
 	                    eventArg->triggerId);

--- a/server/test/testArmZabbixAPI.cc
+++ b/server/test/testArmZabbixAPI.cc
@@ -792,7 +792,7 @@ static void addDummyFirstEvent(void)
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
 	EventInfo eventInfo = testEventInfo[0];
 	eventInfo.serverId = 1;
-	eventInfo.id = 0;
+	eventInfo.id = "0";
 	eventInfo.time.tv_sec = 0;
 	eventInfo.time.tv_nsec = 0;
 	dbMonitoring.addEventInfo(&eventInfo);
@@ -829,13 +829,14 @@ void test_oneNewEvent(void)
 	armZbxApiTestee.callUpdateEvents();
 	ThreadLocalDBCache cache;
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
-        uint64_t actualEventId = dbMonitoring.getLastEventId(serverInfo.id);
+	uint64_t actualEventId;
+	Utils::conv(actualEventId, dbMonitoring.getLastEventId(serverInfo.id));
 	cppcut_assert_equal(expectedEventId, actualEventId);
 
 	++expectedEventId;
 	g_apiEmulator.setExpectedLastEventId(expectedEventId);
 	armZbxApiTestee.callUpdateEvents();
-        actualEventId = dbMonitoring.getLastEventId(serverInfo.id);
+	Utils::conv(actualEventId, dbMonitoring.getLastEventId(serverInfo.id));
 	cppcut_assert_equal(expectedEventId, actualEventId);
 }
 

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -71,7 +71,8 @@ static string makeExpectedString(const ActionDef &actDef, int expectedId)
 }
 
 static string makeExpectedLogString(
-  const ActionDef &actDef, const EventInfo &eventInfo, uint64_t logId,
+  const ActionDef &actDef, const EventInfo &eventInfo,
+  const ActionLogIdType &logId,
   ActionLogStatus status = ACTLOG_STAT_STARTED,
   ActionLogExecFailureCode failureCode = ACTLOG_EXECFAIL_NONE)
 {
@@ -88,13 +89,14 @@ static string makeExpectedLogString(
 
 	string expect =
 	  StringUtils::sprintf(
-	    "%" PRIu64 "|%d|%d|%d|%s|%s|%s|%d|%s|%" PRIu32 "|%" PRIu64 "\n",
+	    "%" FMT_ACTION_LOG_ID "|%d|%d|%d|%s|%s|%s|%d|%s|"
+	    "%" FMT_SERVER_ID "|%" FMT_EVENT_ID "\n",
 	    logId, actDef.id, status, expectedStarterId,
 	    DBCONTENT_MAGIC_NULL,
 	    DBCONTENT_MAGIC_CURR_DATETIME,
 	    expectedExitTime, failureCode,
 	    DBCONTENT_MAGIC_NULL,
-	    eventInfo.serverId, eventInfo.id);
+	    eventInfo.serverId, eventInfo.id.c_str());
 	return expect;
 }
 
@@ -616,7 +618,7 @@ void test_startExecAction(void)
 			status = ACTLOG_STAT_STARTED;
 			cut_fail("Unknown action type: %d\n", actDef.type);
 		}
-		uint64_t logId =
+		const ActionLogIdType logId =
 		  dbAction.createActionLog(actDef, eventInfo,
 		                           ACTLOG_EXECFAIL_NONE, status);
 		const uint64_t expectedId = i + 1;
@@ -690,7 +692,7 @@ void test_getTriggerActionList(void)
 	const ActionCondition condTarget = testActionDef[idxTarget].condition;
 	EventInfo eventInfo;
 	eventInfo.serverId  = condTarget.serverId;
-	eventInfo.id        = 0;
+	eventInfo.id        = "0";
 	eventInfo.time.tv_sec  = 1378339653;
 	eventInfo.time.tv_nsec = 6889;
 	eventInfo.type      = EVENT_TYPE_GOOD;
@@ -727,7 +729,7 @@ void test_getTriggerActionListWithAllCondition(void)
 	const ActionCondition condTarget = testActionDef[idxTarget].condition;
 	EventInfo eventInfo;
 	eventInfo.serverId  = condTarget.serverId;
-	eventInfo.id        = 0;
+	eventInfo.id        = "0";
 	eventInfo.time.tv_sec  = 1378339653;
 	eventInfo.time.tv_nsec = 6889;
 	eventInfo.type      = EVENT_TYPE_GOOD;
@@ -765,7 +767,7 @@ static void _assertGetActionWithSeverity(
 	const ActionDef &actionDef = testActionDef[targetActionIdx];
 	const ActionCondition condTarget = actionDef.condition;
 	eventInfo.serverId  = condTarget.serverId ? : 1129;
-	eventInfo.id        = 1192;
+	eventInfo.id        = "1192";
 	eventInfo.time.tv_sec  = 1378339653;
 	eventInfo.time.tv_nsec = 6889;
 	eventInfo.type      = EVENT_TYPE_BAD;

--- a/server/test/testIncidentSenderRedmine.cc
+++ b/server/test/testIncidentSenderRedmine.cc
@@ -163,7 +163,7 @@ string expectedJSON(const EventInfo &event, const IncidentTrackerInfo &tracker)
 	    server.id,
 	    event.hostIdInServer.c_str(),
 	    event.triggerId.c_str(),
-	    event.id,
+	    event.id.c_str(),
 	    eventsURL.c_str());
 	return expected;
 }

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -68,10 +68,11 @@ static string eventTypeToString(EventType type)
 static string dumpEventInfo(const EventInfo &info)
 {
 	return StringUtils::sprintf(
-		"%" PRIu32 "|%" PRIu64 "|%lu|%ld|%s|%s|%s|%" FMT_LOCAL_HOST_ID
+		"%" FMT_SERVER_ID "|%" FMT_EVENT_ID
+		"|%lu|%ld|%s|%s|%s|%" FMT_LOCAL_HOST_ID
 		"|%s|%s\n",
 		info.serverId,
-		info.id,
+		info.id.c_str(),
 		info.time.tv_sec,
 		info.time.tv_nsec,
 		eventTypeToString(info.type).c_str(),

--- a/server/test/testUtils.cc
+++ b/server/test/testUtils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -18,6 +18,7 @@
  */
 
 #include <cppcutter.h>
+#include <gcutter.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -418,6 +419,22 @@ void test_setGLibTimer(void)
 	cppcut_assert_not_equal(INVALID_EVENT_ID, id);
 	g_main_loop_run(gizmo.loop);
 	cppcut_assert_equal(true, gizmo.called);
+}
+
+void data_add(void)
+{
+	gcut_add_datum("Simple",
+	               "num0",   G_TYPE_STRING, "1",
+	               "num1",   G_TYPE_UINT64, 2,
+	               "expect", G_TYPE_UINT64, 3, NULL);
+}
+
+void test_add(gconstpointer data)
+{
+	const gchar *num0 = gcut_data_get_string(data, "num0");
+	const uint64_t num1 = gcut_data_get_uint64(data, "num1");
+	const uint64_t expect = gcut_data_get_uint64(data, "expect");
+	cppcut_assert_equal(expect, Utils::add(num0, num1));
 }
 
 } // namespace testUtils

--- a/server/test/testUtils.cc
+++ b/server/test/testUtils.cc
@@ -429,12 +429,12 @@ void data_add(void)
 	               "expect", G_TYPE_UINT64, 3, NULL);
 }
 
-void test_add(gconstpointer data)
+void test_sum(gconstpointer data)
 {
 	const gchar *num0 = gcut_data_get_string(data, "num0");
 	const uint64_t num1 = gcut_data_get_uint64(data, "num1");
 	const uint64_t expect = gcut_data_get_uint64(data, "expect");
-	cppcut_assert_equal(expect, Utils::add(num0, num1));
+	cppcut_assert_equal(expect, Utils::sum(num0, num1));
 }
 
 } // namespace testUtils


### PR DESCRIPTION
Some monitoring systems such as OpenStack's ceilometer
handle events as UUID. In order to save that kind of
events, hatohol should also handle them as a string.