### PR TITLE
[server][MLPL] SmartBuffer: Do not leak buffer after realloc() failure.

### DIFF
--- a/server/mlpl/src/SmartBuffer.cc
+++ b/server/mlpl/src/SmartBuffer.cc
@@ -115,9 +115,10 @@ size_t SmartBuffer::watermark(void) const
 
 void SmartBuffer::alloc(size_t size, bool _resetIndexDeep)
 {
-	m_buf = static_cast<uint8_t *>(realloc(m_buf, size));
-	if (m_buf == NULL)
+	uint8_t *newBuffer = static_cast<uint8_t *>(realloc(m_buf, size));
+	if (newBuffer == NULL)
 		throw SmartBufferException();
+	m_buf = newBuffer;
 	if (_resetIndexDeep)
 		resetIndexDeep();
 	m_size = size;


### PR DESCRIPTION
If realloc() fails, it does not free old block.  We have to remember
the old pointer pointer, or we leak.

Signed-off-by: YOSHIFUJI Hideaki <hideaki.yoshifuji@miraclelinux.com>