### PR TITLE
Update CodingConvension.md

### DIFF
--- a/CodingConvention.md
+++ b/CodingConvention.md
@@ -27,10 +27,8 @@ An input parameter shall be 'const TYPE &'.
 
 #### Not using
 - Boost
-- C++11
-However, we'll begin to use features of C++11 in near future. Probably it is
-when we support CentOS7 (g++4.7) instead of CentOS6 (g++4.4) series.
-Of course, we can now use features supported by g++4.4.
+- C++14 (except for supported by g++-4.8 series)
+We can now use C++14 features (but very restricted...) supported by g++-4.8.
 
 ### Others
 - Don't use 'using namespace' in a header file.


### PR DESCRIPTION
I've forgot to update this file.... :confounded: 
We start to use C++11/C++14 (only supported by g++-4.8 series), doesn't we?

NOTE:
g++-4.8 supports only C++14 features which is `Return type deduction for normal functions` ([N3638](https://isocpp.org/files/papers/N3638.html)).
Otherwise, C++14 feature support in g++-4.8 is partially or nothing.