### PR TITLE
[DBTablesHost] Clean up.

### DIFF
--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1023,12 +1023,10 @@ bool DBTablesHost::isAccessible(
 	ItemGroupListConstIterator itemGrpItr = grpList.begin();
 	for (; itemGrpItr != grpList.end(); ++itemGrpItr) {
 		ServerIdType serverId;
-		string hostgroupIdInServer;
+		HostgroupIdType hostgroupId;
 		ItemGroupStream itemGroupStream(*itemGrpItr);
 		itemGroupStream >> serverId;
-		// TODO: DBTablesUser should handle hostgroup ID as a string
-		HostgroupIdType hostgroupId =
-		  itemGroupStream.read<string, HostgroupIdType>();
+		itemGroupStream >> hostgroupId;
 		if (dbUser.isAccessible(serverId, hostgroupId, option))
 			return true;
 	}


### PR DESCRIPTION
Now HostgroupIdType is a string. So the complicated conversion is no long needed.