### PR TITLE
Get max event

### DIFF
--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -34,6 +34,7 @@ static const guint DEFAULT_TIMEOUT = 60;
 static const size_t HISTORY_LIMIT_PER_ONCE = 1000;
 
 const uint64_t ZabbixAPI::EVENT_ID_NOT_FOUND = -1;
+const size_t ZabbixAPI::EVENT_ID_DIGIT_NUM = 20;
 
 struct ZabbixAPI::Impl {
 
@@ -1052,6 +1053,22 @@ string ZabbixAPI::pushString(JSONParser &parser, ItemGroup *itemGroup,
 	return value;
 }
 
+string ZabbixAPI::pushString(
+  JSONParser &parser, ItemGroup *itemGroup,
+  const string &name, const ItemId &itemId,
+  const size_t &digitNum, const char &padChar)
+{
+	string value;
+	getString(parser, name, value);
+	int numPads = digitNum - value.size();
+	string fixedValue;
+	if (numPads > 0)
+		fixedValue = string(numPads, padChar);
+	fixedValue += value;
+	itemGroup->add(new ItemString(itemId, fixedValue), false);
+	return fixedValue;
+}
+
 void ZabbixAPI::parseAndPushTriggerData(
   JSONParser &parser, VariableItemTablePtr &tablePtr, const int &index)
 {
@@ -1319,7 +1336,8 @@ void ZabbixAPI::parseAndPushEventsData(
 {
 	startElement(parser, index);
 	VariableItemGroupPtr grp;
-	pushString(parser, grp, "eventid",      ITEM_ID_ZBX_EVENTS_EVENTID);
+	pushString(parser, grp, "eventid",      ITEM_ID_ZBX_EVENTS_EVENTID,
+	           EVENT_ID_DIGIT_NUM, '0');
 	pushInt   (parser, grp, "source",       ITEM_ID_ZBX_EVENTS_SOURCE);
 	pushInt   (parser, grp, "object",       ITEM_ID_ZBX_EVENTS_OBJECT);
 	pushString(parser, grp, "objectid",     ITEM_ID_ZBX_EVENTS_OBJECTID);

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -667,6 +667,8 @@ uint64_t ZabbixAPI::getEndEventId(const bool &isFirst)
 SoupMessage *ZabbixAPI::queryEvent(uint64_t eventIdFrom, uint64_t eventIdTill,
 				   HatoholError &queryRet)
 {
+	using StringUtils::sprintf;
+
 	JSONBuilder agent;
 	agent.startObject();
 	agent.add("jsonrpc", "2.0");
@@ -674,13 +676,9 @@ SoupMessage *ZabbixAPI::queryEvent(uint64_t eventIdFrom, uint64_t eventIdTill,
 
 	agent.startObject("params");
 	agent.add("output", "extend");
-	string strEventIdFrom = StringUtils::sprintf("%" PRId64, eventIdFrom);
-	agent.add("eventid_from", strEventIdFrom.c_str());
-	if (eventIdTill != UNLIMITED) {
-		string strEventIdTill = StringUtils::sprintf("%" PRId64,
-		                                             eventIdTill);
-		agent.add("eventid_till", strEventIdTill.c_str());
-	}
+	agent.add("eventid_from", sprintf("%" PRIu64, eventIdFrom));
+	if (eventIdTill != UNLIMITED)
+		agent.add("eventid_till", sprintf("%" PRIu64, eventIdTill));
 	agent.endObject(); // params
 
 	agent.add("auth", m_impl->authToken);

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -41,6 +41,7 @@ public:
 		VALUE_TYPE_INTEGER = 3,
 		VALUE_TYPE_TEXT    = 4
 	} ValueType;
+	static const size_t EVENT_ID_DIGIT_NUM;
 
 	ZabbixAPI(void);
 	virtual ~ZabbixAPI();
@@ -306,6 +307,29 @@ protected:
 	                    const std::string &name, const ItemId &itemId);
 	std::string pushString(JSONParser &parser, ItemGroup *itemGroup,
 	                       const std::string &name, const ItemId &itemId);
+
+	/**
+	 * Get the value form the JSONParser as a string, pad the specified
+	 * character to the head of the string, and add it to ItemGroup.
+	 *
+	 * @parser    A JSONParser.
+	 * @itemGroup A pointer to the ItemGroup.
+	 * @name      A name of the JSON element to be gotten.
+	 * @itemId    An item ID of the ItemData to be created.
+	 * @digitNum
+	 * A digit nubmer of the created string for the ItemData. If the
+	 * length of the original string is smaller than this value, the
+	 * specified character \padChar is filled at the head of the
+	 * created string.
+	 * @padChar   A character for padding.
+	 *
+	 * @return    A created string with padding.
+	 */
+	std::string pushString(
+	  JSONParser &parser, ItemGroup *itemGroup,
+	  const std::string &name, const ItemId &itemId,
+	  const size_t &digitNum, const char &padChar);
+
 	void parseAndPushTriggerData(
 	  JSONParser &parser,
 	  VariableItemTablePtr &tablePtr, const int &index);

--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -539,7 +539,7 @@ void ArmNagiosNDOUtils::addConditionForEventQuery(void)
 	ThreadLocalDBCache cache;
 	const MonitoringServerInfo &svInfo = getServerInfo();
 	const EventIdType lastEventId =
-	  cache.getMonitoring().getLastEventId(svInfo.id);
+	  cache.getMonitoring().getMaxEventId(svInfo.id);
 	string cond;
 	DBAgent::SelectExArg &arg = m_impl->selectEventBuilder.getSelectExArg();
 	arg.condition = m_impl->selectEventBaseCondition;

--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -121,7 +121,7 @@ void ArmZabbixAPI::updateEvents(void)
 
 	ThreadLocalDBCache cache;
 	const EventIdType _dbLastEventId =
-	  cache.getMonitoring().getLastEventId(m_impl->zabbixServerId);
+	  cache.getMonitoring().getMaxEventId(m_impl->zabbixServerId);
 	uint64_t dbLastEventId = EVENT_ID_NOT_FOUND;
 	if (_dbLastEventId != EVENT_NOT_FOUND)
 		Utils::conv(dbLastEventId, _dbLastEventId);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2002,15 +2002,17 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	return HatoholError(HTERR_OK);
 }
 
-EventIdType DBTablesMonitoring::getLastEventId(const ServerIdType &serverId)
+EventIdType DBTablesMonitoring::getMaxEventId(const ServerIdType &serverId)
 {
+	using StringUtils::sprintf;
 	DBTermCStringProvider rhs(*getDBAgent().getDBTermCodec());
 	DBAgent::SelectExArg arg(tableProfileEvents);
-	// TODO: This is inefficient
-	string stmt = StringUtils::sprintf("max(cast(%s as unsigned))",
-	    COLUMN_DEF_EVENTS[IDX_EVENTS_ID].columnName);
+	string stmt = sprintf("coalesce(max(%s), '%s')",
+	                      COLUMN_DEF_EVENTS[IDX_EVENTS_ID].columnName,
+	                      EVENT_NOT_FOUND.c_str());
 	arg.add(stmt, COLUMN_DEF_EVENTS[IDX_EVENTS_ID].type);
-	arg.condition = StringUtils::sprintf("%s=%s",
+	arg.condition =
+	  sprintf("%s=%s",
 	    COLUMN_DEF_EVENTS[IDX_EVENTS_SERVER_ID].columnName,
 	    rhs(serverId));
 

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -185,14 +185,14 @@ public:
 				      IncidentInfoVect *incidentInfoVect = NULL);
 
 	/**
-	 * get the last (maximum) event ID of the event that belongs to
-	 * the specified server
+	 * get the maximum event ID that belongs to the specified server
+	 *
 	 * @param serverId A target server ID.
 	 * @return
-	 * The last event ID. If there is no event data, EVENT_NOT_FOUND
+	 * The max event ID. If there is no event data, EVENT_NOT_FOUND
 	 * is returned.
 	 */
-	EventIdType getLastEventId(const ServerIdType &serverId);
+	EventIdType getMaxEventId(const ServerIdType &serverId);
 
 	/**
 	 * Get the time of the last event.

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -802,7 +802,7 @@ void HatoholArmPluginGate::cmdHandlerGetLastEventId(
 {
 	ThreadLocalDBCache cache;
 	const EventIdType lastEventId =
-	  cache.getMonitoring().getLastEventId(m_impl->serverInfo.id);
+	  cache.getMonitoring().getMaxEventId(m_impl->serverInfo.id);
 	const size_t additionalSize = lastEventId.size() + 1;
 	SmartBuffer resBuf;
 	HapiResLastEventId *body =

--- a/server/test/ZabbixAPITestUtils.cc
+++ b/server/test/ZabbixAPITestUtils.cc
@@ -166,6 +166,15 @@ ItemTablePtr ZabbixAPITestee::callGetHistory(
 	return getHistory(itemId, valueType, beginTime, endTime);
 }
 
+string ZabbixAPITestee::callPushString(
+  JSONParser &parser, ItemGroup *itemGroup,
+  const string &name, const ItemId &itemId,
+  const size_t &digitNum, const char &padChar)
+{
+	return pushString(parser, itemGroup, name, itemId, digitNum, padChar);
+}
+
+
 void ZabbixAPITestee::makeTriggersItemTable(ItemTablePtr &triggersTablePtr)
 {
 	ifstream ifs("fixtures/zabbix-api-res-triggers-003-hosts.json");

--- a/server/test/ZabbixAPITestUtils.h
+++ b/server/test/ZabbixAPITestUtils.h
@@ -58,6 +58,10 @@ public:
 				    const ZabbixAPI::ValueType &valueType,
 				    const time_t &beginTime,
 				    const time_t &endTime);
+	std::string callPushString(
+	  JSONParser &parser, ItemGroup *itemGroup,
+	  const std::string &name, const ItemId &itemId,
+	  const size_t &digitNum, const char &padChar);
 
 	void makeTriggersItemTable(ItemTablePtr &triggersTablePtr);
 	void makeTriggerExpandedDescriptionItemTable(

--- a/server/test/testArmZabbixAPI.cc
+++ b/server/test/testArmZabbixAPI.cc
@@ -864,13 +864,13 @@ void test_oneNewEvent(void)
 	ThreadLocalDBCache cache;
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
 	uint64_t actualEventId;
-	Utils::conv(actualEventId, dbMonitoring.getLastEventId(serverInfo.id));
+	Utils::conv(actualEventId, dbMonitoring.getMaxEventId(serverInfo.id));
 	cppcut_assert_equal(expectedEventId, actualEventId);
 
 	++expectedEventId;
 	g_apiEmulator.setExpectedLastEventId(expectedEventId);
 	armZbxApiTestee.callUpdateEvents();
-	Utils::conv(actualEventId, dbMonitoring.getLastEventId(serverInfo.id));
+	Utils::conv(actualEventId, dbMonitoring.getMaxEventId(serverInfo.id));
 	cppcut_assert_equal(expectedEventId, actualEventId);
 }
 

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -711,21 +711,21 @@ void data_getLastEventId(void)
 	prepareTestDataForFilterForDataOfDefunctServers();
 }
 
-void test_getLastEventId(gconstpointer data)
+void test_getMaxEventId(gconstpointer data)
 {
 	test_addEventInfoList(data);
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
 	const ServerIdType serverid = 3;
 	cppcut_assert_equal(findLastEventId(serverid),
-	                    dbMonitoring.getLastEventId(serverid));
+	                    dbMonitoring.getMaxEventId(serverid));
 }
 
-void test_getLastEventIdWithNoEvent(void)
+void test_getMaxEventIdWithNoEvent(void)
 {
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
 	const ServerIdType serverid = 3;
 	cppcut_assert_equal(EVENT_NOT_FOUND,
-	                    dbMonitoring.getLastEventId(serverid));
+	                    dbMonitoring.getMaxEventId(serverid));
 }
 
 void test_getTimeOfLastEvent(void)


### PR DESCRIPTION
In a recent commit, getLastEventId() had changed to use cast().
in order to get the maximum number from the ones saved as a string.
However, it cannot utilize indexes. So it degrades the performance.

This patch just reverts it and uses max() again as with the code before.
Instead, the events have to be saved with the same digit number.
For Zabbix events, this has already been done in the previous commit.

NOTE: We should delete all events in DB before use it.