### PR TITLE
[server][DBTablesAction] Add test cases that actions does not run when monitored servers belong to multiple hostgroups

### DIFF
--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -1028,6 +1028,30 @@ void test_withoutPrivilege(void)
 	cppcut_assert_equal(expected, option.getCondition());
 }
 
+static void assertActionsQueryCondition(const UserIdType id, const EventInfo &event,
+					const ActionsQueryOption option,
+					const string expectedHostgroupIdStringList)
+{
+	string expected
+	  = StringUtils::sprintf(
+	    "(owner_user_id=%" FMT_USER_ID " AND "
+	    "action_type>=0 AND action_type<2) AND "
+	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
+	    "((host_id_in_server IS NULL) OR "
+	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
+	    "((host_group_id IS NULL) OR host_group_id IN (%" FMT_HOST_GROUP_ID ")) AND "
+	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
+	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
+	    "((trigger_severity IS NULL) OR "
+	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
+	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
+	    id, event.serverId, event.hostIdInServer.c_str(),
+	    expectedHostgroupIdStringList.c_str(),
+	    event.triggerId.c_str(),
+	    event.status, event.severity, event.severity);
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
 void test_withEventInfo(void)
 {
 	loadTestDBTablesUser();

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -1056,6 +1056,68 @@ void test_withEventInfo(void)
 	cppcut_assert_equal(expected, option.getCondition());
 }
 
+void test_withEventInfoWithOneHostgroup(void)
+{
+	loadTestDBTablesUser();
+	loadTestDBHostgroupMember();
+
+	UserIdType id = findUserWithout(OPPRVLG_GET_ALL_ACTION);
+	const EventInfo &event = testEventInfo[1]; // use host_id_in_server='10002'
+	ActionsQueryOption option(id);
+	option.setTargetEventInfo(&event);
+	string expectedHostgroupId = "'1'";
+	string expected
+	  = StringUtils::sprintf(
+	    "(owner_user_id=%" FMT_USER_ID " AND "
+	    "action_type>=0 AND action_type<2) AND "
+	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
+	    "((host_id_in_server IS NULL) OR "
+	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
+	    // test with empty hostgroups
+	    "((host_group_id IS NULL) OR host_group_id IN (%" FMT_HOST_GROUP_ID ")) AND "
+	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
+	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
+	    "((trigger_severity IS NULL) OR "
+	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
+	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
+	    id, event.serverId, event.hostIdInServer.c_str(),
+	    expectedHostgroupId.c_str(),
+	    event.triggerId.c_str(),
+	    event.status, event.severity, event.severity);
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
+void test_withEventInfoWithHostgroups(void)
+{
+	loadTestDBTablesUser();
+	loadTestDBHostgroupMember();
+
+	UserIdType id = findUserWithout(OPPRVLG_GET_ALL_ACTION);
+	const EventInfo &event = testEventInfo[2]; // use host_id_in_server='235012'
+	ActionsQueryOption option(id);
+	option.setTargetEventInfo(&event);
+	string expectedHostgroupIds = "'2','1'";
+	string expected
+	  = StringUtils::sprintf(
+	    "(owner_user_id=%" FMT_USER_ID " AND "
+	    "action_type>=0 AND action_type<2) AND "
+	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
+	    "((host_id_in_server IS NULL) OR "
+	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
+	    // test with empty hostgroups
+	    "((host_group_id IS NULL) OR host_group_id IN (%" FMT_HOST_GROUP_ID ")) AND "
+	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
+	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
+	    "((trigger_severity IS NULL) OR "
+	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
+	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
+	    id, event.serverId, event.hostIdInServer.c_str(),
+	    expectedHostgroupIds.c_str(),
+	    event.triggerId.c_str(),
+	    event.status, event.severity, event.severity);
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
 void data_actionType(void)
 {
 	gcut_add_datum("All",

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -1060,24 +1060,9 @@ void test_withEventInfo(void)
 	const EventInfo &event = testEventInfo[0];
 	ActionsQueryOption option(id);
 	option.setTargetEventInfo(&event);
-	string expected
-	  = StringUtils::sprintf(
-	    "(owner_user_id=%" FMT_USER_ID " AND "
-	    "action_type>=0 AND action_type<2) AND "
-	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
-	    "((host_id_in_server IS NULL) OR "
-	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
-	    // test with empty hostgroups
-	    "((host_group_id IS NULL) OR host_group_id IN ('0')) AND "
-	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
-	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
-	    "((trigger_severity IS NULL) OR "
-	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
-	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
-	    id, event.serverId, event.hostIdInServer.c_str(),
-	    event.triggerId.c_str(),
-	    event.status, event.severity, event.severity);
-	cppcut_assert_equal(expected, option.getCondition());
+	// test with empty hostgroups
+	string expectedHostgroupIdStringList = "'0'";
+	assertActionsQueryCondition(id, event, option, expectedHostgroupIdStringList);
 }
 
 void test_withEventInfoWithOneHostgroup(void)
@@ -1089,26 +1074,8 @@ void test_withEventInfoWithOneHostgroup(void)
 	const EventInfo &event = testEventInfo[1]; // use host_id_in_server='10002'
 	ActionsQueryOption option(id);
 	option.setTargetEventInfo(&event);
-	string expectedHostgroupId = "'1'";
-	string expected
-	  = StringUtils::sprintf(
-	    "(owner_user_id=%" FMT_USER_ID " AND "
-	    "action_type>=0 AND action_type<2) AND "
-	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
-	    "((host_id_in_server IS NULL) OR "
-	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
-	    // test with empty hostgroups
-	    "((host_group_id IS NULL) OR host_group_id IN (%" FMT_HOST_GROUP_ID ")) AND "
-	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
-	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
-	    "((trigger_severity IS NULL) OR "
-	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
-	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
-	    id, event.serverId, event.hostIdInServer.c_str(),
-	    expectedHostgroupId.c_str(),
-	    event.triggerId.c_str(),
-	    event.status, event.severity, event.severity);
-	cppcut_assert_equal(expected, option.getCondition());
+	string expectedHostgroupIdStringList = "'1'";
+	assertActionsQueryCondition(id, event, option, expectedHostgroupIdStringList);
 }
 
 void test_withEventInfoWithHostgroups(void)
@@ -1120,26 +1087,8 @@ void test_withEventInfoWithHostgroups(void)
 	const EventInfo &event = testEventInfo[2]; // use host_id_in_server='235012'
 	ActionsQueryOption option(id);
 	option.setTargetEventInfo(&event);
-	string expectedHostgroupIds = "'2','1'";
-	string expected
-	  = StringUtils::sprintf(
-	    "(owner_user_id=%" FMT_USER_ID " AND "
-	    "action_type>=0 AND action_type<2) AND "
-	    "((server_id IS NULL) OR (server_id=%" FMT_SERVER_ID ")) AND "
-	    "((host_id_in_server IS NULL) OR "
-	    "(host_id_in_server='%" FMT_LOCAL_HOST_ID "')) AND "
-	    // test with empty hostgroups
-	    "((host_group_id IS NULL) OR host_group_id IN (%" FMT_HOST_GROUP_ID ")) AND "
-	    "((trigger_id IS NULL) OR (trigger_id='%" FMT_TRIGGER_ID "')) AND "
-	    "((trigger_status IS NULL) OR (trigger_status=%d)) AND "
-	    "((trigger_severity IS NULL) OR "
-	    "(trigger_severity_comp_type=1 AND trigger_severity=%d) OR "
-	    "(trigger_severity_comp_type=2 AND trigger_severity<=%d))",
-	    id, event.serverId, event.hostIdInServer.c_str(),
-	    expectedHostgroupIds.c_str(),
-	    event.triggerId.c_str(),
-	    event.status, event.severity, event.severity);
-	cppcut_assert_equal(expected, option.getCondition());
+	string expectedHostgroupIdStringList = "'2','1'";
+	assertActionsQueryCondition(id, event, option, expectedHostgroupIdStringList);
 }
 
 void data_actionType(void)


### PR DESCRIPTION
This work is related to https://github.com/project-hatohol/hatohol/pull/1154#issuecomment-85028522.

* Add test case for found one hostgroupMemberId
* Add test case for found two hostgroupMemberIds