### PR TITLE
[server][DBTablesMonitoring] Use events.extended_info instead of triggers' one

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2729,9 +2729,7 @@ void DBTablesMonitoring::addIncidentInfoWithoutTransaction(
 static bool updateDB(
   DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
-	const int &oldVer = oldPackedVer.minorVer;
-	const int &oldMajorVer = oldPackedVer.majorVer;
-	const int &oldVendorVer = oldPackedVer.vendorVer;
+	const int &oldVer = oldPackedVer.getPackedVer();
 
 	if (oldVer == 4) {
 		const string oldTableName = "issues";
@@ -2793,8 +2791,7 @@ static bool updateDB(
 		addColumnsArg.columnIndexes.push_back(IDX_TRIGGERS_VALIDITY);
 		dbAgent.addColumns(addColumnsArg);
 	}
-	if (DBTables::Version::getPackedVer(oldVendorVer, oldMajorVer, oldVer)
-	    <= DBTables::Version::getPackedVer(0, 1, 1)) {
+	if (oldVer <= DBTables::Version::getPackedVer(0, 1, 1)) {
 		// add a new column "extended_info" to events
 		DBAgent::AddColumnsArg addColumnsArg(tableProfileEvents);
 		addColumnsArg.columnIndexes.push_back(IDX_EVENTS_EXTENDED_INFO);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -358,6 +358,15 @@ static const ColumnDef COLUMN_DEF_EVENTS[] = {
 	SQL_KEY_NONE,                      // keyType
 	0,                                 // flags
 	NULL,                              // defaultValue
+}, {
+	"extended_info",                   // columnName
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	32767,                             // columnLength
+	0,                                 // decFracLength
+	true,                              // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
 },
 };
 
@@ -375,6 +384,7 @@ enum {
 	IDX_EVENTS_HOST_ID_IN_SERVER,
 	IDX_EVENTS_HOST_NAME,
 	IDX_EVENTS_BRIEF,
+	IDX_EVENTS_EXTENDED_INFO,
 	NUM_IDX_EVENTS,
 };
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -62,7 +62,7 @@ const char *DBTablesMonitoring::TABLE_NAME_INCIDENTS  = "incidents";
 //   * incidents.event_id -> VARCHAR
 //   * items.id           -> VARCHAR
 const int DBTablesMonitoring::MONITORING_DB_VERSION =
-  DBTables::Version::getPackedVer(0, 1, 0);
+  DBTables::Version::getPackedVer(0, 1, 1);
 
 void operator>>(ItemGroupStream &itemGroupStream, TriggerStatusType &rhs)
 {
@@ -2730,6 +2730,9 @@ static bool updateDB(
   DBAgent &dbAgent, const DBTables::Version &oldPackedVer, void *data)
 {
 	const int &oldVer = oldPackedVer.minorVer;
+	const int &oldMajorVer = oldPackedVer.majorVer;
+	const int &oldVendorVer = oldPackedVer.vendorVer;
+
 	if (oldVer == 4) {
 		const string oldTableName = "issues";
 		if (dbAgent.isTableExisting(oldTableName)) {
@@ -2789,6 +2792,14 @@ static bool updateDB(
 		DBAgent::AddColumnsArg addColumnsArg(tableProfileTriggers);
 		addColumnsArg.columnIndexes.push_back(IDX_TRIGGERS_VALIDITY);
 		dbAgent.addColumns(addColumnsArg);
+	}
+	if (DBTables::Version::getPackedVer(oldVendorVer, oldMajorVer, oldVer)
+	    <= DBTables::Version::getPackedVer(0, 1, 1)) {
+		// add a new column "extended_info" to events
+		DBAgent::AddColumnsArg addColumnsArg(tableProfileEvents);
+		addColumnsArg.columnIndexes.push_back(IDX_EVENTS_EXTENDED_INFO);
+		dbAgent.addColumns(addColumnsArg);
+		return true;
 	}
 	return true;
 }

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1867,6 +1867,7 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	builder.add(IDX_EVENTS_HOST_ID_IN_SERVER);
 	builder.add(IDX_EVENTS_HOST_NAME);
 	builder.add(IDX_EVENTS_BRIEF);
+	builder.add(IDX_EVENTS_EXTENDED_INFO);
 
 	// TODO: CONSIDER:  Should we also have extended_info in the event
 	// table ? Then we can delte the following complicated join.
@@ -2668,6 +2669,7 @@ void DBTablesMonitoring::addEventInfoWithoutTransaction(
 	arg.add(eventInfo.hostIdInServer);
 	arg.add(eventInfo.hostName);
 	arg.add(eventInfo.brief);
+	arg.add(eventInfo.extendedInfo);
 	arg.upsertOnDuplicate = true;
 	dbAgent.insert(arg);
 	eventInfo.unifiedId = dbAgent.getLastInsertId();

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1800,14 +1800,14 @@ void DBTablesMonitoring::updateTrigger(const TriggerInfoList &triggerInfoList,
 		updateTriggerList.push_back(newTriggerInfo);
 	}
 
-	
+
 	TriggerIdInfoMapIterator invalidTriggerItr = triggerMap.begin();
 	for (; invalidTriggerItr != triggerMap.end(); ++invalidTriggerItr) {
 		TriggerInfo *invalidTrigger = invalidTriggerItr->second;
 		invalidTrigger->validity = TRIGGER_INVALID;
 		updateTriggerList.push_back(*invalidTrigger);
 	}
-	
+
 	addTriggerInfoList(updateTriggerList);
 }
 
@@ -2126,7 +2126,7 @@ void DBTablesMonitoring::getItemInfoList(ItemInfoList &itemInfoList,
 	                     IDX_HOST_SERVER_HOST_DEF_SERVER_ID,
 	  tableProfileItems, IDX_ITEMS_HOST_ID_IN_SERVER,
 	                     IDX_HOST_SERVER_HOST_DEF_HOST_ID_IN_SERVER);
-	
+
 	DBAgent::SelectExArg &arg = builder.build();
 	arg.useDistinct = option.isHostgroupUsed();
 	arg.useFullName = option.isHostgroupUsed();

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1099,12 +1099,10 @@ string EventsQueryOption::getCondition(void) const
 	if (m_impl->minSeverity != TRIGGER_SEVERITY_UNKNOWN) {
 		if (!condition.empty())
 			condition += " AND ";
-		// Use triggers table because events tables doesn't contain
-		// collect severity.
+		// Use events table because events tables contains severity.
 		condition += StringUtils::sprintf(
-			"%s.%s>=%d",
-			DBTablesMonitoring::TABLE_NAME_TRIGGERS,
-			COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_SEVERITY].columnName,
+			"%s>=%d",
+			COLUMN_DEF_EVENTS[IDX_EVENTS_SEVERITY].columnName,
 			m_impl->minSeverity);
 	}
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1869,14 +1869,6 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	builder.add(IDX_EVENTS_BRIEF);
 	builder.add(IDX_EVENTS_EXTENDED_INFO);
 
-	// TODO: CONSIDER:  Should we also have extended_info in the event
-	// table ? Then we can delte the following complicated join.
-	builder.addTable(
-	  tableProfileTriggers, DBClientJoinBuilder::LEFT_JOIN,
-	  tableProfileEvents, IDX_EVENTS_SERVER_ID, IDX_TRIGGERS_SERVER_ID,
-	  tableProfileEvents, IDX_EVENTS_TRIGGER_ID, IDX_TRIGGERS_ID);
-	builder.add(IDX_TRIGGERS_EXTENDED_INFO);
-
 	if (incidentInfoVect) {
 		builder.addTable(
 		  tableProfileIncidents, DBClientJoinBuilder::LEFT_JOIN,

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -386,6 +386,7 @@ const EventInfo testEventInfo[] = {
 	"10001",                  // hostIdInServer,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
+	"{\"expandedDescription\":\"Test Trigger on hostZ1\"}", // extendedInfo
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
@@ -399,6 +400,7 @@ const EventInfo testEventInfo[] = {
 	"10002",                  // hostIdInServer,
 	"hostZ2",                 // hostName,
 	"TEST Trigger 3",         // brief,
+	"",
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
@@ -412,6 +414,7 @@ const EventInfo testEventInfo[] = {
 	"235012",                 // hostIdInServer,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1a",        // brief,
+	"{\"expandedDescription\":\"Test Trigger on hostX1\"}", // extendedInfo
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
@@ -425,6 +428,7 @@ const EventInfo testEventInfo[] = {
 	"235012",                 // hostIdInServer,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1",         // brief,
+	"",
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	1,                        // serverId
@@ -451,6 +455,7 @@ const EventInfo testEventInfo[] = {
 	"10001",                  // hostIdInServer,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
+	"{\"expandedDescription\":\"Test Trigger on hostZ1\"}", // extendedInfo
 }, {
 	// This entry is for tests with a defunct server
 	AUTO_INCREMENT_VALUE,     // unifiedId
@@ -465,6 +470,7 @@ const EventInfo testEventInfo[] = {
 	trigInfoDefunctSv1.hostIdInServer, // hostIdInServer,
 	trigInfoDefunctSv1.hostName,       // hostName,
 	trigInfoDefunctSv1.brief,          // brief,
+	"",
 },
 // We assumed the data of the default server's is at the tail in testEventInfo.
 // See also the definition of trigInfoDefunctSv1 above. Anyway,
@@ -486,6 +492,7 @@ EventInfo testDupEventInfo[] = {
 	"10001",                  // hostIdInServer,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
+	"{\"expandedDescription\":\"Test Trigger on hostZ1\"}", // extendedInfo
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
@@ -499,6 +506,7 @@ EventInfo testDupEventInfo[] = {
 	"10002",                  // hostIdInServer,
 	"hostZ2",                 // hostName,
 	"TEST Trigger 3",         // brief,
+	"",
 }, {
 	AUTO_INCREMENT_VALUE,     // unifiedId
 	3,                        // serverId
@@ -512,6 +520,7 @@ EventInfo testDupEventInfo[] = {
 	"10002",                  // hostIdInServer,
 	"hostZ2",                 // hostName,
 	"TEST Trigger 3",         // brief,
+	"",
 },
 };
 size_t NumTestDupEventInfo = ARRAY_SIZE(testDupEventInfo);

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -487,7 +487,7 @@ string makeEventOutput(const EventInfo &eventInfo)
 	string output =
 	  mlpl::StringUtils::sprintf(
 	    "%" FMT_SERVER_ID "|%" FMT_EVENT_ID "|%ld|%ld|%d|%" FMT_TRIGGER_ID
-	    "|%d|%u|%" FMT_HOST_ID "|%" FMT_LOCAL_HOST_ID "|%s|%s\n",
+	    "|%d|%u|%" FMT_HOST_ID "|%" FMT_LOCAL_HOST_ID "|%s|%s|%s\n",
 	    eventInfo.serverId, eventInfo.id.c_str(),
 	    eventInfo.time.tv_sec, eventInfo.time.tv_nsec,
 	    eventInfo.type, eventInfo.triggerId.c_str(),
@@ -495,7 +495,8 @@ string makeEventOutput(const EventInfo &eventInfo)
 	    eventInfo.globalHostId,
 	    eventInfo.hostIdInServer.c_str(),
 	    eventInfo.hostName.c_str(),
-	    eventInfo.brief.c_str());
+	    eventInfo.brief.c_str(),
+	    eventInfo.extendedInfo.c_str());
 	return output;
 }
 

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -282,8 +282,11 @@ static void _assertEvents(const string &path, const string &callbackName = "")
 		assertValueInParser(parser, "hostId",    eventInfo.hostIdInServer);
 		assertValueInParser(parser, "brief",     eventInfo.brief);
 		if (!eventInfo.extendedInfo.empty()) {
+			string parsedExtendedInfo = "";
+			RestResourceHost::parseExtendedInfo(eventInfo.extendedInfo,
+							    parsedExtendedInfo);
 			assertValueInParser(parser, "expandedDescription",
-			                    eventInfo.extendedInfo);
+			                    parsedExtendedInfo);
 		}
 		if (shouldHaveIncident) {
 			assertStartObject(parser, "incident");

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -377,7 +377,7 @@ void test_eventQueryOptionWithMinimumSeverity(gconstpointer data)
 {
 	EventsQueryOption option(USER_ID_SYSTEM);
 	option.setMinimumSeverity(TRIGGER_SEVERITY_CRITICAL);
-	string expected =  "triggers.severity>=4";
+	string expected =  "severity>=4";
 	fixupForFilteringDefunctServer(data, expected, option);
 	cppcut_assert_equal(TRIGGER_SEVERITY_CRITICAL,
 			    option.getMinimumSeverity());


### PR DESCRIPTION
This work is for https://github.com/project-hatohol/hatohol/pull/1109#issuecomment-81364017.

* These patches keep migration code as possible. 
* Stop to use joining triggers and events tables.