### PR TITLE
[server][test][DBTablesAction] Loosen assertion for HostgroupIdStringList

### DIFF
--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -891,28 +891,6 @@ ItemDataNullFlagType DBTablesAction::getNullFlag
 		return ITEM_DATA_NULL;
 }
 
-static void getHostgroupIdStringList(string &stringHostgroupId,
-  const ServerIdType &serverId, const LocalHostIdType &hostId)
-{
-	HostgroupMemberVect hostgrpMembers;
-	HostgroupMembersQueryOption option(USER_ID_SYSTEM);
-	option.setTargetServerId(serverId);
-	option.setTargetHostId(hostId);
-	UnifiedDataStore *uds = UnifiedDataStore::getInstance();
-	uds->getHostgroupMembers(hostgrpMembers, option);
-
-	if (hostgrpMembers.empty())
-		return;
-
-	SeparatorInjector commaInjector(",");
-	DBTermCodec dbCodec;
-	for (size_t i = 0; i < hostgrpMembers.size(); i++) {
-		const HostgroupMember &hostgrpMember = hostgrpMembers[i];
-		commaInjector(stringHostgroupId);
-		stringHostgroupId += dbCodec.enc(hostgrpMember.hostgroupIdInServer);
-	}
-}
-
 bool DBTablesAction::getLog(ActionLog &actionLog, const string &condition)
 {
 	DBAgent::SelectExArg arg(tableProfileActionLogs);
@@ -1302,6 +1280,28 @@ string ActionsQueryOption::getCondition(void) const
 	                eventInfo->status,
 	                eventInfo->severity, eventInfo->severity);
 	return cond;
+}
+
+void ActionsQueryOption::getHostgroupIdStringList(string &stringHostgroupId,
+  const ServerIdType &serverId, const LocalHostIdType &hostId)
+{
+	HostgroupMemberVect hostgrpMembers;
+	HostgroupMembersQueryOption option(USER_ID_SYSTEM);
+	option.setTargetServerId(serverId);
+	option.setTargetHostId(hostId);
+	UnifiedDataStore *uds = UnifiedDataStore::getInstance();
+	uds->getHostgroupMembers(hostgrpMembers, option);
+
+	if (hostgrpMembers.empty())
+		return;
+
+	SeparatorInjector commaInjector(",");
+	DBTermCodec dbCodec;
+	for (size_t i = 0; i < hostgrpMembers.size(); i++) {
+		const HostgroupMember &hostgrpMember = hostgrpMembers[i];
+		commaInjector(stringHostgroupId);
+		stringHostgroupId += dbCodec.enc(hostgrpMember.hostgroupIdInServer);
+	}
 }
 
 bool ActionDef::parseIncidentSenderCommand(IncidentTrackerIdType &trackerId) const

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -254,6 +254,10 @@ public:
 
 	virtual std::string getCondition(void) const override;
 
+protected:
+	static void getHostgroupIdStringList(std::string &stringHostgroupId,
+	                                     const ServerIdType &serverId,
+	                                     const LocalHostIdType &hostId);
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;


### PR DESCRIPTION
This work is related to https://github.com/project-hatohol/hatohol/pull/1160#issuecomment-85766514.

Before:

* '1', '2' -> Fail
* '2', '1' -> Pass

After:

* '1', '2' -> Pass
* '2', '1' -> Pass

Because `getHostgroupIdStringList` does not gurantee a hostgroupId sequence.

* Add test for `getHostgroupIdStringList`