### PR TITLE
[server][FaceRest] Use 400 status when authentcation failed

### DIFF
--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -558,14 +558,14 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	gchar *user = (gchar *)g_hash_table_lookup(job->m_query, "user");
 	if (!user) {
 		MLPL_INFO("Not found: user\n");
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
 		return;
 	}
 	gchar *password
 	  = (gchar *)g_hash_table_lookup(job->m_query, "password");
 	if (!password) {
 		MLPL_INFO("Not found: password\n");
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
 		return;
 	}
 
@@ -574,7 +574,7 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	if (userId == INVALID_USER_ID) {
 		MLPL_INFO("Failed to authenticate: Client: %s, User: %s.\n",
 			  soup_client_context_get_host(job->m_client), user);
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_UNAUTHORIZED);
+		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
 		return;
 	}
 


### PR DESCRIPTION
This work is related to #1144.
Hatohol Server does not use HTTP authentication, so it should be used Bad Request (400) status code instead of Unauthorized(401).