### PR TITLE
[server][JSONBuilder] Use enumize boolean value in JSONBuilder

### DIFF
--- a/server/common/JSONBuilder.cc
+++ b/server/common/JSONBuilder.cc
@@ -109,9 +109,12 @@ void JSONBuilder::add(const string &value)
 void JSONBuilder::add(const string &member, const JSONBoolean value)
 {
 	json_builder_set_member_name(m_builder, member.c_str());
-	if (value == JSONTrue) {
+	switch(value) {
+	case JSONTrue:
 		json_builder_add_boolean_value(m_builder, TRUE);
-	} else if (value == JSONFalse) {
+		break;
+	case JSONFalse:
 		json_builder_add_boolean_value(m_builder, FALSE);
+		break;
 	}
 }

--- a/server/common/JSONBuilder.cc
+++ b/server/common/JSONBuilder.cc
@@ -117,3 +117,13 @@ void JSONBuilder::addFalse(const string &member)
 	json_builder_set_member_name(m_builder, member.c_str());
 	json_builder_add_boolean_value(m_builder, FALSE);
 }
+
+void JSONBuilder::add(const string &member, const JSONBoolean value)
+{
+	json_builder_set_member_name(m_builder, member.c_str());
+	if (value == JSONTrue) {
+		json_builder_add_boolean_value(m_builder, TRUE);
+	} else if (value == JSONFalse) {
+		json_builder_add_boolean_value(m_builder, FALSE);
+	}
+}

--- a/server/common/JSONBuilder.cc
+++ b/server/common/JSONBuilder.cc
@@ -106,18 +106,6 @@ void JSONBuilder::add(const string &value)
 	json_builder_add_string_value(m_builder, value.c_str());
 }
 
-void JSONBuilder::addTrue(const string &member)
-{
-	json_builder_set_member_name(m_builder, member.c_str());
-	json_builder_add_boolean_value(m_builder, TRUE);
-}
-
-void JSONBuilder::addFalse(const string &member)
-{
-	json_builder_set_member_name(m_builder, member.c_str());
-	json_builder_add_boolean_value(m_builder, FALSE);
-}
-
 void JSONBuilder::add(const string &member, const JSONBoolean value)
 {
 	json_builder_set_member_name(m_builder, member.c_str());

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -23,6 +23,11 @@
 #include <string>
 #include <json-glib/json-glib.h>
 
+enum JSONBoolean {
+  JSONTrue,
+  JSONFalse
+};
+
 class JSONBuilder
 {
 public:

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -44,10 +44,6 @@ public:
 	void add(const gint64 value);
 	void add(const std::string &value);
 	void add(const std::string &member, JSONBoolean value);
-	__attribute__ ((deprecated))
-	void addTrue(const std::string &member);
-	__attribute__ ((deprecated))
-	void addFalse(const std::string &member);
 	void addNull(const std::string &member);
 
 private:

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -44,7 +44,9 @@ public:
 	void add(const gint64 value);
 	void add(const std::string &value);
 	void add(const std::string &member, JSONBoolean value);
+	__attribute__ ((deprecated))
 	void addTrue(const std::string &member);
+	__attribute__ ((deprecated))
 	void addFalse(const std::string &member);
 	void addNull(const std::string &member);
 

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -43,6 +43,7 @@ public:
 	void add(const std::string &member, gint64 value);
 	void add(const gint64 value);
 	void add(const std::string &value);
+	void add(const std::string &member, JSONBoolean value);
 	void addTrue(const std::string &member);
 	void addFalse(const std::string &member);
 	void addNull(const std::string &member);

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -43,7 +43,7 @@ public:
 	void add(const std::string &member, gint64 value);
 	void add(const gint64 value);
 	void add(const std::string &value);
-	void add(const std::string &member, JSONBoolean value);
+	void add(const std::string &member, const JSONBoolean value);
 	void addNull(const std::string &member);
 
 private:

--- a/server/common/ZabbixAPI.cc
+++ b/server/common/ZabbixAPI.cc
@@ -731,7 +731,7 @@ SoupMessage *ZabbixAPI::queryTrigger(HatoholError &queryRet, int requestSince)
 	if (requestSince > 0)
 		agent.add("lastChangeSince", requestSince);
 	agent.add("selectHosts", "refer");
-	agent.addTrue("active");
+	agent.add("active", JSONTrue);
 	agent.endObject();
 
 	agent.add("auth", m_impl->authToken);
@@ -758,7 +758,7 @@ SoupMessage *ZabbixAPI::queryTriggerExpandedDescription(HatoholError &queryRet,
 		agent.add("lastChangeSince", requestSince);
 	agent.add("expandDescription", 1);
 	agent.add("selectHosts", "refer");
-	agent.addTrue("active");
+	agent.add("active", JSONTrue);
 	agent.endObject(); //params
 
 	agent.add("auth", m_impl->authToken);
@@ -778,7 +778,7 @@ SoupMessage *ZabbixAPI::queryItem(HatoholError &queryRet)
 	agent.startObject("params");
 	agent.add("output", "extend");
 	agent.add("selectApplications", "refer");
-	agent.addTrue("monitored");
+	agent.add("monitored", JSONTrue);
 	agent.endObject(); // params
 
 	agent.add("auth", m_impl->authToken);
@@ -827,7 +827,7 @@ SoupMessage *ZabbixAPI::queryHost(HatoholError &queryRet)
 	agent.startObject("params");
 	agent.add("output", "extend");
 	agent.add("selectGroups", "refer");
-	agent.addTrue("monitored_hosts");
+	agent.add("monitored_hosts", JSONTrue);
 	agent.endObject(); // params
 
 	agent.add("auth", m_impl->authToken);
@@ -845,7 +845,7 @@ SoupMessage *ZabbixAPI::queryGroup(HatoholError &queryRet)
 	agent.add("method", "hostgroup.get");
 
 	agent.startObject("params");
-	agent.addTrue("real_hosts");
+	agent.add("real_hosts", JSONTrue);
 	agent.add("output", "extend");
 	agent.add("selectHosts", "refer");
 	agent.endObject(); //params

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -509,9 +509,9 @@ void FaceRest::handlerTest(ResourceHandler *job)
 	  agent, HatoholError(HTERR_OK));
 	const bool testMode = ConfigManager::getInstance()->isTestMode();
 	if (testMode)
-		agent.addTrue("testMode");
+		agent.add("testMode", JSONTrue);
 	else
-		agent.addFalse("testMode");
+		agent.add("testMode", JSONFalse);
 
 	if (string(job->m_path) == "/test" &&
 	    string(job->m_message->method) == "POST")

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -646,9 +646,9 @@ void RestResourceHost::handlerGetEvent(void)
 	// TODO: should use transaction to avoid conflicting with event list
 	agent.add("lastUnifiedEventId", getLastUnifiedEventId(this));
 	if (addIncidents)
-		agent.addTrue("haveIncident");
+		agent.add("haveIncident", JSONTrue);
 	else
-		agent.addFalse("haveIncident");
+		agent.add("haveIncident", JSONFalse);
 	agent.startArray("events");
 	EventInfoListIterator it = eventList.begin();
 	for (size_t i = 0; it != eventList.end(); ++i, ++it) {

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -157,9 +157,9 @@ static void addServers(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 			const bool passiveMode =
 			  (pluginIt->path == HatoholArmPluginGate::PassivePluginQuasiPath);
 			if (passiveMode)
-				agent.addTrue("passiveMode");
+				agent.add("passiveMode", JSONTrue);
 			else
-				agent.addFalse("passiveMode");
+				agent.add("passiveMode", JSONFalse);
 			agent.add("brokerUrl", pluginIt->brokerUrl);
 			agent.add("staticQueueAddress",
 			          pluginIt->staticQueueAddress);
@@ -170,9 +170,9 @@ static void addServers(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 			agent.add("tlsCACertificatePath",
 			          pluginIt->tlsCACertificatePath);
 			if (pluginIt->tlsEnableVerify)
-				agent.addTrue("tlsEnableVerify");
+				agent.add("tlsEnableVerify", JSONTrue);
 			else
-				agent.addFalse("tlsEnableVerify");
+				agent.add("tlsEnableVerify", JSONFalse);
 		}
 		agent.endObject();
 	}


### PR DESCRIPTION
Use straightforward implementation for `add(const std::string&, bool)` member function causes ambiguous occurrence calling overrode like this:

```log
ZabbixAPI.cc: In member function 'SoupMessage* ZabbixAPI::queryEvent(uint64_t, uint64_t, HatoholError&)':
ZabbixAPI.cc:687:19: error: call of overloaded 'add(const char [3], int)' is ambiguous
  agent.add("id", 1);
                   ^
ZabbixAPI.cc:687:19: note: candidates are:
In file included from ZabbixAPI.h:28:0,
                 from ZabbixAPI.cc:24:
JSONBuilder.h:37:7: note: void JSONBuilder::add(const string&, const string&) <near match>
  void add(const std::string &member, const std::string &value);
       ^
JSONBuilder.h:37:7: note:   no known conversion for argument 2 from 'int' to 'const string& {aka const std::basic_string<char>&}'
JSONBuilder.h:38:7: note: void JSONBuilder::add(const string&, gint64)
  void add(const std::string &member, gint64 value);
       ^
JSONBuilder.h:39:7: note: void JSONBuilder::add(const string&, bool)
  void add(const std::string &member, bool value);
       ^
```

So, I defined enum to represent boolean value for JSON and use it.

Ideally speaking, this situation is suitable to use sum type like Scala:

```scala
sealed trait JSONBoolean
case class JSONTrue() extends JSONBoolean
case class JSONFalse() extends JSONBoolean

def sumType(value: JSONBoolean): String = value match {
  case JSONTrue() => "True"
  case JSONFalse() => "False"
}

sumType(new JSONTrue())
// => res0: String = True

sumType(new JSONFalse())
// => res1: String = False
```

But C++ does not have sum type, then I use `enum` to partially emulate sum type behavior.