### PR TITLE
Take some trigger information in events when the save

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1854,16 +1854,12 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	builder.add(IDX_EVENTS_HOST_NAME);
 	builder.add(IDX_EVENTS_BRIEF);
 
+	// TODO: CONSIDER:  Should we also have extended_info in the event
+	// table ? Then we can delte the following complicated join.
 	builder.addTable(
 	  tableProfileTriggers, DBClientJoinBuilder::LEFT_JOIN,
 	  tableProfileEvents, IDX_EVENTS_SERVER_ID, IDX_TRIGGERS_SERVER_ID,
 	  tableProfileEvents, IDX_EVENTS_TRIGGER_ID, IDX_TRIGGERS_ID);
-	builder.add(IDX_TRIGGERS_STATUS);
-	builder.add(IDX_TRIGGERS_SEVERITY);
-	builder.add(IDX_TRIGGERS_GLOBAL_HOST_ID);
-	builder.add(IDX_TRIGGERS_HOST_ID_IN_SERVER);
-	builder.add(IDX_TRIGGERS_HOSTNAME);
-	builder.add(IDX_TRIGGERS_BRIEF);
 	builder.add(IDX_TRIGGERS_EXTENDED_INFO);
 
 	if (incidentInfoVect) {
@@ -1921,63 +1917,17 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 		itemGroupStream >> eventInfo.time.tv_nsec;
 		itemGroupStream >> eventInfo.type;
 		itemGroupStream >> eventInfo.triggerId;
+		itemGroupStream >> eventInfo.status;
+		itemGroupStream >> eventInfo.severity;
+		itemGroupStream >> eventInfo.globalHostId;
+		itemGroupStream >> eventInfo.hostIdInServer;
+		itemGroupStream >> eventInfo.hostName;
+		itemGroupStream >> eventInfo.brief;
 
-		TriggerStatusType   eventStatus;
-		TriggerSeverityType eventSeverity;
-		HostIdType          eventGlobalHostId;
-		LocalHostIdType     eventHostIdInServer;
-		string              eventHostName;
-		string              eventBrief;
-		itemGroupStream >> eventStatus;
-		itemGroupStream >> eventSeverity;
-		itemGroupStream >> eventGlobalHostId;
-		itemGroupStream >> eventHostIdInServer;
-		itemGroupStream >> eventHostName;
-		itemGroupStream >> eventBrief;
-
-		TriggerStatusType   triggerStatus;
-		TriggerSeverityType triggerSeverity;
-		HostIdType          triggerGlobalHostId;
-		LocalHostIdType     triggerHostIdInServer;
-		string              triggerHostName;
-		string              triggerBrief;
-		string              triggerExtendedInfo;
-		itemGroupStream >> triggerStatus;
-		itemGroupStream >> triggerSeverity;
-		itemGroupStream >> triggerGlobalHostId;
-		itemGroupStream >> triggerHostIdInServer;
-		itemGroupStream >> triggerHostName;
-		itemGroupStream >> triggerBrief;
+		string triggerExtendedInfo;
 		itemGroupStream >> triggerExtendedInfo;
-
-		if (eventStatus != TRIGGER_STATUS_UNKNOWN) {
-			eventInfo.status = eventStatus;
-		} else {
-			eventInfo.status = triggerStatus;
-		}
-		if (eventSeverity != TRIGGER_SEVERITY_UNKNOWN) {
-			eventInfo.severity = eventSeverity;
-		} else {
-			eventInfo.severity = triggerSeverity;
-		}
-
-		if (eventGlobalHostId != INVALID_HOST_ID) {
-			eventInfo.globalHostId   = eventGlobalHostId;
-			eventInfo.hostIdInServer = eventHostIdInServer;
-			eventInfo.hostName = eventHostName;
-		} else {
-			eventInfo.globalHostId   = triggerGlobalHostId;
-			eventInfo.hostIdInServer = triggerHostIdInServer;
-			eventInfo.hostName = triggerHostName;
-		}
-		if (!eventBrief.empty()) {
-			eventInfo.brief = eventBrief;
-		} else {
-			eventInfo.brief = triggerBrief;
-		}
-		if (!triggerExtendedInfo.empty()) {
+		if (!triggerExtendedInfo.empty())
 			eventInfo.extendedInfo = triggerExtendedInfo;
-		}
 
 		if (incidentInfoVect) {
 			incidentInfoVect->push_back(IncidentInfo());

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -277,6 +277,25 @@ protected:
 	  DBAgent &dbAgent, const MonitoringServerStatus &serverStatus);
 	static void addIncidentInfoWithoutTransaction(
 	  DBAgent &dbAgent, const IncidentInfo &incidentInfo);
+
+	/**
+	 * Fill the following members if they are not set, with the
+	 * corresponding trigger information.
+	 *   - severity
+	 *   - globalHostId
+	 *   - hostIdInServer
+	 *   - hostName
+	 *   - brief
+	 *   - extenededInfo
+	 *
+	 * @param eventInfo An EventInfo instance to be set.
+	 *
+	 * @return
+	 * true if the corresponding trigger is found and the values are set.
+	 * Otherwise false is returned.
+	 */
+	static bool mergeTriggerInfo(DBAgent &dbAgent, EventInfo &eventInfo);
+
 	size_t getNumberOfTriggers(const TriggersQueryOption &option,
 				   const std::string &additionalCondition);
 

--- a/server/src/HatoholDBUtils.cc
+++ b/server/src/HatoholDBUtils.cc
@@ -17,9 +17,10 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <ZabbixAPI.h>
 #include "HatoholDBUtils.h"
 #include "DBTablesMonitoring.h"
-#include <ZabbixAPI.h>
+#include "ThreadLocalDBCache.h"
 
 using namespace std;
 using namespace mlpl;

--- a/server/test/testArmBase.cc
+++ b/server/test/testArmBase.cc
@@ -617,7 +617,7 @@ void test_setServerConnectStatus(void)
 	eventInfo.severity = TRIGGER_SEVERITY_EMERGENCY;
 	eventInfo.globalHostId = 1;
 	eventInfo.hostIdInServer = MONITORING_SELF_LOCAL_HOST_ID;
-	//eventInfo.hostName = "_SELF";
+	eventInfo.hostName = "_SELF";
 	eventInfo.brief = HatoholError(HTERR_INTERNAL_ERROR).getMessage();
 	cppcut_assert_equal(makeEventOutput(eventInfo),
 			    makeEventOutput(*events.begin()));


### PR DESCRIPTION
Until now, some members in EventInfo such as severity and brief
have been filled using a join operation with the trigger table,
when it's retrieved. This way has the following two demerits.

(1) It's hard to delete records in the trigger table.
(2) The number of the save of an event is only once, however
    it may be read many times with join operations.

So this patch resolves the problems by storing duplicated information
 in the event table.