### PR TITLE
[configure][server] Enable C++11 by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,9 +199,9 @@ dnl **************************************************************
 dnl enable C++11
 dnl **************************************************************
 AC_ARG_ENABLE([cpp11],
-  [AS_HELP_STRING([--enable-cpp11], [Enable C++11 features (default is no)])],
+  [AS_HELP_STRING([--enable-cpp11], [Enable C++11 features (default is yes)])],
   [],
-  [enable_cpp=no])
+  [enable_cpp=yes])
 
 if test "$enable_cpp11" == "yes"; then
   AC_DEFINE(USE_CPP11, 1, [Define to 1 if you use C++11])


### PR DESCRIPTION
This pull request permits to use C++11 by default.

Related to #1186.