### PR TITLE
[ArmBase] Set proper trigger status at setServerConnectStatus()

### DIFF
--- a/server/src/ArmBase.cc
+++ b/server/src/ArmBase.cc
@@ -425,7 +425,12 @@ void ArmBase::setInitialTriggerStatus(void)
 
 void ArmBase::setServerConnectStatus(const ArmPollingResult &type)
 {
-	m_impl->utils.updateTriggerStatus(type, TRIGGER_STATUS_PROBLEM);
+	TriggerStatusType status;
+	if (type == COLLECT_OK)
+		status = TRIGGER_STATUS_OK;
+	else
+		status = TRIGGER_STATUS_PROBLEM;
+	m_impl->utils.updateTriggerStatus(type, status);
 }
 
 gpointer ArmBase::mainThread(HatoholThreadArg *arg)


### PR DESCRIPTION
In the previous code it always pass TRIGGER_STATUS_PROBLEM as
the second argument of ArmUtils::updateTriggerStatus() even if
ArmPollingResult is COLLECT_OK. Although it doesn't use the second
argument in this case, it's too misleading.