### PR TITLE
[server][DBTablesMonitoring] Fix exception when filtering with hostname in event page (for releng_15.03)

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -817,8 +817,8 @@ void initEventInfo(EventInfo &eventInfo)
 static const HostResourceQueryOption::Synapse synapseEventsQueryOption(
   tableProfileEvents,
   IDX_EVENTS_UNIFIED_ID, IDX_EVENTS_SERVER_ID,
-  tableProfileTriggers,
-  IDX_TRIGGERS_HOST_ID_IN_SERVER, true,
+  tableProfileEvents,
+  IDX_EVENTS_HOST_ID_IN_SERVER, true,
   tableProfileHostgroupMember,
   IDX_HOSTGROUP_MEMBER_SERVER_ID, IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER,
   IDX_HOSTGROUP_MEMBER_GROUP_ID,

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -235,7 +235,9 @@ static void _assertTriggers(
 }
 #define assertTriggers(P,...) cut_trace(_assertTriggers(P,##__VA_ARGS__))
 
-static void _assertEvents(const string &path, const string &callbackName = "")
+static void _assertEvents(const string &path, const string &callbackName = "",
+                          const ServerIdType &serverId = ALL_SERVERS,
+                          const LocalHostIdType &hostIdInServer = ALL_LOCAL_HOSTS)
 {
 	loadTestDBTriggers();
 	loadTestDBEvents();
@@ -255,6 +257,18 @@ static void _assertEvents(const string &path, const string &callbackName = "")
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	JSONParser *parser = getResponseAsJSONParser(arg);
 	unique_ptr<JSONParser> parserPtr(parser);
+
+	// request
+	StringMap queryMap;
+	if (serverId != ALL_SERVERS) {
+		queryMap["serverId"] =
+		  StringUtils::sprintf("%" PRIu32, serverId);
+	}
+	if (hostIdInServer != ALL_LOCAL_HOSTS)
+		queryMap["hostId"] = hostIdInServer;
+	arg.parameters = queryMap;
+
+	// check the reply
 	assertErrorCode(parser);
 	assertValueInParser(parser, "numberOfEvents",
 	                    eventsArg.expectedRecords.size());
@@ -557,6 +571,13 @@ void test_triggersForOneServerOneHost(void)
 	assertTriggers("/trigger", "foo",
 	               testTriggerInfo[1].serverId,
 	               testTriggerInfo[1].hostIdInServer);
+}
+
+void test_eventsForOneServerOneHost(void)
+{
+	assertEvents("/event", "foo",
+		     testEventInfo[1].serverId,
+		     testEventInfo[1].hostIdInServer);
 }
 
 void test_events(void)

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -573,13 +573,6 @@ void test_triggersForOneServerOneHost(void)
 	               testTriggerInfo[1].hostIdInServer);
 }
 
-void test_eventsForOneServerOneHost(void)
-{
-	assertEvents("/event", "foo",
-		     testEventInfo[1].serverId,
-		     testEventInfo[1].hostIdInServer);
-}
-
 void test_events(void)
 {
 	assertEvents("/event");
@@ -596,6 +589,13 @@ void test_eventsWithIncidents(void)
 void test_eventsJSONP(void)
 {
 	assertEvents("/event", "foo");
+}
+
+void test_eventsForOneServerOneHost(void)
+{
+	assertEvents("/event", "foo",
+		     testEventInfo[1].serverId,
+		     testEventInfo[1].hostIdInServer);
 }
 
 void test_items(void)

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -430,7 +430,7 @@ void test_eventQueryOptionGetServerIdColumnName(gconstpointer data)
 	                  "%s.%s=26 AND %s.%s='32' AND %s.%s='48'",
 			  DBTablesMonitoring::TABLE_NAME_EVENTS,
 			  serverIdColumnName.c_str(),
-			  DBTablesMonitoring::TABLE_NAME_TRIGGERS,
+			  DBTablesMonitoring::TABLE_NAME_EVENTS,
 			  hostIdColumnName.c_str(),
 	                  tableProfileHostgroupMember.name,
 			  hostgroupIdColumnName.c_str());


### PR DESCRIPTION
* fix a bug that exception is raised when filtering with hostname in event page
* Add a reproduce test case for this bug