### PR TITLE
[wercker][expermental] Use DevToolSet-2 on CentOS 6.x series

### DIFF
--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -17,7 +17,6 @@ RUN yum groupinstall -y 'Development tools'
 # setup newer gcc toolchain
 RUN cd /etc/yum.repos.d && wget http://people.centos.org/tru/devtools-2/devtools-2.repo
 RUN yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
-RUN scl enable devtoolset-2 bash
 RUN yum install -y Django
 RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm
 RUN yum install -y cutter tar

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -25,9 +25,10 @@ RUN yum install -y cutter tar
 RUN git clone https://github.com/project-hatohol/hatohol.git ~/hatohol
 # build
 RUN cd ~/hatohol && libtoolize && autoreconf -i
-RUN cd ~/hatohol && ./configure
-RUN cd ~/hatohol && make -j `cat /proc/cpuinfo | grep processor | wc -l`
+RUN cd ~/hatohol && scl enable devtoolset-2 "./configure"
+RUN cd ~/hatohol && scl enable devtoolset-2 "make -j `cat /proc/cpuinfo | grep processor | wc -l`"
 RUN cd ~/hatohol && make dist -j `cat /proc/cpuinfo | grep processor | wc -l`
 # rpm build
 RUN yum install -y rpm-build
-RUN cd ~/hatohol && MAKEFLAGS="-j `cat /proc/cpuinfo | grep processor | wc -l`" rpmbuild -tb hatohol-*.tar.bz2
+RUN cd ~/hatohol && scl enable devtoolset-2 "MAKEFLAGS=\"-j `cat /proc/cpuinfo | grep processor | wc -l`\" rpmbuild -tb hatohol-*.tar.bz2"
+RUN scl enable devtoolset-2 "gcc --version"

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -14,6 +14,10 @@ RUN wget -P /etc/yum.repos.d/ http://project-hatohol.github.io/repo/hatohol.repo
 RUN yum install -y json-glib-devel qpid-cpp-server-devel
 # setup build environment
 RUN yum groupinstall -y 'Development tools'
+# setup newer gcc toolchain
+RUN cd /etc/yum.repos.d && wget http://people.centos.org/tru/devtools-2/devtools-2.repo
+RUN yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
+RUN scl enable devtoolset-2 bash
 RUN yum install -y Django
 RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm
 RUN yum install -y cutter tar


### PR DESCRIPTION
CentOS 6.x can use DevToolSet version 2.
Thus, gcc 4.8.x series work fine in CentOS 6.x series.

This pull request intends to prepare to use C++11 and partially C++14 feature in Wercker.

=>C++11: [N3337](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3337.pdf)
=>C++14: [N3797](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3797.pdf)

* gcc 4.8 seems to support almost all C++11 feature. (see ref: https://gcc.gnu.org/gcc-4.8/cxx0x_status.html)
* gcc 4.8 seems to support C++14 feature partially. (see ref: https://gcc.gnu.org/projects/cxx1y.html)

---
NOTE:
If we want to use almost all C++14 feature in Wercker, we have to build a Docker image which contains gcc 5.x series build toolchain and its runtime.
Or, we have to build a Docker image which contains clang and llvm 3.4 or higher. ref: http://clang.llvm.org/cxx_status.html