### PR TITLE
[HatoholArmPluginGate] Save MonitoringServerStatus on getting items

### DIFF
--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -218,16 +218,15 @@ void ArmZabbixAPI::makeHatoholEvents(ItemTablePtr events)
 void ArmZabbixAPI::makeHatoholItems(
   ItemTablePtr items, ItemTablePtr applications)
 {
-	ThreadLocalDBCache cache;
-	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
 	ItemInfoList itemInfoList;
 	MonitoringServerStatus serverStatus;
 	serverStatus.serverId = m_impl->zabbixServerId;
 	HatoholDBUtils::transformItemsToHatoholFormat(
 	  itemInfoList, serverStatus, items, applications,
 	  m_impl->zabbixServerId, m_impl->hostInfoCache);
-	dbMonitoring.addItemInfoList(itemInfoList);
-	dbMonitoring.addMonitoringServerStatus(&serverStatus);
+	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+	dataStore->addItemList(itemInfoList);
+	dataStore->addMonitoringServerStatus(serverStatus);
 }
 
 void ArmZabbixAPI::makeHatoholHostgroups(ItemTablePtr groups)

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2243,12 +2243,12 @@ void DBTablesMonitoring::getApplicationInfoVect(ApplicationInfoVect &application
 }
 
 void DBTablesMonitoring::addMonitoringServerStatus(
-  MonitoringServerStatus *serverStatus)
+  const MonitoringServerStatus &serverStatus)
 {
 	struct TrxProc : public DBAgent::TransactionProc {
-		MonitoringServerStatus *serverStatus;
+		const MonitoringServerStatus &serverStatus;
 
-		TrxProc(MonitoringServerStatus *_serverStatus)
+		TrxProc(const MonitoringServerStatus &_serverStatus)
 		: serverStatus(_serverStatus)
 		{
 		}
@@ -2256,7 +2256,7 @@ void DBTablesMonitoring::addMonitoringServerStatus(
 		void operator ()(DBAgent &dbAgent) override
 		{
 			addMonitoringServerStatusWithoutTransaction(
-			  dbAgent, *serverStatus);
+			  dbAgent, serverStatus);
 		}
 	} trx(serverStatus);
 	getDBAgent().runTransaction(trx);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -214,7 +214,8 @@ public:
 			     const ItemsQueryOption &option);
 	void getApplicationInfoVect(ApplicationInfoVect &applicationInfoVect,
 			     const ItemsQueryOption &option);
-	void addMonitoringServerStatus(MonitoringServerStatus *serverStatus);
+	void addMonitoringServerStatus(
+	  const MonitoringServerStatus &serverStatus);
 
 	/**
 	 * get the number of triggers with the given server ID, host group ID,

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -301,7 +301,9 @@ bool HatoholArmPluginGate::startOnDemandFetchItem(Closure0 *closure)
 			HatoholDBUtils::transformItemsToHatoholFormat(
 			  itemList, serverStatus, itemTablePtr, appTablePtr,
 			  serverId, hostInfoCache);
-			UnifiedDataStore::getInstance()->addItemList(itemList);
+			UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+			dataStore->addItemList(itemList);
+			dataStore->addMonitoringServerStatus(serverStatus);
 			cleanup();
 		}
 

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -610,6 +610,14 @@ void UnifiedDataStore::addItemList(const ItemInfoList &itemList)
 	dbMonitoring.addItemInfoList(itemList);
 }
 
+void UnifiedDataStore::addMonitoringServerStatus(
+  const MonitoringServerStatus &serverStatus)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	dbMonitoring.addMonitoringServerStatus(serverStatus);
+}
+
 void UnifiedDataStore::getUserList(UserInfoList &userList,
                                    const UserQueryOption &option)
 {

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -65,6 +65,11 @@ public:
 	 */
 	void addEventList(EventInfoList &eventList);
 
+	void addItemList(const ItemInfoList &itemList);
+
+	void addMonitoringServerStatus(
+	  const MonitoringServerStatus &serverStatus);
+
 
 	/*
 	 *  Functions which require operation privilege
@@ -72,8 +77,6 @@ public:
 
 	void getTriggerList(TriggerInfoList &triggerList,
 	                    const TriggersQueryOption &option);
-
-	void addItemList(const ItemInfoList &itemList);
 
 	/**
 	 * Get the last change time of the trigger that belongs to

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -2059,7 +2059,7 @@ void loadTestDBServerStatus(void)
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
 	for (size_t i = 0; i < NumTestServerStatus; i++) {
 		MonitoringServerStatus *serverStatus = &testServerStatus[i];
-		dbMonitoring.addMonitoringServerStatus(serverStatus);
+		dbMonitoring.addMonitoringServerStatus(*serverStatus);
 	}
 }
 


### PR DESCRIPTION
In addition I changed the first argument of
DBTablesMonitoring::addMonitoringServerStatus() from pointer to
reference because there is no possibility to pass a NULL pointer.