### PR TITLE
Host group ID in Action condition => String

### DIFF
--- a/server/common/HatoholArmPluginInterface.h
+++ b/server/common/HatoholArmPluginInterface.h
@@ -268,11 +268,13 @@ struct HapiHapSelfTriggers {
 struct HapiParamReqFetchHistory {
 	uint16_t hostIdLength;  // Not include the NULL terminator
 	uint16_t hostIdOffset;  // from the top of this structure
-	uint64_t itemId;
+	uint16_t itemIdLength;  // Not include the NULL terminator
+	uint16_t itemIdOffset;  // from the top of this structure
 	uint16_t valueType;
 	uint64_t beginTime;
 	uint64_t endTime;
 	// Body of hostId  (including NULL terminator)
+	// Body of itemId  (including NULL terminator)
 } __attribute__((__packed__));
 
 struct HapiTriggerCollect {

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -74,8 +74,8 @@ typedef std::string EventIdType;
 typedef std::string ItemIdType;
 #define FMT_ITEM_ID "s"
 
-typedef uint64_t ItemCategoryIdType;
-#define FMT_ITEM_CATEGORY_ID PRIu64
+typedef std::string ItemCategoryIdType;
+#define FMT_ITEM_CATEGORY_ID "s"
 
 typedef std::string TriggerIdType;
 #define FMT_TRIGGER_ID "s"
@@ -145,7 +145,7 @@ static const EventIdType EVENT_NOT_FOUND = "";
 static const ItemIdType ALL_ITEMS    = "*";
 
 // Special ItemCategory IDs ===================================================
-static const ItemCategoryIdType NO_ITEM_CATEGORY_ID = -1;
+static const ItemCategoryIdType NO_ITEM_CATEGORY_ID = "";
 
 // Special User IDs ===========================================================
 static const UserIdType INVALID_USER_ID = -1;
@@ -204,6 +204,10 @@ typedef HostgroupIdSet::const_iterator      HostgroupIdSetConstIterator;
 typedef std::map<ServerIdType, HostgroupIdSet> ServerHostGrpSetMap;
 typedef ServerHostGrpSetMap::iterator       ServerHostGrpSetMapIterator;
 typedef ServerHostGrpSetMap::const_iterator ServerHostGrpSetMapConstIterator;
+
+typedef std::vector<ItemCategoryIdType>      ItemCategoryIdVector;
+typedef ItemCategoryIdVector::iterator       ItemCategoryIdVecotrIterator;
+typedef ItemCategoryIdVector::const_iterator ItemCategoryIdVecotrConstIterator;
 
 typedef std::map<ItemCategoryIdType, std::string> ItemCategoryNameMap;
 typedef ItemCategoryNameMap::iterator       ItemCategoryNameMapIterator;

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -71,8 +71,8 @@ typedef uint64_t UnifiedEventIdType;
 typedef std::string EventIdType;
 #define FMT_EVENT_ID "s"
 
-typedef uint64_t ItemIdType;
-#define FMT_ITEM_ID PRIu64
+typedef std::string ItemIdType;
+#define FMT_ITEM_ID "s"
 
 typedef uint64_t ItemCategoryIdType;
 #define FMT_ITEM_CATEGORY_ID PRIu64
@@ -142,7 +142,7 @@ static const TriggerIdType FAILED_SELF_TRIGGER_ID_TERMINATION   =
 static const EventIdType EVENT_NOT_FOUND = "";
 
 // Special Item IDs ===========================================================
-static const ItemIdType ALL_ITEMS    = -1;
+static const ItemIdType ALL_ITEMS    = "*";
 
 // Special ItemCategory IDs ===================================================
 static const ItemCategoryIdType NO_ITEM_CATEGORY_ID = -1;

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -1364,24 +1364,12 @@ void ZabbixAPI::pushSomethingId(
 	parser.endObject();
 }
 
-void ZabbixAPI::pushTriggersHostid(JSONParser &parser,
-                                   ItemGroup *itemGroup)
+void ZabbixAPI::pushTriggersHostid(JSONParser &parser, ItemGroup *itemGroup)
 {
-	ItemId itemId = ITEM_ID_ZBX_TRIGGERS_HOSTID;
-	startObject(parser, "hosts");
-	int numElem = parser.countElements();
-	if (numElem == 0) {
-		const string dummyData;
-		itemGroup->addNewItem(itemId, dummyData, ITEM_DATA_NULL);
-	} else  {
-		for (int i = 0; i < numElem; i++) {
-			startElement(parser, i);
-			pushString(parser, itemGroup, "hostid", itemId);
-			break; // we use the first applicationid
-		}
-		parser.endElement();
-	}
-	parser.endObject();
+	static const LocalHostIdType dummyHostName = "";
+	pushSomethingId<LocalHostIdType>(
+	  parser, itemGroup, ITEM_ID_ZBX_TRIGGERS_HOSTID,
+	  "hosts", "hostid", dummyHostName);
 }
 
 void ZabbixAPI::pushApplicationid(JSONParser &parser, ItemGroup *itemGroup)

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -454,7 +454,7 @@ ItemTablePtr ZabbixAPI::getHistory(const ItemIdType &itemId,
 	for (int i = 0; i < numData; i++) {
 		startElement(parser, i);
 		VariableItemGroupPtr grp;
-		pushUint64(parser, grp, "itemid", ITEM_ID_ZBX_HISTORY_ITEMID);
+		pushString(parser, grp, "itemid", ITEM_ID_ZBX_HISTORY_ITEMID);
 		pushUint64(parser, grp, "clock",  ITEM_ID_ZBX_HISTORY_CLOCK);
 		pushUint64(parser, grp, "ns",     ITEM_ID_ZBX_HISTORY_NS);
 		pushString(parser, grp, "value",  ITEM_ID_ZBX_HISTORY_VALUE);
@@ -1112,7 +1112,7 @@ void ZabbixAPI::parseAndPushItemsData(
 {
 	startElement(parser, index);
 	VariableItemGroupPtr grp;
-	pushUint64(parser, grp, "itemid",       ITEM_ID_ZBX_ITEMS_ITEMID);
+	pushString(parser, grp, "itemid",       ITEM_ID_ZBX_ITEMS_ITEMID);
 	pushInt   (parser, grp, "type",         ITEM_ID_ZBX_ITEMS_TYPE);
 	pushString(parser, grp, "snmp_community",
 	           ITEM_ID_ZBX_ITEMS_SNMP_COMMUNITY);

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -1084,7 +1084,7 @@ void ZabbixAPI::parseAndPushTriggerData(
 	pushInt   (parser, grp, "flags",       ITEM_ID_ZBX_TRIGGERS_FLAGS);
 
 	// get hostid
-	pushTriggersHostid(parser, grp);
+	pushTriggersHostId(parser, grp);
 
 	tablePtr->add(grp);
 
@@ -1364,7 +1364,7 @@ void ZabbixAPI::pushSomethingId(
 	parser.endObject();
 }
 
-void ZabbixAPI::pushTriggersHostid(JSONParser &parser, ItemGroup *itemGroup)
+void ZabbixAPI::pushTriggersHostId(JSONParser &parser, ItemGroup *itemGroup)
 {
 	static const LocalHostIdType dummyHostName = "";
 	pushSomethingId<LocalHostIdType>(

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -1185,7 +1185,7 @@ void ZabbixAPI::parseAndPushItemsData(
 	pushString(parser, grp, "lifetime",    ITEM_ID_ZBX_ITEMS_LIFETIME);
 
 	// application
-	pushApplicationid(parser, grp);
+	pushApplicationId(parser, grp);
 
 	tablePtr->add(grp);
 
@@ -1372,7 +1372,7 @@ void ZabbixAPI::pushTriggersHostId(JSONParser &parser, ItemGroup *itemGroup)
 	  "hosts", "hostid", dummyHostName);
 }
 
-void ZabbixAPI::pushApplicationid(JSONParser &parser, ItemGroup *itemGroup)
+void ZabbixAPI::pushApplicationId(JSONParser &parser, ItemGroup *itemGroup)
 {
 	pushSomethingId<ItemCategoryIdType>(
 	  parser, itemGroup, ITEM_ID_ZBX_ITEMS_APPLICATIONID,

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -164,7 +164,7 @@ protected:
 	 *
 	 * @return The obtained triggers as an ItemTable format.
 	 */
-	ItemTablePtr getApplications(const std::vector<uint64_t> &appIdVector);
+	ItemTablePtr getApplications(const ItemCategoryIdVector &appIdVector);
 	ItemTablePtr getApplications(ItemTablePtr items);
 
 	/**
@@ -257,7 +257,7 @@ protected:
 	 * @return
 	 * A SoupMessage object with the raw Zabbix servers's response.
 	 */
-	SoupMessage *queryApplication(const std::vector<uint64_t> &appIdVector,
+	SoupMessage *queryApplication(const ItemCategoryIdVector &appIdVector,
 				      HatoholError &queryRet);
 
 	/**
@@ -336,6 +336,12 @@ protected:
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
+
+	template <typename T>
+	void pushSomethingId(
+	  JSONParser &parser, ItemGroup *itemGroup, const ItemId &itemId,
+	  const std::string &objectName, const std::string &elementName,
+	  const T &dummyValue);
 };
 
 #endif // ZabbixAPI_h

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -331,7 +331,7 @@ protected:
 	  VariableItemTablePtr &tablePtr, const int &index);
 
 	void pushTriggersHostId(JSONParser &parser, ItemGroup *itemGroup);
-	void pushApplicationid(JSONParser &parser, ItemGroup *itemGroup);
+	void pushApplicationId(JSONParser &parser, ItemGroup *itemGroup);
 
 private:
 	struct Impl;

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -330,7 +330,7 @@ protected:
 	  JSONParser &parser,
 	  VariableItemTablePtr &tablePtr, const int &index);
 
-	void pushTriggersHostid(JSONParser &parser, ItemGroup *itemGroup);
+	void pushTriggersHostId(JSONParser &parser, ItemGroup *itemGroup);
 	void pushApplicationid(JSONParser &parser, ItemGroup *itemGroup);
 
 private:

--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -1038,7 +1038,7 @@ HatoholError HapProcessCeilometer::getResource(
 	// fill
 	// TODO: Don't use IDs concerned with Zabbix.
 	LocalHostIdType hostId = instanceId;
-	const ItemIdType itemId = generateHashU64(instanceId + counter_name);
+	const ItemIdType itemId = instanceId + "/" + counter_name;
 	const int timestampSec =
 	  (int)parseStateTimestamp(timestamp).getAsTimespec().tv_sec;
 	const string name = counter_name + " (" + counter_unit + ")";

--- a/server/hap/HapProcessZabbixAPI.cc
+++ b/server/hap/HapProcessZabbixAPI.cc
@@ -186,12 +186,12 @@ HatoholError HapProcessZabbixAPI::fetchHistory(const MessagingContext &msgCtx,
 	ZabbixAPI::ValueType valueType =
 	  ZabbixAPI::fromItemValueType(
 	    static_cast<ItemInfoValueType>(LtoN(params->valueType)));
-	ItemTablePtr items =
-	  getHistory(static_cast<ItemIdType>(LtoN(params->itemId)),
-		     valueType,
-		     static_cast<time_t>(LtoN(params->beginTime)),
-		     static_cast<time_t>(LtoN(params->endTime)));
-
+	const char *itemId = HatoholArmPluginInterface::getString(
+	                       cmdBuf, params,
+	                       params->itemIdOffset, params->itemIdLength);
+	ItemTablePtr items = getHistory(itemId, valueType,
+	                       static_cast<time_t>(LtoN(params->beginTime)),
+	                       static_cast<time_t>(LtoN(params->endTime)));
 	SmartBuffer resBuf;
 	setupResponseBuffer<void>(resBuf, 0, HAPI_RES_HISTORY, &msgCtx);
 	appendItemTable(resBuf, items);

--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -147,7 +147,7 @@ void ArmZabbixAPI::updateEvents(void)
 void ArmZabbixAPI::updateApplications(void)
 {
 	// getHosts() tries to get all hosts when an empty vector is passed.
-	static const vector<uint64_t> appIdVector;
+	static const ItemCategoryIdVector appIdVector;
 	ItemTablePtr tablePtr = getApplications(appIdVector);
 }
 

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -39,7 +39,9 @@ const static guint DEFAULT_ACTION_DELETE_INTERVAL_MSEC = 3600 * 1000; // 1hour
 
 // 8 -> 9: Add actions.onwer_user_id
 // -> 1.0
-//   * action_logs.id -> VARCHAR
+//   * action_def.trigger_id    -> VARCHAR
+//   * action_def.host_group_id -> VARCHAR
+//   * action_logs.id           -> VARCHAR
 const int DBTablesAction::ACTION_DB_VERSION =
   DBTables::Version::getPackedVer(0, 1, 0);
 
@@ -105,8 +107,8 @@ static const ColumnDef COLUMN_DEF_ACTIONS[] = {
 	NULL,                              // defaultValue
 }, {
 	"host_group_id",                   // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	true,                              // canBeNull
 	SQL_KEY_IDX,                       // keyType

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -56,7 +56,7 @@ struct ActionCondition {
 
 	ServerIdType serverId;
 	LocalHostIdType hostIdInServer;
-	uint64_t hostgroupId;
+	HostgroupIdType hostgroupId;
 	TriggerIdType triggerId;
 	int      triggerStatus;
 	int      triggerSeverity;
@@ -70,8 +70,9 @@ struct ActionCondition {
 	}
 
 	ActionCondition(uint32_t _enableBits, const ServerIdType &_serverId,
-	                const LocalHostIdType _hostIdInServer,
-	                uint64_t _hostgroupId, const TriggerIdType & _triggerId,
+	                const LocalHostIdType &_hostIdInServer,
+	                const HostgroupIdType &_hostgroupId,
+	                const TriggerIdType & _triggerId,
 	                int _triggerStatus, int _triggerSeverity,
 	                ComparisonType _triggerSeverityCompType)
 	: enableBits(_enableBits),

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -60,6 +60,7 @@ const char *DBTablesMonitoring::TABLE_NAME_INCIDENTS  = "incidents";
 //   * events.trigger_id  -> VARCHAR
 //   * events.id          -> VARCHAR
 //   * incidents.event_id -> VARCHAR
+//   * items.id           -> VARCHAR
 const int DBTablesMonitoring::MONITORING_DB_VERSION =
   DBTables::Version::getPackedVer(0, 1, 0);
 
@@ -413,8 +414,8 @@ static const ColumnDef COLUMN_DEF_ITEMS[] = {
 	NULL,                              // defaultValue
 }, {
 	"id",                              // columnName
-	SQL_COLUMN_TYPE_BIGUINT,           // type
-	20,                                // columnLength
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_IDX,                       // keyType

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -375,12 +375,12 @@ void HatoholArmPluginGate::startOnDemandFetchHistory(
 	callback->serverId = m_impl->serverInfo.id;
 
 	const size_t additionalSize =
-	  itemInfo.hostIdInServer.size() + 1; // +1: NULL term.
+	  itemInfo.hostIdInServer.size() + 1 +
+	  itemInfo.id.size()             + 1; // +1: NULL term.
 	SmartBuffer cmdBuf;
 	HapiParamReqFetchHistory *body =
 	  setupCommandHeader<HapiParamReqFetchHistory>(
 	    cmdBuf, HAPI_CMD_REQ_FETCH_HISTORY, additionalSize);
-	body->itemId    = NtoL(itemInfo.id);
 	body->valueType = NtoL(static_cast<uint16_t>(itemInfo.valueType));
 	body->beginTime = NtoL(beginTime);
 	body->endTime   = NtoL(endTime);
@@ -388,6 +388,8 @@ void HatoholArmPluginGate::startOnDemandFetchHistory(
 	char *buf = reinterpret_cast<char *>(body + 1);
 	buf = putString(buf, body, itemInfo.hostIdInServer,
 	                &body->hostIdOffset, &body->hostIdLength);
+	buf = putString(buf, body, itemInfo.id,
+	                &body->itemIdOffset, &body->itemIdLength);
 	send(cmdBuf, callback);
 }
 

--- a/server/src/HatoholDBUtils.cc
+++ b/server/src/HatoholDBUtils.cc
@@ -192,7 +192,7 @@ void HatoholDBUtils::transformItemsToHatoholFormat(
 	const ItemGroupList &appGroupList = applications->getItemGroupList();
 	ItemGroupListConstIterator appGrpItr = appGroupList.begin();
 	for (; appGrpItr != appGroupList.end(); ++appGrpItr) {
-		uint64_t appId;
+		ItemCategoryIdType appId;
 		string   appName;
 		ItemGroupStream itemGroupStream(*appGrpItr);
 
@@ -478,8 +478,9 @@ bool HatoholDBUtils::transformItemItemGroupToItemInfo(
 		ItemCategoryNameMapConstIterator it =
 		  itemCategoryNameMap.find(itemCategoryId);
 		if (it == itemCategoryNameMap.end()) {
-			MLPL_ERR("Failed to get item category name: %"
-			         FMT_ITEM_CATEGORY_ID "\n", itemCategoryId);
+			MLPL_ERR("Failed to get item category name: "
+			         "%" FMT_ITEM_CATEGORY_ID "\n",
+			         itemCategoryId.c_str());
 			return false;
 		}
 		itemInfo.itemGroupName = it->second;

--- a/server/src/RestResourceAction.cc
+++ b/server/src/RestResourceAction.cc
@@ -117,7 +117,7 @@ void RestResourceAction::handleGet(void)
 		  agent, cond, "serverId", ACTCOND_SERVER_ID, cond.serverId);
 		setActionCondition<std::string>(
 		   agent, cond, "hostId", ACTCOND_HOST_ID, cond.hostIdInServer);
-		setActionCondition<uint64_t>(
+		setActionCondition<HostgroupIdType>(
 		  agent, cond, "hostgroupId", ACTCOND_HOST_GROUP_ID,
 		   cond.hostgroupId);
 		setActionCondition<std::string>(
@@ -223,8 +223,9 @@ static HatoholError parseActionParameter(FaceRest::ResourceHandler *job,
 	};
 
 	// hostgroupId
-	succeeded = getParamWithErrorReply<uint64_t>(
-	              job, "hostgroupId", "%" PRIu64, cond.hostgroupId, &exist);
+	succeeded = getParamWithErrorReply<HostgroupIdType>(
+	              job, "hostgroupId", "%" FMT_HOST_GROUP_ID,
+	              cond.hostgroupId, &exist);
 	if (!succeeded)
 		return HatoholError(HTERR_NOT_FOUND_PARAMETER, "hostgroupId");
 	if (exist)

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -851,7 +851,7 @@ static HatoholError parseHistoryParameter(
 void RestResourceHost::handlerGetHistory(void)
 {
 	ServerIdType serverId = ALL_SERVERS;
-	ItemId itemId = ALL_ITEMS;
+	ItemIdType itemId = ALL_ITEMS;
 	const time_t SECONDS_IN_A_DAY = 60 * 60 * 24;
 	time_t endTime = time(NULL);
 	time_t beginTime = endTime - SECONDS_IN_A_DAY;
@@ -875,7 +875,7 @@ void RestResourceHost::handlerGetHistory(void)
 		// We assume that items are alreay fetched.
 		// Because clients can't know the itemId wihout them.
 		string message = StringUtils::sprintf("itemId: %" FMT_ITEM_ID,
-						      itemId);
+						      itemId.c_str());
 		HatoholError err(HTERR_NOT_FOUND_TARGET_RECORD, message);
 		replyError(err);
 		return;

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -500,7 +500,7 @@ size_t NumTestDupEventInfo = ARRAY_SIZE(testDupEventInfo);
 ItemInfo testItemInfo[] = {
 {
 	1,                        // serverId
-	2,                        // id
+	"2",                      // id
 	30,                       // globalHostId
 	"1129",                   // hostIdInServer
 	"Rome wasn't built in a day",// brief
@@ -513,7 +513,7 @@ ItemInfo testItemInfo[] = {
 	"",                       // unit
 }, {
 	3,                        // serverId
-	1,                        // id
+	"1",                      // id
 	42,                       // globalHostId
 	"5",                      // hostIdInServer
 	"The age of the cat.",    // brief
@@ -526,7 +526,7 @@ ItemInfo testItemInfo[] = {
 	"age",                    // unit
 }, {
 	3,                        // serverId
-	2,                        // id
+	"2",                      // id
 	45,                       // globalHostId
 	"100",                    // hostIdInServer
 	"All roads lead to Rome.",// brief
@@ -539,7 +539,7 @@ ItemInfo testItemInfo[] = {
 	"",                       // unit
 }, {
 	4,                        // serverId
-	1,                        // id
+	"1",                      // id
 	100,                      // globalHostId
 	"100",                    // hostIdInServer
 	"All roads lead to Rome.",// brief
@@ -1014,37 +1014,37 @@ size_t NumTestIncidentInfo = ARRAY_SIZE(testIncidentInfo);
 HistoryInfo testHistoryInfo[] = {
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"0.0",          // value
 	{1205277200,0}, // clock
 },
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"1.0",          // value
 	{1236813200,0}, // clock
 },
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"2.0",          // value
 	{1268349200,0}, // clock
 },
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"3.0",          // value
 	{1299885200,0}, // clock
 },
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"4.0",          // value
 	{1331421200,0}, // clock
 },
 {
 	3,              // serverId
-	1,              // itemId
+	"1",            // itemId
 	"5.0",          // value
 	{1362957200,0}, // clock
 },
@@ -1427,7 +1427,7 @@ void getTestItemsIndexes(ServerIdItemInfoIdIndexMapMap &indexMap)
 
 ItemInfo *findTestItem(
   const ServerIdItemInfoIdIndexMapMap &indexMap,
-  const ServerIdType &serverId, const uint64_t itemId)
+  const ServerIdType &serverId, const ItemIdType &itemId)
 {
 	ServerIdItemInfoIdIndexMapMapConstIterator it = indexMap.find(serverId);
 	if (it == indexMap.end())

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -562,7 +562,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_TRIGGER_STATUS,   // enableBits
 	  1,                        // serverId
 	  "10",                     // hostIdInServer
-	  5,                        // hostgroupId
+	  "5",                      // hostgroupId
 	  "3",                      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_INFO,    // triggerSeverity
@@ -580,7 +580,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_TRIGGER_SEVERITY, // enableBits
 	  0,                        // serverId
 	  "0",                      // hostIdInServer
-	  0,                        // hostgroupId
+	  "0",                      // hostgroupId
 	  "74565", // 0x12345,      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
@@ -598,7 +598,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_TRIGGER_ID | ACTCOND_TRIGGER_STATUS,   // enableBits
 	  100,                      // serverIdInServer
 	  "9223372036854775807",    // hostIdInServer (0x7fffffffffffffff)
-	  0x8000000000000000,       // hostgroupId
+	  "9223372036854775808",  // 0x8000000000000000, // hostgroupId
 	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
@@ -617,7 +617,7 @@ ActionDef testActionDef[] = {
 	   ACTCOND_TRIGGER_SEVERITY,   // enableBits
 	  2,                        // serverId
 	  "9920249034889494527",    // hostIdInServer
-	  0x8000000000000000,       // hostGroupId
+	  "9223372036854775808",  // 0x8000000000000000, // hostgroupId
 	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
@@ -636,7 +636,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_TRIGGER_STATUS | ACTCOND_TRIGGER_SEVERITY, // enableBits
 	  100001,                   // serverId
 	  "100001",                 // hostIdInServer
-	  100001,                   // hostgroupId
+	  "100001",                 // hostgroupId
 	  "74565", // 0x12345,      // triggerId
 	  TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	  TRIGGER_SEVERITY_WARNING, // triggerSeverity
@@ -654,7 +654,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_TRIGGER_ID | ACTCOND_TRIGGER_STATUS,   // enableBits
 	  101,                      // serverId
 	  "9223372036854775807",    // hostIdInServer (0x7fffffffffffffff)
-	  0x8000000000000000,       // hostgroupId
+	  "9223372036854775808",  // 0x8000000000000000, // hostgroupId
 	  "18364758544493064720", // 0xfedcba9876543210, // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
@@ -672,7 +672,7 @@ ActionDef testActionDef[] = {
 	  ACTCOND_HOST_GROUP_ID,    // enableBits
 	  1,                        // serverId
 	  "10",                     // hostIdInServer
-	  5,                        // hostgroupId
+	  "5",                      // hostgroupId
 	  "0",                      // triggerId
 	  TRIGGER_STATUS_OK,        // triggerStatus
 	  TRIGGER_SEVERITY_CRITICAL,// triggerSeverity
@@ -696,7 +696,7 @@ ActionDef testUpdateActionDef = {
 		ACTCOND_TRIGGER_SEVERITY, // enableBits
 		2,                        // serverId
 		"1001",                   // hostIdInServer
-		2001,                     // hostGroupId
+		"2001",                   // hostGroupId
 		"14000",                  // triggerId
 		TRIGGER_STATUS_OK,        // triggerStatus
 		TRIGGER_SEVERITY_WARNING, // triggerSeverity

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -132,7 +132,7 @@ size_t getNumberOfTestTriggers(
   const HostgroupIdType &hostgroupId = ALL_HOST_GROUPS,
   const TriggerSeverityType &severity = NUM_TRIGGER_SEVERITY);
 
-typedef std::map<uint64_t, size_t>         ItemInfoIdIndexMap;
+typedef std::map<ItemIdType, size_t>         ItemInfoIdIndexMap;
 typedef ItemInfoIdIndexMap::iterator       ItemInfoIdIndexMapIterator;
 typedef ItemInfoIdIndexMap::const_iterator ItemInfoIdIndexMapConstIterator;
 
@@ -146,7 +146,7 @@ typedef ServerIdItemInfoIdIndexMapMap::const_iterator
 void getTestItemsIndexes(ServerIdItemInfoIdIndexMapMap &indexMap);
 ItemInfo *findTestItem(
   const ServerIdItemInfoIdIndexMapMap &indexMap,
-  const ServerIdType &serverId, const uint64_t itemId);
+  const ServerIdType &serverId, const ItemIdType &itemId);
 size_t getNumberOfTestItems(const ServerIdType &serverId);
 
 size_t getNumberOfTestHosts(

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -531,7 +531,7 @@ string makeHistoryOutput(const HistoryInfo &historyInfo)
 	    "%" FMT_SERVER_ID "|%" FMT_ITEM_ID
 	    "|%" PRIu64 "|%" PRIu64
 	    "|%s\n",
-	    historyInfo.serverId, historyInfo.itemId,
+	    historyInfo.serverId, historyInfo.itemId.c_str(),
 	    (uint64_t)historyInfo.clock.tv_sec,
 	    (uint64_t)historyInfo.clock.tv_nsec,
 	    historyInfo.value.c_str());

--- a/server/test/testActionManager.cc
+++ b/server/test/testActionManager.cc
@@ -1386,7 +1386,7 @@ void test_checkEventsWithMultipleIncidentSender(void)
 	    ACTCOND_TRIGGER_STATUS | ACTCOND_TRIGGER_SEVERITY, // enableBits
 	    0,                        // serverId
 	    "",                       // hostId
-	    0,                        // hostgroupId
+	    "",                       // hostgroupId
 	    "",                       // triggerId
 	    TRIGGER_STATUS_PROBLEM,   // triggerStatus
 	    TRIGGER_SEVERITY_INFO,    // triggerSeverity

--- a/server/test/testArmBase.cc
+++ b/server/test/testArmBase.cc
@@ -492,7 +492,7 @@ void test_fetchHistory(void)
 	  TestFetchCtx::oneProcFetchHistoryHook, &ctx);
 
 	ItemInfo itemInfo;
-	itemInfo.id = 0;
+	itemInfo.id = "0";
 	itemInfo.serverId = 0;
 	itemInfo.globalHostId = 0;
 	itemInfo.valueType = ITEM_INFO_VALUE_TYPE_FLOAT;

--- a/server/test/testArmZabbixAPI.cc
+++ b/server/test/testArmZabbixAPI.cc
@@ -172,7 +172,7 @@ public:
 	{
 		ItemInfo itemInfo;
 		itemInfo.serverId = 1;
-		itemInfo.id = 25490;
+		itemInfo.id = "25490";
 		itemInfo.globalHostId = 0;
 		itemInfo.valueType = ITEM_INFO_VALUE_TYPE_FLOAT;
 		const ArmPollingResult oneProcEndType

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -48,7 +48,8 @@ static string makeExpectedString(const ActionDef &actDef, int expectedId)
 	                                 cond.hostIdInServer.c_str()) :
 	            DBCONTENT_MAGIC_NULL "|";
 	expect += cond.isEnable(ACTCOND_HOST_GROUP_ID) ?
-	            StringUtils::sprintf("%" PRIu64 "|", cond.hostgroupId) :
+	            StringUtils::sprintf("%" FMT_HOST_GROUP_ID "|",
+	                                 cond.hostgroupId.c_str()) :
 	            DBCONTENT_MAGIC_NULL "|";
 	expect += cond.isEnable(ACTCOND_TRIGGER_ID) ?
 	             StringUtils::sprintf("%" FMT_TRIGGER_ID "|",

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -143,7 +143,7 @@ static string makeItemOutput(const ItemInfo &itemInfo)
 	  StringUtils::sprintf(
 	    "%" FMT_SERVER_ID "|%" FMT_ITEM_ID "|%" FMT_HOST_ID
 	    "|%" FMT_LOCAL_HOST_ID "|%s|%ld|%lu|%s|%s|%s|%d|%s\n",
-	    itemInfo.serverId, itemInfo.id,
+	    itemInfo.serverId, itemInfo.id.c_str(),
 	    itemInfo.globalHostId,
 	    itemInfo.hostIdInServer.c_str(),
 	    itemInfo.brief.c_str(),

--- a/server/test/testFaceRestAction.cc
+++ b/server/test/testFaceRestAction.cc
@@ -130,7 +130,7 @@ static void _assertActions(const string &path, const string &callbackName = "",
 		  string, cond.hostIdInServer);
 		asssertActionCondition(
 		  g_parser, cond, "hostgroupId", ACTCOND_HOST_GROUP_ID,
-		  uint64_t, cond.hostgroupId);
+		  HostgroupIdType, cond.hostgroupId);
 		asssertActionCondition(
 		  g_parser, cond, "triggerId", ACTCOND_TRIGGER_ID,
 		  string, cond.triggerId);

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -348,7 +348,7 @@ static void _assertItems(const string &path, const string &callbackName = "",
 	set<ItemInfo *> itemInfoPtrSet;
 	for (ssize_t i = 0; i < numItems; i++) {
 		int64_t serverId = 0;
-		int64_t itemInfoId = 0;
+		ItemIdType itemInfoId;
 
 		parser->startElement(i);
 		cppcut_assert_equal(true, parser->read("serverId", serverId));
@@ -647,7 +647,7 @@ void test_getHistoryWithMinimumParameter(void)
 	RequestArg arg("/history");
 	StringMap params;
 	params["serverId"] = StringUtils::toString(testItemInfo[0].serverId);
-	params["itemId"] = StringUtils::toString(testItemInfo[0].id);
+	params["itemId"] = testItemInfo[0].id;
 	arg.parameters = params;
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	JSONParser *parser = getResponseAsJSONParser(arg);
@@ -664,7 +664,7 @@ void test_getHistoryWithInvalidItemId(void)
 	RequestArg arg("/history");
 	StringMap params;
 	params["serverId"] = StringUtils::toString(testItemInfo[0].serverId);
-	params["itemId"] = StringUtils::toString(testItemInfo[0].id);
+	params["itemId"] = testItemInfo[0].id;
 	arg.parameters = params;
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	JSONParser *parser = getResponseAsJSONParser(arg);

--- a/server/test/testHatoholArmPluginGate.cc
+++ b/server/test/testHatoholArmPluginGate.cc
@@ -338,7 +338,9 @@ struct HatoholArmPluginBaseTest :
 		SmartBuffer *cmdBuf = getCurrBuffer();
 		HapiParamReqFetchHistory *params =
 		  getCommandBody<HapiParamReqFetchHistory>(*cmdBuf);
-		ItemId itemId = static_cast<ItemIdType>(LtoN(params->itemId));
+		ItemIdType itemId = getString(*cmdBuf, params,
+		                      params->itemIdOffset,
+		                      params->itemIdLength);
 		time_t beginTime = static_cast<time_t>(LtoN(params->beginTime));
 		time_t endTime = static_cast<time_t>(LtoN(params->endTime));
 

--- a/server/test/testHatoholArmPluginGate.cc
+++ b/server/test/testHatoholArmPluginGate.cc
@@ -314,7 +314,8 @@ struct HatoholArmPluginBaseTest :
 			const ItemInfo &itemInfo = testItemInfo[i];
 			if (itemInfo.serverId != serverIdOfHapGate)
 				continue;
-			const ItemCategoryIdType itemCategoryId = i + 100;
+			const ItemCategoryIdType itemCategoryId =
+			  StringUtils::sprintf("%zd", i + 100);
 			itemTablePtr->add(convert(itemInfo, itemCategoryId));
 			itemCategoryNameMap[itemCategoryId] =
 			  itemInfo.itemGroupName;

--- a/server/test/testHatoholDBUtils.cc
+++ b/server/test/testHatoholDBUtils.cc
@@ -53,7 +53,7 @@ public:
 	  const bool useItemCategoryNameMap)
 	{
 		const ItemCategoryIdType itemCategoryId =
-		  useItemCategoryNameMap ? 1234 : NO_ITEM_CATEGORY_ID;
+		  useItemCategoryNameMap ? "1234" : NO_ITEM_CATEGORY_ID;
 		ItemInfo expect = testItemInfo[0]; // make a copy
 		VariableItemGroupPtr item = convert(expect, itemCategoryId);
 

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -479,10 +479,10 @@ void data_itemsQueryOptionWithTargetId(void)
 void test_itemsQueryOptionWithTargetId(gconstpointer data)
 {
 	ItemsQueryOption option(USER_ID_SYSTEM);
-	ItemIdType expectedId = 436;
+	ItemIdType expectedId = "436";
 	option.setTargetId(expectedId);
 	string expected = StringUtils::sprintf(
-		"items.id=%" FMT_ITEM_ID, expectedId);
+		"items.id='%" FMT_ITEM_ID "'", expectedId.c_str());
 	fixupForFilteringDefunctServer(data, expected, option);
 	cppcut_assert_equal(expectedId, option.getTargetId());
 	cppcut_assert_equal(expected, option.getCondition());

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -89,7 +89,7 @@ static string dumpItemInfo(const ItemInfo &info)
 		"%" FMT_SERVER_ID "|%" FMT_ITEM_ID "|%" FMT_HOST_ID
 		"|%" FMT_LOCAL_HOST_ID "|%s|%lu|%ld|%s|%s|%s\n",
 		info.serverId,
-		info.id,
+		info.id.c_str(),
 		info.globalHostId,
 		info.hostIdInServer.c_str(),
 		info.brief.c_str(),

--- a/server/test/testZabbixAPI.cc
+++ b/server/test/testZabbixAPI.cc
@@ -199,7 +199,7 @@ void test_getHistory(void)
 	zbxApiTestee.testOpenSession();
 	ZabbixAPI::ValueType valueTypeFloat = ZabbixAPI::VALUE_TYPE_FLOAT;
 	ItemTablePtr history =
-	  zbxApiTestee.callGetHistory(25490, valueTypeFloat,
+	  zbxApiTestee.callGetHistory("25490", valueTypeFloat,
 				      1413265550, 1413268970);
 	const ItemGroupList &list = history->getItemGroupList();
 	ItemGroupListConstIterator it = list.begin();
@@ -221,12 +221,12 @@ void test_getHistory(void)
 			json += ",";
 		json += mlpl::StringUtils::sprintf(
 			"{"
-			"\"itemid\":\"%" PRIu64 "\","
+			"\"itemid\":\"%" FMT_ITEM_ID "\","
 			"\"clock\":\"%" PRIu64 "\","
 			"\"value\":\"%s\","
 			"\"ns\":\"%" PRIu64 "\""
 			"}",
-			itemid, clock, value.c_str(), ns);
+			itemid.c_str(), clock, value.c_str(), ns);
 	}
 	string path = getFixturesDir() + "zabbix-api-res-history.json";
 	gchar *contents = NULL;

--- a/server/test/zabbix-api-response-collector.cc
+++ b/server/test/zabbix-api-response-collector.cc
@@ -174,7 +174,7 @@ bool ZabbixAPIResponseCollector::commandFuncApplication(CommandContext &ctx)
 	if (!commandFuncOpenSilent(ctx))
 		return false;
 
-	vector<uint64_t> hostIds; // empty means all hosts.
+	const ItemCategoryIdVector hostIds; // empty means all hosts.
 	HatoholError queryRet;
 	SoupMessage *msg = queryApplication(hostIds, queryRet);
 	if (!msg)


### PR DESCRIPTION
[server] Change the type of the Hostgroup ID in Action conditionItem ID to a string.

Some monitoring systems such as OpenStack's ceilometer
use UUIDs to identify some resources. In order to save that
kind of data, Hatohol should also handle them as a string.
