### PR TITLE
Add extended info for monitoring server

### DIFF
--- a/server/common/MonitoringServerInfo.h
+++ b/server/common/MonitoringServerInfo.h
@@ -66,6 +66,7 @@ struct MonitoringServerInfo {
 	std::string          password;
 	std::string          dbName; // for naigos ndutils
 	std::string          baseURL; // for User specified monitoring server URL
+	std::string          extendedInfo;
 
 	// methods
 

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -230,6 +230,9 @@ public:
 	virtual void select(const SelectExArg &selectExArg) = 0;
 	virtual void deleteRows(const DeleteArg &deleteArg) = 0;
 	virtual void addColumns(const AddColumnsArg &addColumnsArg) = 0;
+	virtual void changeColumnDef(const TableProfile &tableProfile,
+				     const std::string &oldColumnName,
+				     const size_t &columnIndex) = 0;
 	virtual void renameTable(const std::string &sourceName,
 				 const std::string &destName) = 0;
 	virtual void dropTable(const std::string &tableName);

--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -533,6 +533,19 @@ void DBAgentMySQL::addColumns(const AddColumnsArg &addColumnsArg)
 	execSql(query);
 }
 
+void DBAgentMySQL::changeColumnDef(const TableProfile &tableProfile,
+				   const string &oldColumnName,
+				   const size_t &columnIndex)
+{
+	string query = "ALTER TABLE ";
+	query += tableProfile.name;
+	query += " CHANGE ";
+	query += oldColumnName;
+	query += " ";
+	query += getColumnDefinitionQuery(tableProfile.columnDefs[columnIndex]);
+	execSql(query);
+}
+
 void DBAgentMySQL::renameTable(const string &srcName, const string &destName)
 {
 	string query = makeRenameTableStatement(srcName, destName);

--- a/server/src/DBAgentMySQL.h
+++ b/server/src/DBAgentMySQL.h
@@ -61,6 +61,9 @@ public:
 	virtual void select(const SelectExArg &selectExArg) override;
 	virtual void deleteRows(const DeleteArg &deleteArg) override;
 	virtual void addColumns(const AddColumnsArg &addColumnsArg);
+	virtual void changeColumnDef(const TableProfile &tableProfile,
+				     const std::string &oldColumnName,
+				     const size_t &columnIndex) override;
 	virtual void renameTable(const std::string &srcName,
 				 const std::string &destName);
 	virtual uint64_t getLastInsertId(void);

--- a/server/src/DBAgentSQLite3.cc
+++ b/server/src/DBAgentSQLite3.cc
@@ -781,6 +781,13 @@ void DBAgentSQLite3::addColumns(const AddColumnsArg &addColumnsArg)
 	MLPL_BUG("Not implemented: %s\n", __PRETTY_FUNCTION__);
 }
 
+void DBAgentSQLite3::changeColumnDef(const TableProfile &tableProfile,
+				     const string &oldColumnName,
+				     const size_t &columnIndex)
+{
+	MLPL_BUG("Not implemented: %s\n", __PRETTY_FUNCTION__);
+}
+
 void DBAgentSQLite3::renameTable(const string &srcName, const string &destName)
 {
 	string query = makeRenameTableStatement(srcName, destName);

--- a/server/src/DBAgentSQLite3.h
+++ b/server/src/DBAgentSQLite3.h
@@ -60,6 +60,9 @@ public:
 	virtual void select(const SelectExArg &selectExArg) override;
 	virtual void deleteRows(const DeleteArg &deleteArg) override;
 	virtual void addColumns(const AddColumnsArg &addColumnsArg) override;
+	virtual void changeColumnDef(const TableProfile &tableProfile,
+				     const std::string &oldColumnName,
+				     const size_t &columnIndex) override;
 	virtual void renameTable(const std::string &srcName,
 				 const std::string &destName);
 	virtual const

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -160,7 +160,7 @@ static const ColumnDef COLUMN_DEF_SERVER_TYPES[] = {
 }, {
 	"plugin_enabled",                  // columnName
 	SQL_COLUMN_TYPE_INT,               // type
-	1,                                // columnLength
+	1,                                 // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_NONE,                      // keyType
@@ -287,7 +287,7 @@ static const ColumnDef COLUMN_DEF_SERVERS[] = {
 }, {
 	"base_url",                        // columnName
 	SQL_COLUMN_TYPE_VARCHAR,           // type
-	32767,                              // columnLength
+	32767,                             // columnLength
 	0,                                 // decFracLength
 	true,                              // canBeNull
 	SQL_KEY_NONE,                      // keyType
@@ -296,7 +296,7 @@ static const ColumnDef COLUMN_DEF_SERVERS[] = {
 }, {
 	"extended_info",                   // columnName
 	SQL_COLUMN_TYPE_VARCHAR,           // type
-	32767,                              // columnLength
+	32767,                             // columnLength
 	0,                                 // decFracLength
 	true,                              // canBeNull
 	SQL_KEY_NONE,                      // keyType

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -287,7 +287,7 @@ static const ColumnDef COLUMN_DEF_SERVERS[] = {
 }, {
 	"base_url",                        // columnName
 	SQL_COLUMN_TYPE_VARCHAR,           // type
-	32767,                             // columnLength
+	2047,                              // columnLength
 	0,                                 // decFracLength
 	true,                              // canBeNull
 	SQL_KEY_NONE,                      // keyType
@@ -607,6 +607,11 @@ static bool updateDB(
 		DBAgent::AddColumnsArg addColumnsArg(tableProfileServers);
 		addColumnsArg.columnIndexes.push_back(IDX_SERVERS_EXTENDED_INFO);
 		dbAgent.addColumns(addColumnsArg);
+
+		// fixup max length of servers.base_url
+		dbAgent.changeColumnDef(tableProfileServers,
+					"base_url",
+					IDX_SERVERS_BASE_URL);
 	}
 	return true;
 }

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -141,6 +141,7 @@ static void addServers(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 		agent.add("pollingInterval", serverInfo.pollingIntervalSec);
 		agent.add("retryInterval", serverInfo.retryIntervalSec);
 		agent.add("baseURL", serverInfo.baseURL);
+		agent.add("extendedInfo", serverInfo.extendedInfo);
 		if (canUpdateServer(option, serverInfo)) {
 			// Shouldn't show account information of the server to
 			// a user who isn't allowed to update it.
@@ -419,6 +420,14 @@ static HatoholError parseServerParameter(
 		return HatoholError(HTERR_NOT_FOUND_PARAMETER, key);
 	if (value)
 		svInfo.baseURL = value;
+
+	// baseURL
+	key = "extendedInfo";
+	value = (char *)g_hash_table_lookup(query, key.c_str());
+	if (!value && isRequired(requiredKeys, key, allowEmpty))
+		return HatoholError(HTERR_NOT_FOUND_PARAMETER, key);
+	if (value)
+		svInfo.extendedInfo = value;
 
 	//
 	// HAPI's parameters

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -127,6 +127,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"goo",                    // password
 	"dbX",                    // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	2,                        // id
 	MONITORING_SYSTEM_ZABBIX, // type
@@ -140,6 +141,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"Albert",                 // password
 	"gravity",                // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	3,                        // id
 	MONITORING_SYSTEM_ZABBIX, // type
@@ -153,6 +155,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"fermion",                // password
 	"",                       // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	4,                        // id
 	MONITORING_SYSTEM_ZABBIX, // type
@@ -166,6 +169,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"OTSU",                   // password
 	"zzz",                    // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	211,                      // id
 	MONITORING_SYSTEM_ZABBIX, // type
@@ -179,6 +183,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"siranami",               // password
 	"zabbix",                 // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	222,                      // id
 	MONITORING_SYSTEM_ZABBIX, // type
@@ -192,6 +197,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"doradora",               // password
 	"z@bb1x",                 // db_name
 	"",                       // base_url
+	"",                       // exteneded_info
 },{
 	301,                      // id
 	MONITORING_SYSTEM_NAGIOS, // type
@@ -205,6 +211,7 @@ const MonitoringServerInfo testServerInfo[] =
 	"5t64k-f3-ui.l76n",       // password
 	"nAgiOs_ndoutils",        // db_name
 	"http://10.0.0.32/nagios3", // base_url
+	"test extended info",     // exteneded_info
 }};
 const size_t NumTestServerInfo = ARRAY_SIZE(testServerInfo);
 

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -406,7 +406,7 @@ string getExpectedNullNotation(DBAgent &dbAgent)
 string makeServerInfoOutput(const MonitoringServerInfo &serverInfo)
 {
 	string expectedOut = StringUtils::sprintf
-	                       ("%u|%d|%s|%s|%s|%d|%d|%d|%s|%s|%s|%s\n",
+	                       ("%u|%d|%s|%s|%s|%d|%d|%d|%s|%s|%s|%s|%s\n",
 	                        serverInfo.id, serverInfo.type,
 	                        serverInfo.hostName.c_str(),
 	                        serverInfo.ipAddress.c_str(),
@@ -417,7 +417,8 @@ string makeServerInfoOutput(const MonitoringServerInfo &serverInfo)
 	                        serverInfo.userName.c_str(),
 	                        serverInfo.password.c_str(),
 	                        serverInfo.dbName.c_str(),
-	                        serverInfo.baseURL.c_str());
+	                        serverInfo.baseURL.c_str(),
+				serverInfo.extendedInfo.c_str());
 	return expectedOut;
 }
 

--- a/server/test/testDBAgent.cc
+++ b/server/test/testDBAgent.cc
@@ -341,6 +341,9 @@ private:
 	virtual void select(const SelectExArg &selectExArg) {}
 	virtual void deleteRows(const DeleteArg &deleteArg) {}
 	virtual void addColumns(const AddColumnsArg &addColumnsArg) {}
+	virtual void changeColumnDef(const TableProfile &tableProfile,
+				     const std::string &oldColumnName,
+				     const size_t &columnIndex) {}
 	virtual void renameTable(const string &srcName, const string &destName) {}
 
 	virtual uint64_t getLastInsertId(void)

--- a/server/test/testFaceRestServer.cc
+++ b/server/test/testFaceRestServer.cc
@@ -82,6 +82,10 @@ static void assertServersInParser(
 				    svInfo.pollingIntervalSec);
 		assertValueInParser(parser, "retryInterval",
 				    svInfo.retryIntervalSec);
+		assertValueInParser(parser, "baseURL",
+				    svInfo.baseURL);
+		assertValueInParser(parser, "extendedInfo",
+				    svInfo.extendedInfo);
 		if (shouldHaveAccountInfo) {
 			assertValueInParser(parser, "userName",
 					    svInfo.userName);
@@ -196,6 +200,8 @@ static void serverInfo2StringMap(
 	  = StringUtils::toString(src.pollingIntervalSec);
 	dest["retryInterval"]
 	  = StringUtils::toString(src.retryIntervalSec);
+	dest["baseURL"] = src.baseURL;
+	dest["extendedInfo"] = src.extendedInfo;
 }
 
 void test_addServer(void)


### PR DESCRIPTION
Because it's required in HAPI 2.0:

https://github.com/project-hatohol/HAPI-2.0-Specification

In addition change the length of servers.base_url to 2047 according to https://github.com/project-hatohol/HAPI-2.0-Specification/issues/5

Revise #1196.
