### PR TITLE
[HapProcessCeilometer] Use a simple Item ID string.

### DIFF
--- a/server/hap/HapProcessCeilometer.cc
+++ b/server/hap/HapProcessCeilometer.cc
@@ -1041,7 +1041,7 @@ HatoholError HapProcessCeilometer::getResource(
 	// fill
 	// TODO: Don't use IDs concerned with Zabbix.
 	LocalHostIdType hostId = instanceId;
-	const ItemIdType itemId = instanceId + "/" + counterName;
+	const ItemIdType itemId = counterName;
 	const int timestampSec =
 	  (int)parseStateTimestamp(timestamp).getAsTimespec().tv_sec;
 	const string name = counterName + " (" + counterUnit + ")";

--- a/server/hap/HapProcessCeilometer.h
+++ b/server/hap/HapProcessCeilometer.h
@@ -106,8 +106,8 @@ protected:
 	  const std::string &instanceId);
 	std::string getHistoryTimeString(const timespec &timeSpec);
 	ItemTablePtr getHistory(
-	  const ItemIdType &itemId, const time_t &beginTime,
-	  const time_t &endTime);
+	  const ItemIdType &itemId, const LocalHostIdType &hostId,
+	  const time_t &beginTime, const time_t &endTime);
 
 private:
 	struct Impl;


### PR DESCRIPTION
Now an instance ID is also sent with the item ID.
So it's unnecessary to include an instance ID.