### PR TITLE
Use global host id 3

### DIFF
--- a/server/src/ArmNagiosNDOUtils.cc
+++ b/server/src/ArmNagiosNDOUtils.cc
@@ -806,6 +806,8 @@ void ArmNagiosNDOUtils::getHostgroupMembers(void)
 		  itemGroupStream.read<int, string>();
 		hostgrpMember.hostgroupIdInServer =
 		  itemGroupStream.read<int, string>();
+		hostgrpMember.hostId =
+		  m_impl->getGlobalHostId(hostgrpMember.hostIdInServer);
 		hostgroupMembers.push_back(hostgrpMember);
 	}
 	UnifiedDataStore::getInstance()->upsertHostgroupMembers(hostgroupMembers);

--- a/server/src/ArmZabbixAPI.cc
+++ b/server/src/ArmZabbixAPI.cc
@@ -247,7 +247,8 @@ void ArmZabbixAPI::makeHatoholMapHostsHostgroups(ItemTablePtr hostsGroups)
 {
 	HostgroupMemberVect hostgroupMembers;
 	HatoholDBUtils::transformHostsGroupsToHatoholFormat(
-	  hostgroupMembers, hostsGroups, m_impl->zabbixServerId);
+	  hostgroupMembers, hostsGroups, m_impl->zabbixServerId,
+	  m_impl->hostInfoCache);
 	UnifiedDataStore *uds = UnifiedDataStore::getInstance();
 	THROW_HATOHOL_EXCEPTION_IF_NOT_OK(
 	  uds->upsertHostgroupMembers(hostgroupMembers));

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -375,10 +375,11 @@ static bool updateDB(
 {
 	const int &oldVer = oldPackedVer.minorVer;
 	if (oldVer == 1 || oldVer == 2) {
-		// In table ver.1 and 2 (on 14.09 and 14.12), these table is
+		// In table ver.1 and 2 (on 14.09 and 14.12), these tables are
 		// not used. So we can drop it.
 		dbAgent.dropTable(tableProfileHostList.name);
 		dbAgent.dropTable(tableProfileServerHostDef.name);
+		dbAgent.dropTable(tableProfileHostgroupMember.name);
 	}
 	return true;
 }

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -925,6 +925,7 @@ HatoholError DBTablesHost::getHostgroupMembers(
 	arg.add(IDX_HOSTGROUP_MEMBER_SERVER_ID);
 	arg.add(IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER);
 	arg.add(IDX_HOSTGROUP_MEMBER_GROUP_ID);
+	arg.add(IDX_HOSTGROUP_MEMBER_HOST_ID);
 
 	arg.condition = option.getCondition();
 
@@ -940,6 +941,7 @@ HatoholError DBTablesHost::getHostgroupMembers(
 		itemGroupStream >> hostgrpMember.serverId;
 		itemGroupStream >> hostgrpMember.hostIdInServer;
 		itemGroupStream >> hostgrpMember.hostgroupIdInServer;
+		itemGroupStream >> hostgrpMember.hostId;
 		hostgroupMembers.push_back(hostgrpMember);
 	}
 
@@ -1027,13 +1029,9 @@ bool DBTablesHost::isAccessible(
 	DBClientJoinBuilder builder(tableProfileServerHostDef);
 	builder.add(IDX_HOST_SERVER_HOST_DEF_SERVER_ID);
 
-	// TODO: add a column including host_id and use it
 	builder.addTable(
 	  tableProfileHostgroupMember, DBClientJoinBuilder::INNER_JOIN,
-	  tableProfileServerHostDef, IDX_HOST_SERVER_HOST_DEF_SERVER_ID,
-	  IDX_HOSTGROUP_MEMBER_SERVER_ID,
-	  tableProfileServerHostDef, IDX_HOST_SERVER_HOST_DEF_HOST_ID_IN_SERVER,
-	  IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER);
+	  IDX_HOST_SERVER_HOST_DEF_HOST_ID, IDX_HOSTGROUP_MEMBER_HOST_ID);
 	builder.add(IDX_HOSTGROUP_MEMBER_GROUP_ID);
 
 	DBAgent::SelectExArg &arg = builder.build();
@@ -1074,25 +1072,21 @@ HatoholError DBTablesHost::getServerHostDefs(
 	builder.add(IDX_HOST_SERVER_HOST_DEF_HOST_STATUS);
 
 	if (option.isHostgroupUsed()) {
-		// TODO: add a column including host_id and use it
 		builder.addTable(
 		  tableProfileHostgroupMember, DBClientJoinBuilder::INNER_JOIN,
-		  tableProfileServerHostDef, IDX_HOST_SERVER_HOST_DEF_SERVER_ID,
-		  IDX_HOSTGROUP_MEMBER_SERVER_ID,
-		  tableProfileServerHostDef,
-		  IDX_HOST_SERVER_HOST_DEF_HOST_ID_IN_SERVER,
-		  IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER);
+		  IDX_HOST_SERVER_HOST_DEF_HOST_ID,
+		  IDX_HOSTGROUP_MEMBER_HOST_ID);
 	}
 
 	DBAgent::SelectExArg &arg = builder.build();
 	if (option.isHostgroupUsed()) {
 		// TODO: FIX This low level implementation is temporary
 		// We should make a framework to use a sub query
-		string matchCond = StringUtils::sprintf("%s=%s AND %s=%s",
-		  tableProfileServerHostDef.getFullColumnName(IDX_HOST_SERVER_HOST_DEF_SERVER_ID).c_str(),
-		  tableProfileHostgroupMember.getFullColumnName(IDX_HOSTGROUP_MEMBER_SERVER_ID).c_str(),
-		  tableProfileServerHostDef.getFullColumnName(IDX_HOST_SERVER_HOST_DEF_HOST_ID_IN_SERVER).c_str(),
-		  tableProfileHostgroupMember.getFullColumnName(IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER).c_str());
+		string matchCond = StringUtils::sprintf("%s=%s",
+		  tableProfileServerHostDef.getFullColumnName(
+		    IDX_HOST_SERVER_HOST_DEF_HOST_ID).c_str(),
+		  tableProfileHostgroupMember.getFullColumnName(
+		    IDX_HOSTGROUP_MEMBER_HOST_ID).c_str());
 
 		arg.tableField = tableProfileServerHostDef.name;
 		arg.condition = "EXISTS (SELECT * from ";

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -326,6 +326,15 @@ static const ColumnDef COLUMN_DEF_HOSTGROUP_MEMBER[] = {
 	SQL_KEY_IDX,                       // keyType
 	0,                                 // flags
 	NULL,                              // defaultValue
+}, {
+	"host_id",                         // columnName
+	SQL_COLUMN_TYPE_BIGUINT,           // type
+	20,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_IDX,                       // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
 },
 };
 
@@ -868,6 +877,7 @@ GenericIdType DBTablesHost::upsertHostgroupMember(
 	arg.add(hostgroupMember.serverId);
 	arg.add(hostgroupMember.hostIdInServer);
 	arg.add(hostgroupMember.hostgroupIdInServer);
+	arg.add(hostgroupMember.hostId);
 	arg.upsertOnDuplicate = true;
 
 	DBAgent &dbAgent = getDBAgent();

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -83,6 +83,7 @@ struct HostgroupMember {
 	ServerIdType    serverId;
 	LocalHostIdType hostIdInServer;
 	HostgroupIdType hostgroupIdInServer;
+	HostIdType      hostId;
 };
 
 typedef std::vector<HostgroupMember>        HostgroupMemberVect;
@@ -133,6 +134,7 @@ enum {
 	IDX_HOSTGROUP_MEMBER_SERVER_ID,
 	IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER,
 	IDX_HOSTGROUP_MEMBER_GROUP_ID,
+	IDX_HOSTGROUP_MEMBER_HOST_ID,
 	NUM_IDX_HOSTGROUP_MEMBER,
 };
 

--- a/server/src/HatoholArmPluginGate.cc
+++ b/server/src/HatoholArmPluginGate.cc
@@ -911,7 +911,8 @@ void HatoholArmPluginGate::cmdHandlerSendHostgroupElements(
 
 	HostgroupMemberVect hostgroupMembers;
 	HatoholDBUtils::transformHostsGroupsToHatoholFormat(
-	  hostgroupMembers, hostgroupElementTablePtr, m_impl->serverInfo.id);
+	  hostgroupMembers, hostgroupElementTablePtr, m_impl->serverInfo.id,
+	  m_impl->hostInfoCache);
 
 	UnifiedDataStore *uds = UnifiedDataStore::getInstance();
 	THROW_HATOHOL_EXCEPTION_IF_NOT_OK(

--- a/server/src/HatoholDBUtils.cc
+++ b/server/src/HatoholDBUtils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -142,8 +142,8 @@ void HatoholDBUtils::transformGroupsToHatoholFormat(
 }
 
 void HatoholDBUtils::transformHostsGroupsToHatoholFormat(
-  HostgroupMemberVect &hostgroupMembers,
-  const ItemTablePtr mapHostHostgroups, const ServerIdType &serverId)
+  HostgroupMemberVect &hostgroupMembers, const ItemTablePtr mapHostHostgroups,
+  const ServerIdType &serverId, const HostInfoCache &hostInfoCache)
 {
 	const ItemGroupList &itemGroupList = mapHostHostgroups->getItemGroupList();
 	ItemGroupListConstIterator it = itemGroupList.begin();
@@ -151,7 +151,7 @@ void HatoholDBUtils::transformHostsGroupsToHatoholFormat(
 		HostgroupMember hostgrpMember;
 		hostgrpMember.serverId = serverId;
 		transformHostsGroupsItemGroupToHatoholFormat(
-		  hostgrpMember, *it);
+		  hostgrpMember, *it, serverId, hostInfoCache);
 		hostgroupMembers.push_back(hostgrpMember);
 	}
 }
@@ -402,7 +402,8 @@ void HatoholDBUtils::transformGroupItemGroupToHostgroupInfo(
 }
 
 void HatoholDBUtils::transformHostsGroupsItemGroupToHatoholFormat(
-  HostgroupMember &hostgrpMember, const ItemGroup *groupHostsGroups)
+  HostgroupMember &hostgrpMember, const ItemGroup *groupHostsGroups,
+  const ServerIdType &serverId, const HostInfoCache &hostInfoCache)
 {
 	hostgrpMember.id = AUTO_INCREMENT_VALUE;
 
@@ -416,6 +417,13 @@ void HatoholDBUtils::transformHostsGroupsItemGroupToHatoholFormat(
 	itemGroupStream.seek(ITEM_ID_ZBX_HOSTS_GROUPS_GROUPID);
 	hostgrpMember.hostgroupIdInServer =
 	  itemGroupStream.read<uint64_t, string>();
+
+	HostInfoCache::Element cacheElem;
+	const bool found = findHostCache(serverId, hostgrpMember.hostIdInServer,
+	                                 hostInfoCache,  cacheElem);
+	if (!found)
+		return;
+	hostgrpMember.hostId = cacheElem.hostId;
 }
 
 bool HatoholDBUtils::transformItemItemGroupToItemInfo(

--- a/server/src/HatoholDBUtils.h
+++ b/server/src/HatoholDBUtils.h
@@ -40,7 +40,7 @@ public:
 	static void transformHostsGroupsToHatoholFormat(
 	  HostgroupMemberVect &hostgroupMembers,
 	  const ItemTablePtr mapHostHostgroups,
-	  const ServerIdType &serverId);
+	  const ServerIdType &serverId, const HostInfoCache &hostInfoCache);
 
 	static void transformHostsToHatoholFormat(
 	  ServerHostDefVect &svHostDefs, const ItemTablePtr hosts,
@@ -78,7 +78,8 @@ protected:
 	  Hostgroup &hostgroup, const ItemGroup *groupItemGroup);
 
 	static void transformHostsGroupsItemGroupToHatoholFormat(
-	  HostgroupMember &hostgrpMember, const ItemGroup *groupHostsGroups);
+	  HostgroupMember &hostgrpMember, const ItemGroup *groupHostsGroups,
+	  const ServerIdType &serverId, const HostInfoCache &hostInfoCache);
 
 	static bool transformItemItemGroupToItemInfo(
 	  ItemInfo &itemInfo, const ItemGroup *item,

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1242,63 +1242,73 @@ const HostgroupMember testHostgroupMember[] = {
 	1,                               // serverId
 	"235012",                        // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	10,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	1,                               // serverId
 	"235012",                        // hostIdInServer
 	"2",                             // hostgroupIdInServer
+	10,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	1,                               // serverId
 	"235013",                        // hostIdInServer
 	"2",                             // hostgroupIdInServer
+	11,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	1,                               // serverId
 	"1129",                          // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	30,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	2,                               // serverId
 	"512",                           // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	40,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	2,                               // serverId
 	"512",                           // hostIdInServer
 	"2",                             // hostgroupIdInServer
+	40,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	3,                               // serverId
 	"10001",                         // hostIdInServer
 	"2",                             // hostgroupIdInServer
+	35,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	3,                               // serverId
 	"10002",                         // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	41,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	3,                               // serverId
 	"5",                             // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	42,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	3,                               // serverId
 	"100",                           // hostIdInServer
 	"2",                             // hostgroupIdInServer
+	45,                              // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	4,                               // serverId
 	"100",                           // hostIdInServer
 	"1",                             // hostgroupIdInServer
+	100,                             // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	2,                               // serverId
-	//"0x89abcdefffffffff",          // hostIdInServer
-	"9920249034889494527",           // getHostInfoList() handles HostID As decimal
-	// "0x8000000000000000",            // hostgroupIdInServer
-	"9223372036854775808",
+	"9920249034889494527", //"0x89abcdefffffffff",  // hostIdInServer
+	"9223372036854775808", // "0x8000000000000000", // hostgroupIdInServer
+	101,                             // hostId
 }, {
 	// This entry is for tests with a defunct server
 	AUTO_INCREMENT_VALUE,            // id
@@ -1306,31 +1316,37 @@ const HostgroupMember testHostgroupMember[] = {
 	// trigInfoDefunctSv1.hostIdInServer, // hostId,
 	"10002", // TODO: use the above after host ID in trigger becomes string
 	"1",                             // hostgroupIdInServer
+	494,                             // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	211,                             // serverId
 	"200",                           // hostIdInServer
 	"0",                             // hostgroupIdInServer
+	1050,                            // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	211,                             // serverId
 	"12111",                         // hostIdInServer
 	"123",                           // hostgroupIdInServer
+	2111,                            // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	211,                             // serverId
 	"12112",                         // hostIdInServer
 	"123",                           // hostgroupIdInServer
+	2112,                            // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	211,                             // serverId
 	"12113",                         // hostIdInServer
 	"124",                           // hostgroupIdInServer
+	2113,                            // hostId
 }, {
 	AUTO_INCREMENT_VALUE,            // id
 	222,                             // serverId
 	"110005",                        // hostIdInServer
 	"124",                           // hostgroupIdInServer
+	10005,                           // hostId
 }
 };
 const size_t NumTestHostgroupMember = ARRAY_SIZE(testHostgroupMember);

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -553,6 +553,41 @@ void test_upsertHostgroupMemberUpdateUsingIndex(void)
 	cppcut_assert_equal(id0, id1);
 }
 
+void test_getHostgroupMembers(void)
+{
+	loadTestDBServer();
+
+	HostgroupMember hostgroupMember;
+	hostgroupMember.id = AUTO_INCREMENT_VALUE;
+	hostgroupMember.serverId = testServerInfo[0].id;
+	hostgroupMember.hostIdInServer = "88664422";
+	hostgroupMember.hostgroupIdInServer = "1133";
+	hostgroupMember.hostId = 11223344;
+
+	DECLARE_DBTABLES_HOST(dbHost);
+	GenericIdType id0 = dbHost.upsertHostgroupMember(hostgroupMember);
+	const string expected0 =
+	  makeMapHostsHostgroupsOutput(hostgroupMember, id0);
+
+	hostgroupMember.hostIdInServer = "0817";
+	hostgroupMember.hostgroupIdInServer = "1155";
+	hostgroupMember.hostId = 1976;
+	GenericIdType id1 = dbHost.upsertHostgroupMember(hostgroupMember);
+	const string expected1 =
+	  makeMapHostsHostgroupsOutput(hostgroupMember, id1);
+
+	// Read the data out and check them
+	HostgroupMemberVect actualMembers;
+	HostgroupMembersQueryOption option(USER_ID_SYSTEM);
+	HatoholError err = dbHost.getHostgroupMembers(actualMembers, option);
+	assertHatoholError(HTERR_OK, err);
+	cppcut_assert_equal((size_t)2, actualMembers.size());
+	cppcut_assert_equal(expected0,
+	  makeMapHostsHostgroupsOutput(actualMembers[0], id0));
+	cppcut_assert_equal(expected1,
+	  makeMapHostsHostgroupsOutput(actualMembers[1], id1));
+}
+
 void test_getHypervisor(void)
 {
 	loadTestDBVMInfo();

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -133,11 +133,12 @@ static string makeMapHostsHostgroupsOutput(
   const HostgroupMember &hostgrpMember, const size_t &id)
 {
 	string expectedOut = StringUtils::sprintf(
-	  "%zd|%" FMT_SERVER_ID "|%s|%s\n",
+	  "%zd|%" FMT_SERVER_ID "|%s|%s|%" FMT_HOST_ID "\n",
 	  id + 1,
 	  hostgrpMember.serverId,
 	  hostgrpMember.hostIdInServer.c_str(),
-	  hostgrpMember.hostgroupIdInServer.c_str());
+	  hostgrpMember.hostgroupIdInServer.c_str(),
+	  hostgrpMember.hostId);
 
 	return expectedOut;
 }
@@ -455,11 +456,12 @@ void test_upsertHostgroupMember(void)
 	hostgroupMember.serverId = 52;
 	hostgroupMember.hostIdInServer = "88664422";
 	hostgroupMember.hostgroupIdInServer = "1133";
+	hostgroupMember.hostId = 10;
 
 	DECLARE_DBTABLES_HOST(dbHost);
 	GenericIdType id = dbHost.upsertHostgroupMember(hostgroupMember);
 	const string expect = StringUtils::sprintf(
-	  "%" FMT_GEN_ID "|52|88664422|1133", id);
+	  "%" FMT_GEN_ID "|52|88664422|1133|10", id);
 	const string statement = StringUtils::sprintf(
 	  "SELECT * FROM %s", tableProfileHostgroupMember.name);
 	assertDBContent(&dbHost.getDBAgent(), statement, expect);
@@ -492,14 +494,15 @@ void test_upsertHostgroupMemberAutoIncrement(void)
 	hostgroupMember.serverId = 52;
 	hostgroupMember.hostIdInServer = "88664422";
 	hostgroupMember.hostgroupIdInServer = "1133";
+	hostgroupMember.hostId = 0xfedcba9876543210;
 
 	DECLARE_DBTABLES_HOST(dbHost);
 	GenericIdType id0 = dbHost.upsertHostgroupMember(hostgroupMember);
 	hostgroupMember.hostgroupIdInServer = "Lion";
 	GenericIdType id1 = dbHost.upsertHostgroupMember(hostgroupMember);
 	const string expect = StringUtils::sprintf(
-	  "%" FMT_GEN_ID "|52|88664422|1133\n"
-	  "%" FMT_GEN_ID "|52|88664422|Lion", id0, id1);
+	  "%" FMT_GEN_ID "|52|88664422|1133|18364758544493064720\n"
+	  "%" FMT_GEN_ID "|52|88664422|Lion|18364758544493064720", id0, id1);
 	const string statement = StringUtils::sprintf(
 	  "SELECT * FROM %s ORDER BY id", tableProfileHostgroupMember.name);
 	assertDBContent(&dbHost.getDBAgent(), statement, expect);
@@ -514,13 +517,14 @@ void test_upsertHostgroupMemberUpdate(void)
 	hostgroupMember.serverId = 52;
 	hostgroupMember.hostIdInServer = "88664422";
 	hostgroupMember.hostgroupIdInServer = "1133";
+	hostgroupMember.hostId = 123456789;
 
 	DECLARE_DBTABLES_HOST(dbHost);
 	GenericIdType id0 = dbHost.upsertHostgroupMember(hostgroupMember);
 	hostgroupMember.id = id0;
 	GenericIdType id1 = dbHost.upsertHostgroupMember(hostgroupMember);
 	const string expect = StringUtils::sprintf(
-	  "%" FMT_GEN_ID "|52|88664422|1133", id1);
+	  "%" FMT_GEN_ID "|52|88664422|1133|123456789", id1);
 	const string statement = StringUtils::sprintf(
 	  "SELECT * FROM %s", tableProfileHostgroupMember.name);
 	assertDBContent(&dbHost.getDBAgent(), statement, expect);
@@ -535,12 +539,13 @@ void test_upsertHostgroupMemberUpdateUsingIndex(void)
 	hostgroupMember.serverId = 52;
 	hostgroupMember.hostIdInServer = "88664422";
 	hostgroupMember.hostgroupIdInServer = "1133";
+	hostgroupMember.hostId = 11223344;
 
 	DECLARE_DBTABLES_HOST(dbHost);
 	GenericIdType id0 = dbHost.upsertHostgroupMember(hostgroupMember);
 	GenericIdType id1 = dbHost.upsertHostgroupMember(hostgroupMember);
 	const string expect = StringUtils::sprintf(
-	  "%" FMT_GEN_ID "|52|88664422|1133", id1);
+	  "%" FMT_GEN_ID "|52|88664422|1133|11223344", id1);
 	const string statement = StringUtils::sprintf(
 	  "SELECT * FROM %s", tableProfileHostgroupMember.name);
 	assertDBContent(&dbHost.getDBAgent(), statement, expect);


### PR DESCRIPTION
These patches add 'host_id', in other words Global Host ID in hostgroup_member.
It make some SQL statements simple. Previously some statements use the combination
of Server ID and (loacal) Host ID. This PR eliminates the need for it.