### PR TITLE
[AMQPConnection] Add an ability to publish a message

### DIFF
--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -552,7 +552,7 @@ bool AMQPConnection::consume(AMQPMessage &message)
 	return true;
 }
 
-bool AMQPConnection::publish(string &body)
+bool AMQPConnection::publish(const AMQPMessage &message)
 {
 	if (!isConnected())
 		return false;
@@ -566,11 +566,13 @@ bool AMQPConnection::publish(string &body)
 	amqp_basic_properties_t props;
 	props._flags =
 		AMQP_BASIC_CONTENT_TYPE_FLAG | AMQP_BASIC_DELIVERY_MODE_FLAG;
-	props.content_type = amqp_cstring_bytes("application/json");
+	props.content_type = message.contentType.empty() ?
+		amqp_cstring_bytes("application/octet-stream") :
+		amqp_cstring_bytes(message.contentType.c_str());
 	props.delivery_mode = 2;
 	amqp_bytes_t body_bytes;
-	body_bytes.bytes = const_cast<char *>(body.data());
-	body_bytes.len = body.length();
+	body_bytes.bytes = const_cast<char *>(message.body.data());
+	body_bytes.len = message.body.length();
 	response = amqp_basic_publish(getConnection(),
 				      getChannel(),
 				      exchange,

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -466,3 +466,98 @@ amqp_connection_state_t AMQPConnection::getConnection(void)
 {
 	return m_impl->getConnection();
 }
+
+bool AMQPConnection::startConsuming(void)
+{
+	const amqp_bytes_t queue =
+		amqp_cstring_bytes(getQueueName().c_str());
+	const amqp_bytes_t consumer_tag = amqp_empty_bytes;
+	const amqp_boolean_t no_local = false;
+	const amqp_boolean_t no_ack = true;
+	const amqp_boolean_t exclusive = false;
+	const amqp_table_t arguments = amqp_empty_table;
+	const amqp_basic_consume_ok_t *response;
+	response = amqp_basic_consume(getConnection(),
+				      getChannel(),
+				      queue,
+				      consumer_tag,
+				      no_local,
+				      no_ack,
+				      exclusive,
+				      arguments);
+	if (!response) {
+		const amqp_rpc_reply_t reply =
+			amqp_get_rpc_reply(getConnection());
+		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
+			logErrorResponse("start consuming", reply);
+			return false;
+		}
+	}
+	return true;
+}
+
+bool AMQPConnection::consume(amqp_envelope_t &envelope)
+{
+	amqp_maybe_release_buffers(getConnection());
+
+	struct timeval timeout = {
+		getTimeout(),
+		0
+	};
+	const int flags = 0;
+	amqp_rpc_reply_t reply = amqp_consume_message(getConnection(),
+						      &envelope,
+						      &timeout,
+						      flags);
+	switch (reply.reply_type) {
+	case AMQP_RESPONSE_NORMAL:
+		break;
+	case AMQP_RESPONSE_LIBRARY_EXCEPTION:
+		if (reply.library_error != AMQP_STATUS_TIMEOUT) {
+			logErrorResponse("consume message", reply);
+			disposeConnection();
+		}
+		return false;
+	default:
+		logErrorResponse("consume message", reply);
+		disposeConnection();
+		return false;
+	}
+
+	return true;
+}
+
+bool AMQPConnection::publish(string &body)
+{
+	const amqp_bytes_t exchange = amqp_empty_bytes;
+	const amqp_bytes_t queue =
+		amqp_cstring_bytes(getQueueName().c_str());
+	const amqp_boolean_t no_mandatory = false;
+	const amqp_boolean_t no_immediate = false;
+	int response;
+	amqp_basic_properties_t props;
+	props._flags =
+		AMQP_BASIC_CONTENT_TYPE_FLAG | AMQP_BASIC_DELIVERY_MODE_FLAG;
+	props.content_type = amqp_cstring_bytes("application/json");
+	props.delivery_mode = 2;
+	amqp_bytes_t body_bytes;
+	body_bytes.bytes = const_cast<char *>(body.data());
+	body_bytes.len = body.length();
+	response = amqp_basic_publish(getConnection(),
+				      getChannel(),
+				      exchange,
+				      queue,
+				      no_mandatory,
+				      no_immediate,
+				      &props,
+				      amqp_bytes_malloc_dup(body_bytes));
+	if (response != AMQP_STATUS_OK) {
+		const amqp_rpc_reply_t reply =
+			amqp_get_rpc_reply(getConnection());
+		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
+			logErrorResponse("start publishing", reply);
+			return false;
+		}
+	}
+	return true;
+}

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -382,7 +382,7 @@ AMQPConnection::~AMQPConnection()
 {
 }
 
-bool AMQPConnection::connect()
+bool AMQPConnection::connect(void)
 {
 	m_impl->m_connection = amqp_new_connection();
 	if (initializeConnection()) {
@@ -393,7 +393,7 @@ bool AMQPConnection::connect()
 	}
 }
 
-bool AMQPConnection::initializeConnection()
+bool AMQPConnection::initializeConnection(void)
 {
 	if (!m_impl->openSocket())
 		return false;
@@ -411,37 +411,37 @@ time_t AMQPConnection::getTimeout(void)
 	return m_impl->getTimeout();
 }
 
-bool AMQPConnection::isConnected()
+bool AMQPConnection::isConnected(void)
 {
 	return m_impl->m_connection;
 }
 
-bool AMQPConnection::openSocket()
+bool AMQPConnection::openSocket(void)
 {
 	return m_impl->openSocket();
 }
 
-bool AMQPConnection::login()
+bool AMQPConnection::login(void)
 {
 	return m_impl->login();
 }
 
-bool AMQPConnection::openChannel()
+bool AMQPConnection::openChannel(void)
 {
 	return m_impl->openChannel();
 }
 
-bool AMQPConnection::declareQueue()
+bool AMQPConnection::declareQueue(void)
 {
 	return m_impl->declareQueue();
 }
 
-string AMQPConnection::getQueueName()
+string AMQPConnection::getQueueName(void)
 {
 	return m_impl->getQueueName();
 }
 
-void AMQPConnection::disposeConnection()
+void AMQPConnection::disposeConnection(void)
 {
 	return m_impl->disposeConnection();
 }
@@ -452,7 +452,7 @@ void AMQPConnection::logErrorResponse(const char *context,
 	return m_impl->logErrorResponse(context, reply);
 }
 
-amqp_channel_t AMQPConnection::getChannel()
+amqp_channel_t AMQPConnection::getChannel(void)
 {
 	return m_impl->getChannel();
 }

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -592,7 +592,7 @@ bool AMQPConnection::publish(const AMQPMessage &message)
 	return true;
 }
 
-bool AMQPConnection::purge(void)
+bool AMQPConnection::purgeQueue(void)
 {
 	if (!isConnected())
 		return false;

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -28,7 +28,7 @@ public:
 
 	Impl(const AMQPConnectionInfo &info)
 	: m_connection(NULL),
-	  m_info(const_cast<AMQPConnectionInfo &>(info)),
+	  m_info(info),
 	  m_socket(NULL),
 	  m_socketOpened(false),
 	  m_channel(0)
@@ -207,7 +207,7 @@ public:
 	}
 
 protected:
-	AMQPConnectionInfo m_info;
+	const AMQPConnectionInfo m_info;
 	amqp_socket_t *m_socket;
 	bool m_socketOpened;
 	amqp_channel_t m_channel;

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -612,3 +612,26 @@ bool AMQPConnection::purge(void)
 	}
 	return true;
 }
+
+bool AMQPConnection::deleteQueue(void)
+{
+	if (!isConnected())
+		return false;
+
+	const amqp_bytes_t queue = amqp_cstring_bytes(getQueueName().c_str());
+	amqp_queue_delete_ok_t *response;
+	response = amqp_queue_delete(getConnection(),
+				     getChannel(),
+				     queue,
+				     false,  // delete using queue
+				     false); // delete non empty queue
+	if (!response) {
+		const amqp_rpc_reply_t reply =
+			amqp_get_rpc_reply(getConnection());
+		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
+			logErrorResponse("purge", reply);
+			return false;
+		}
+	}
+	return true;
+}

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -201,6 +201,11 @@ public:
 		return m_channel;
 	}
 
+	amqp_connection_state_t getConnection()
+	{
+		return m_connection;
+	}
+
 protected:
 	const AMQPConnectionInfo &m_info;
 	amqp_socket_t *m_socket;
@@ -455,4 +460,9 @@ void AMQPConnection::logErrorResponse(const char *context,
 amqp_channel_t AMQPConnection::getChannel(void)
 {
 	return m_impl->getChannel();
+}
+
+amqp_connection_state_t AMQPConnection::getConnection(void)
+{
+	return m_impl->getConnection();
 }

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -55,11 +55,6 @@ public:
 		return m_connection;
 	}
 
-	void newConnection()
-	{
-		m_connection = amqp_new_connection();
-	}
-
 	bool openSocket()
 	{
 		if (m_info.useTLS()) {

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -588,7 +588,13 @@ bool AMQPConnection::purge(void)
 	response = amqp_queue_purge(getConnection(),
 				    getChannel(),
 				    queue);
-	if (!response)
-		return false;
+	if (!response) {
+		const amqp_rpc_reply_t reply =
+			amqp_get_rpc_reply(getConnection());
+		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
+			logErrorResponse("purge", reply);
+			return false;
+		}
+	}
 	return true;
 }

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -196,6 +196,11 @@ public:
 		return;
 	}
 
+	amqp_channel_t getChannel()
+	{
+		return m_channel;
+	}
+
 protected:
 	const AMQPConnectionInfo &m_info;
 	amqp_socket_t *m_socket;
@@ -445,4 +450,9 @@ void AMQPConnection::logErrorResponse(const char *context,
 	                              const amqp_rpc_reply_t &reply)
 {
 	return m_impl->logErrorResponse(context, reply);
+}
+
+amqp_channel_t AMQPConnection::getChannel()
+{
+	return m_impl->getChannel();
 }

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -28,7 +28,7 @@ public:
 
 	Impl(const AMQPConnectionInfo &info)
 	: m_connection(NULL),
-	  m_info(info),
+	  m_info(const_cast<AMQPConnectionInfo &>(info)),
 	  m_socket(NULL),
 	  m_socketOpened(false),
 	  m_channel(0)
@@ -207,7 +207,7 @@ public:
 	}
 
 protected:
-	const AMQPConnectionInfo &m_info;
+	AMQPConnectionInfo m_info;
 	amqp_socket_t *m_socket;
 	bool m_socketOpened;
 	amqp_channel_t m_channel;

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -163,6 +163,39 @@ public:
 		m_connection = NULL;
 	}
 
+	time_t getTimeout(void)
+	{
+		return m_info.getTimeout();
+	}
+
+	const string &getQueueName()
+	{
+		return m_info.getQueueName();
+	}
+
+	void logErrorResponse(const char *context,
+			      const amqp_rpc_reply_t &reply)
+	{
+		switch (reply.reply_type) {
+		case AMQP_RESPONSE_NORMAL:
+			break;
+		case AMQP_RESPONSE_NONE:
+			MLPL_ERR("%s: RPC reply type is missing\n", context);
+			break;
+		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
+			MLPL_ERR("failed to %s: %s\n",
+				 context,
+				 amqp_error_string2(reply.library_error));
+			break;
+		case AMQP_RESPONSE_SERVER_EXCEPTION:
+			// TODO: show more messages
+			MLPL_ERR("%s: server exception\n",
+				 context);
+			break;
+		}
+		return;
+	}
+
 protected:
 	const AMQPConnectionInfo &m_info;
 	amqp_socket_t *m_socket;
@@ -203,16 +236,6 @@ protected:
 		return m_info.getVirtualHost();
 	}
 
-	const string &getQueueName()
-	{
-		return m_info.getQueueName();
-	}
-
-	time_t getTimeout(void)
-	{
-		return m_info.getTimeout();
-	}
-
 	const string &getTLSCertificatePath(void)
 	{
 		return m_info.getTLSCertificatePath();
@@ -246,29 +269,6 @@ protected:
 			 context,
 			 status,
 			 amqp_error_string2(status));
-	}
-
-	void logErrorResponse(const char *context,
-			      const amqp_rpc_reply_t &reply)
-	{
-		switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			break;
-		case AMQP_RESPONSE_NONE:
-			MLPL_ERR("%s: RPC reply type is missing\n", context);
-			break;
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-			MLPL_ERR("failed to %s: %s\n",
-				 context,
-				 amqp_error_string2(reply.library_error));
-			break;
-		case AMQP_RESPONSE_SERVER_EXCEPTION:
-			// TODO: show more messages
-			MLPL_ERR("%s: server exception\n",
-				 context);
-			break;
-		}
-		return;
 	}
 
 	bool createTLSSocket(void)
@@ -399,4 +399,50 @@ bool AMQPConnection::initializeConnection()
 	if (!m_impl->declareQueue())
 		return false;
 	return true;
+}
+
+time_t AMQPConnection::getTimeout(void)
+{
+	return m_impl->getTimeout();
+}
+
+bool AMQPConnection::isConnected()
+{
+	return m_impl->m_connection;
+}
+
+bool AMQPConnection::openSocket()
+{
+	return m_impl->openSocket();
+}
+
+bool AMQPConnection::login()
+{
+	return m_impl->login();
+}
+
+bool AMQPConnection::openChannel()
+{
+	return m_impl->openChannel();
+}
+
+bool AMQPConnection::declareQueue()
+{
+	return m_impl->declareQueue();
+}
+
+string AMQPConnection::getQueueName()
+{
+	return m_impl->getQueueName();
+}
+
+void AMQPConnection::disposeConnection()
+{
+	return m_impl->disposeConnection();
+}
+
+void AMQPConnection::logErrorResponse(const char *context,
+	                              const amqp_rpc_reply_t &reply)
+{
+	return m_impl->logErrorResponse(context, reply);
 }

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -561,3 +561,15 @@ bool AMQPConnection::publish(string &body)
 	}
 	return true;
 }
+
+bool AMQPConnection::purge(void)
+{
+	const amqp_bytes_t queue = amqp_cstring_bytes(getQueueName().c_str());
+	amqp_queue_purge_ok_t *response;
+	response = amqp_queue_purge(getConnection(),
+				    getChannel(),
+				    queue);
+	if (!response)
+		return false;
+	return true;
+}

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -475,6 +475,9 @@ amqp_connection_state_t AMQPConnection::getConnection(void)
 
 bool AMQPConnection::startConsuming(void)
 {
+	if (!isConnected())
+		return false;
+
 	const amqp_bytes_t queue =
 		amqp_cstring_bytes(getQueueName().c_str());
 	const amqp_bytes_t consumer_tag = amqp_empty_bytes;
@@ -504,6 +507,9 @@ bool AMQPConnection::startConsuming(void)
 
 bool AMQPConnection::consume(AMQPMessage &message)
 {
+	if (!isConnected())
+		return false;
+
 	amqp_maybe_release_buffers(getConnection());
 
 	struct timeval timeout = {
@@ -548,6 +554,9 @@ bool AMQPConnection::consume(AMQPMessage &message)
 
 bool AMQPConnection::publish(string &body)
 {
+	if (!isConnected())
+		return false;
+
 	const amqp_bytes_t exchange = amqp_empty_bytes;
 	const amqp_bytes_t queue =
 		amqp_cstring_bytes(getQueueName().c_str());
@@ -583,6 +592,9 @@ bool AMQPConnection::publish(string &body)
 
 bool AMQPConnection::purge(void)
 {
+	if (!isConnected())
+		return false;
+
 	const amqp_bytes_t queue = amqp_cstring_bytes(getQueueName().c_str());
 	amqp_queue_purge_ok_t *response;
 	response = amqp_queue_purge(getConnection(),

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -206,6 +206,11 @@ public:
 		return m_connection;
 	}
 
+	const AMQPConnectionInfo &getConnectionInfo()
+	{
+		return m_info;
+	}
+
 protected:
 	const AMQPConnectionInfo m_info;
 	amqp_socket_t *m_socket;
@@ -391,6 +396,11 @@ AMQPConnection::AMQPConnection(const AMQPConnectionInfo &info)
 
 AMQPConnection::~AMQPConnection()
 {
+}
+
+const AMQPConnectionInfo &AMQPConnection::getConnectionInfo(void)
+{
+	return m_impl->getConnectionInfo();
 }
 
 bool AMQPConnection::connect(void)

--- a/server/src/AMQPConnection.cc
+++ b/server/src/AMQPConnection.cc
@@ -378,6 +378,12 @@ protected:
 	}
 };
 
+AMQPConnectionPtr AMQPConnection::create(const AMQPConnectionInfo &info)
+{
+	AMQPConnectionPtr connection(new AMQPConnection(info), false);
+	return connection;
+}
+
 AMQPConnection::AMQPConnection(const AMQPConnectionInfo &info)
 : m_impl(new Impl(info))
 {

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -43,7 +43,7 @@ public:
 	virtual bool connect(void);
 	virtual bool isConnected(void);
 	virtual bool startConsuming(void);
-	virtual bool consume(amqp_envelope_t &envelope);
+	virtual bool consume(AMQPMessage &message);
 	virtual bool publish(std::string &body);
 	virtual bool purge(void);
 

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -32,8 +32,19 @@ class AMQPConnection {
 public:
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
-        virtual bool connect();
-        virtual bool initializeConnection();
+	virtual bool connect();
+	virtual bool initializeConnection();
+	virtual time_t getTimeout(void);
+	virtual bool isConnected();
+	virtual bool openSocket();
+	virtual bool login();
+	virtual bool openChannel();
+	virtual bool declareQueue();
+	virtual std::string getQueueName();
+	virtual void disposeConnection();
+	virtual void logErrorResponse(const char *context,
+	                              const amqp_rpc_reply_t &reply);
+
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -44,7 +44,7 @@ public:
 	virtual bool isConnected(void);
 	virtual bool startConsuming(void);
 	virtual bool consume(AMQPMessage &message);
-	virtual bool publish(std::string &body);
+	virtual bool publish(const AMQPMessage &message);
 	virtual bool purge(void);
 
 protected:

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -33,9 +33,11 @@ public:
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
 	virtual bool connect(void);
+	virtual bool isConnected(void);
+
+protected:
 	virtual bool initializeConnection(void);
 	virtual time_t getTimeout(void);
-	virtual bool isConnected(void);
 	virtual bool openSocket(void);
 	virtual bool login(void);
 	virtual bool openChannel(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -46,6 +46,7 @@ public:
 	virtual bool consume(AMQPMessage &message);
 	virtual bool publish(const AMQPMessage &message);
 	virtual bool purge(void);
+	virtual bool deleteQueue(void);
 
 protected:
 	virtual bool initializeConnection(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -45,6 +45,7 @@ public:
 	virtual void logErrorResponse(const char *context,
 	                              const amqp_rpc_reply_t &reply);
 	amqp_channel_t getChannel(void);
+	amqp_connection_state_t getConnection(void);
 
 private:
 	struct Impl;

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -49,7 +49,7 @@ public:
 	virtual bool startConsuming(void);
 	virtual bool consume(AMQPMessage &message);
 	virtual bool publish(const AMQPMessage &message);
-	virtual bool purge(void);
+	virtual bool purgeQueue(void);
 	virtual bool deleteQueue(void);
 
 protected:

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -37,6 +37,7 @@ public:
 	virtual bool startConsuming(void);
 	virtual bool consume(amqp_envelope_t &envelope);
 	virtual bool publish(std::string &body);
+	virtual bool purge(void);
 
 protected:
 	virtual bool initializeConnection(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -32,19 +32,19 @@ class AMQPConnection {
 public:
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
-	virtual bool connect();
-	virtual bool initializeConnection();
+	virtual bool connect(void);
+	virtual bool initializeConnection(void);
 	virtual time_t getTimeout(void);
-	virtual bool isConnected();
-	virtual bool openSocket();
-	virtual bool login();
-	virtual bool openChannel();
-	virtual bool declareQueue();
-	virtual std::string getQueueName();
-	virtual void disposeConnection();
+	virtual bool isConnected(void);
+	virtual bool openSocket(void);
+	virtual bool login(void);
+	virtual bool openChannel(void);
+	virtual bool declareQueue(void);
+	virtual std::string getQueueName(void);
+	virtual void disposeConnection(void);
 	virtual void logErrorResponse(const char *context,
 	                              const amqp_rpc_reply_t &reply);
-	amqp_channel_t getChannel();
+	amqp_channel_t getChannel(void);
 
 private:
 	struct Impl;

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -32,8 +32,8 @@ class AMQPConnection {
 public:
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
-        virtual bool connect() override;
-        virtual bool initializeConnection() override;
+        virtual bool connect();
+        virtual bool initializeConnection();
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -20,7 +20,6 @@
 #define AMQPConnection_h
 
 #include "AMQPConnectionInfo.h"
-#include "AMQPMessageHandler.h"
 #include <glib.h>
 #include <unistd.h>
 #include <Logger.h>
@@ -32,6 +31,11 @@
 
 class AMQPConnection;
 typedef UsedCountablePtr<AMQPConnection> AMQPConnectionPtr;
+
+struct AMQPMessage {
+	std::string contentType;
+	std::string body;
+};
 
 class AMQPConnection : public UsedCountable
 {

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -44,6 +44,7 @@ public:
 
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
+	virtual const AMQPConnectionInfo &getConnectionInfo(void);
 	virtual bool connect(void);
 	virtual bool isConnected(void);
 	virtual bool startConsuming(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -30,9 +30,14 @@
 #include <amqp_tcp_socket.h>
 #include <amqp_ssl_socket.h>
 
+class AMQPConnection;
+typedef UsedCountablePtr<AMQPConnection> AMQPConnectionPtr;
+
 class AMQPConnection : public UsedCountable
 {
 public:
+	static AMQPConnectionPtr create(const AMQPConnectionInfo &info);
+
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
 	virtual bool connect(void);
@@ -60,7 +65,5 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-typedef UsedCountablePtr<AMQPConnection> AMQPConnectionPtr;
 
 #endif // AMQPConnection_h

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -34,6 +34,9 @@ public:
 	~AMQPConnection();
 	virtual bool connect(void);
 	virtual bool isConnected(void);
+	virtual bool startConsuming(void);
+	virtual bool consume(amqp_envelope_t &envelope);
+	virtual bool publish(std::string &body);
 
 protected:
 	virtual bool initializeConnection(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -44,6 +44,7 @@ public:
 	virtual void disposeConnection();
 	virtual void logErrorResponse(const char *context,
 	                              const amqp_rpc_reply_t &reply);
+	amqp_channel_t getChannel();
 
 private:
 	struct Impl;

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -44,25 +44,25 @@ public:
 
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
-	virtual const AMQPConnectionInfo &getConnectionInfo(void);
-	virtual bool connect(void);
-	virtual bool isConnected(void);
-	virtual bool startConsuming(void);
-	virtual bool consume(AMQPMessage &message);
-	virtual bool publish(const AMQPMessage &message);
-	virtual bool purgeQueue(void);
-	virtual bool deleteQueue(void);
+	const AMQPConnectionInfo &getConnectionInfo(void);
+	bool connect(void);
+	bool isConnected(void);
+	bool startConsuming(void);
+	bool consume(AMQPMessage &message);
+	bool publish(const AMQPMessage &message);
+	bool purgeQueue(void);
+	bool deleteQueue(void);
 
 protected:
-	virtual bool initializeConnection(void);
-	virtual time_t getTimeout(void);
-	virtual bool openSocket(void);
-	virtual bool login(void);
-	virtual bool openChannel(void);
-	virtual bool declareQueue(void);
-	virtual std::string getQueueName(void);
-	virtual void disposeConnection(void);
-	virtual void logErrorResponse(const char *context,
+	bool initializeConnection(void);
+	time_t getTimeout(void);
+	bool openSocket(void);
+	bool login(void);
+	bool openChannel(void);
+	bool declareQueue(void);
+	std::string getQueueName(void);
+	void disposeConnection(void);
+	void logErrorResponse(const char *context,
 	                              const amqp_rpc_reply_t &reply);
 	amqp_channel_t getChannel(void);
 	amqp_connection_state_t getConnection(void);

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -25,10 +25,13 @@
 #include <unistd.h>
 #include <Logger.h>
 #include <StringUtils.h>
+#include <UsedCountable.h>
+#include <UsedCountablePtr.h>
 #include <amqp_tcp_socket.h>
 #include <amqp_ssl_socket.h>
 
-class AMQPConnection {
+class AMQPConnection : public UsedCountable
+{
 public:
 	AMQPConnection(const AMQPConnectionInfo &info);
 	~AMQPConnection();
@@ -57,5 +60,7 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
+
+typedef UsedCountablePtr<AMQPConnection> AMQPConnectionPtr;
 
 #endif // AMQPConnection_h

--- a/server/src/AMQPConnection.h
+++ b/server/src/AMQPConnection.h
@@ -37,6 +37,13 @@ struct AMQPMessage {
 	std::string body;
 };
 
+struct AMQPJSONMessage : public AMQPMessage {
+	AMQPJSONMessage()
+	{
+		contentType = "application/json";
+	}
+};
+
 class AMQPConnection : public UsedCountable
 {
 public:

--- a/server/src/AMQPConnectionInfo.cc
+++ b/server/src/AMQPConnectionInfo.cc
@@ -89,6 +89,20 @@ AMQPConnectionInfo::AMQPConnectionInfo()
 {
 }
 
+AMQPConnectionInfo::AMQPConnectionInfo(const AMQPConnectionInfo &info)
+: m_impl(new Impl())
+{
+	m_impl->setURL(info.m_impl->m_URL);
+	m_impl->m_queueName = info.m_impl->m_queueName;
+}
+
+AMQPConnectionInfo &AMQPConnectionInfo::operator=(const AMQPConnectionInfo &info)
+{
+	m_impl->setURL(info.m_impl->m_URL);
+	m_impl->m_queueName = info.m_impl->m_queueName;
+	return *this;
+}
+
 AMQPConnectionInfo::~AMQPConnectionInfo()
 {
 }

--- a/server/src/AMQPConnectionInfo.cc
+++ b/server/src/AMQPConnectionInfo.cc
@@ -51,6 +51,8 @@ struct AMQPConnectionInfo::Impl {
 	void setURL(const string &URL)
 	{
 		m_URL = normalizeURL(URL);
+		// Because amqp_parse_url() modifies the content of the first
+		// argument, allocate another buffer to keep the original URL.
 		free(m_URLBuf);
 		m_URLBuf = strdup(m_URL.c_str());
 		int status = amqp_parse_url(m_URLBuf, &m_parsedURL);

--- a/server/src/AMQPConnectionInfo.h
+++ b/server/src/AMQPConnectionInfo.h
@@ -27,6 +27,8 @@
 class AMQPConnectionInfo {
 public:
 	AMQPConnectionInfo(void);
+	AMQPConnectionInfo(const AMQPConnectionInfo &info);
+	AMQPConnectionInfo &operator=(const AMQPConnectionInfo &info);
 	virtual ~AMQPConnectionInfo();
 
 	const std::string &getURL(void) const;

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -31,6 +31,17 @@
 using namespace std;
 using namespace mlpl;
 
+AMQPConsumer::AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
+			   AMQPMessageHandler *handler)
+: m_connection(NULL),
+  m_handler(handler),
+  m_started(false)
+{
+	AMQPConnectionPtr connection =
+		AMQPConnection::create(connectionInfo);
+	AMQPConsumer(connection, m_handler);
+}
+
 AMQPConsumer::AMQPConsumer(AMQPConnectionPtr &connection,
 			   AMQPMessageHandler *handler)
 : m_connection(connection),
@@ -41,6 +52,11 @@ AMQPConsumer::AMQPConsumer(AMQPConnectionPtr &connection,
 
 AMQPConsumer::~AMQPConsumer()
 {
+}
+
+AMQPConnectionPtr AMQPConsumer::getConnection(void)
+{
+	return m_connection;
 }
 
 gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -64,7 +64,7 @@ gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 		if (!consumed)
 			continue;
 
-		m_handler->handle(message);
+		m_handler->handle(*m_connection, message);
 	}
 	return NULL;
 }

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -34,7 +34,6 @@ class AMQPConsumerConnection : public AMQPConnection {
 public:
 	AMQPConsumerConnection(const AMQPConnectionInfo &info)
 	: AMQPConnection(info),
-	  m_info(info),
 	  m_connection(NULL),
 	  m_channel(0),
 	  m_envelope()
@@ -80,7 +79,6 @@ public:
 	}
 
 private:
-	const AMQPConnectionInfo &m_info;
 	amqp_connection_state_t m_connection;
 	amqp_channel_t m_channel;
 	amqp_envelope_t m_envelope;

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -31,88 +31,6 @@
 using namespace std;
 using namespace mlpl;
 
-class AMQPConsumerConnection : public AMQPConnection {
-public:
-	AMQPConsumerConnection(const AMQPConnectionInfo &info)
-	: AMQPConnection(info)
-	{
-	}
-
-	~AMQPConsumerConnection()
-	{
-	}
-
-	bool consume(amqp_envelope_t &envelope)
-	{
-		amqp_maybe_release_buffers(getConnection());
-
-		struct timeval timeout = {
-			getTimeout(),
-			0
-		};
-		const int flags = 0;
-		amqp_rpc_reply_t reply = amqp_consume_message(getConnection(),
-							      &envelope,
-							      &timeout,
-							      flags);
-		switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			break;
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-			if (reply.library_error != AMQP_STATUS_TIMEOUT) {
-				logErrorResponse("consume message", reply);
-				disposeConnection();
-			}
-			return false;
-		default:
-			logErrorResponse("consume message", reply);
-			disposeConnection();
-			return false;
-		}
-
-		return true;
-	}
-
-private:
-	bool initializeConnection() override
-	{
-		if (!AMQPConnection::initializeConnection())
-			return false;
-		if (!startConsuming())
-			return false;
-		return true;
-	}
-
-	bool startConsuming()
-	{
-		const amqp_bytes_t queue =
-			amqp_cstring_bytes(getQueueName().c_str());
-		const amqp_bytes_t consumer_tag = amqp_empty_bytes;
-		const amqp_boolean_t no_local = false;
-		const amqp_boolean_t no_ack = true;
-		const amqp_boolean_t exclusive = false;
-		const amqp_table_t arguments = amqp_empty_table;
-		const amqp_basic_consume_ok_t *response;
-		response = amqp_basic_consume(getConnection(),
-					      getChannel(),
-					      queue,
-					      consumer_tag,
-					      no_local,
-					      no_ack,
-					      exclusive,
-					      arguments);
-		if (!response) {
-			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(getConnection());
-			if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
-				logErrorResponse("start consuming", reply);
-				return false;
-			}
-		}
-		return true;
-	}
-};
-
 AMQPConsumer::AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
 			   AMQPMessageHandler *handler)
 : m_connectionInfo(connectionInfo),
@@ -126,7 +44,7 @@ AMQPConsumer::~AMQPConsumer()
 
 gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 {
-	AMQPConsumerConnection connection(m_connectionInfo);
+	AMQPConnection connection(m_connectionInfo);
 	while (!isExitRequested()) {
 		if (!connection.isConnected()) {
 			connection.connect();
@@ -134,6 +52,11 @@ gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 
 		if (!connection.isConnected()) {
 			sleep(1); // TODO: Make retry interval customizable
+			continue;
+		}
+
+		if (!connection.startConsuming()) {
+			sleep(1); // TODO: Same with above
 			continue;
 		}
 

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -35,7 +35,6 @@ public:
 	AMQPConsumerConnection(const AMQPConnectionInfo &info)
 	: AMQPConnection(info),
 	  m_connection(NULL),
-	  m_channel(0),
 	  m_envelope()
 	{
 	}
@@ -80,7 +79,6 @@ public:
 
 private:
 	amqp_connection_state_t m_connection;
-	amqp_channel_t m_channel;
 	amqp_envelope_t m_envelope;
 
 	bool initializeConnection() override
@@ -109,7 +107,7 @@ private:
 		const amqp_table_t arguments = amqp_empty_table;
 		const amqp_basic_consume_ok_t *response;
 		response = amqp_basic_consume(m_connection,
-					      m_channel,
+					      getChannel(),
 					      queue,
 					      consumer_tag,
 					      no_local,

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -81,13 +81,7 @@ private:
 
 	bool initializeConnection() override
 	{
-		if (!openSocket())
-			return false;
-		if (!login())
-			return false;
-		if (!openChannel())
-			return false;
-		if (!declareQueue())
+		if (!AMQPConnection::initializeConnection())
 			return false;
 		if (!startConsuming())
 			return false;

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -37,9 +37,7 @@ AMQPConsumer::AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
   m_handler(handler),
   m_started(false)
 {
-	AMQPConnectionPtr connection =
-		AMQPConnection::create(connectionInfo);
-	AMQPConsumer(connection, m_handler);
+	m_connection = AMQPConnection::create(connectionInfo);
 }
 
 AMQPConsumer::AMQPConsumer(AMQPConnectionPtr &connection,

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -18,6 +18,7 @@
  */
 
 #include "AMQPConsumer.h"
+#include "AMQPConnection.h"
 #include "AMQPConnectionInfo.h"
 #include "AMQPMessageHandler.h"
 #include <unistd.h>
@@ -29,47 +30,20 @@
 using namespace std;
 using namespace mlpl;
 
-class AMQPConnection {
+class AMQPConsumerConnection : public AMQPConnection {
 public:
-	AMQPConnection(const AMQPConnectionInfo &info)
-	: m_info(info),
+	AMQPConsumerConnection(const AMQPConnectionInfo &info)
+	: AMQPConnection(info),
+	  m_info(info),
 	  m_connection(NULL),
-	  m_socket(NULL),
-	  m_socketOpened(false),
 	  m_channel(0),
 	  m_envelope()
 	{
-		const char *virtualHost = getVirtualHost();
-		if (string(virtualHost) == "/") {
-			virtualHost = "";
-		}
-		MLPL_INFO("Broker URL: <%s://%s:%d/%s>\n",
-			  getScheme(),
-			  getHost(),
-			  getPort(),
-			  virtualHost);
 	}
 
-	~AMQPConnection()
+	~AMQPConsumerConnection()
 	{
 		amqp_destroy_envelope(&m_envelope);
-		disposeConnection();
-	}
-
-	bool connect()
-	{
-		m_connection = amqp_new_connection();
-		if (initializeConnection()) {
-			return true;
-		} else {
-			disposeConnection();
-			return false;
-		}
-	}
-
-	bool isConnected()
-	{
-		return m_connection;
 	}
 
 	bool consume(amqp_envelope_t *&envelope)
@@ -105,118 +79,13 @@ public:
 		return true;
 	}
 
-
 private:
 	const AMQPConnectionInfo &m_info;
 	amqp_connection_state_t m_connection;
-	amqp_socket_t *m_socket;
-	bool m_socketOpened;
 	amqp_channel_t m_channel;
 	amqp_envelope_t m_envelope;
 
-	const char *getScheme(void)
-	{
-		if (m_info.useTLS()) {
-			return "amqps";
-		} else {
-			return "amqp";
-		}
-	}
-
-	const char *getHost()
-	{
-		return m_info.getHost();
-	}
-
-	guint getPort()
-	{
-		return m_info.getPort();
-	}
-
-	const char *getUser()
-	{
-		return m_info.getUser();
-	}
-
-	const char *getPassword()
-	{
-		return m_info.getPassword();
-	}
-
-	const char *getVirtualHost(void)
-	{
-		return m_info.getVirtualHost();
-	}
-
-	const string &getQueueName()
-	{
-		return m_info.getQueueName();
-	}
-
-	time_t getTimeout(void)
-	{
-		return m_info.getTimeout();
-	}
-
-	const string &getTLSCertificatePath(void)
-	{
-		return m_info.getTLSCertificatePath();
-	}
-
-	const string &getTLSKeyPath(void)
-	{
-		return m_info.getTLSKeyPath();
-	}
-
-	const string &getTLSCACertificatePath(void)
-	{
-		return m_info.getTLSCACertificatePath();
-	}
-
-	bool isTLSVerifyEnabled(void)
-	{
-		return m_info.isTLSVerifyEnabled();
-	}
-
-	void logErrorResponse(const char *context, int status)
-	{
-		logErrorResponse(context, static_cast<amqp_status_enum>(status));
-	}
-
-	void logErrorResponse(const char *context, amqp_status_enum status)
-	{
-		if (status == AMQP_STATUS_OK)
-			return;
-		MLPL_ERR("failed to %s: %d: %s\n",
-			 context,
-			 status,
-			 amqp_error_string2(status));
-	}
-
-	void logErrorResponse(const char *context,
-			      const amqp_rpc_reply_t &reply)
-	{
-		switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			break;
-		case AMQP_RESPONSE_NONE:
-			MLPL_ERR("%s: RPC reply type is missing\n", context);
-			break;
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-			MLPL_ERR("failed to %s: %s\n",
-				 context,
-				 amqp_error_string2(reply.library_error));
-			break;
-		case AMQP_RESPONSE_SERVER_EXCEPTION:
-			// TODO: show more messages
-			MLPL_ERR("%s: server exception\n",
-				 context);
-			break;
-		}
-		return;
-	}
-
-	bool initializeConnection()
+	bool initializeConnection() override
 	{
 		if (!openSocket())
 			return false;
@@ -228,174 +97,6 @@ private:
 			return false;
 		if (!startConsuming())
 			return false;
-		return true;
-	}
-
-	bool openSocket()
-	{
-		if (m_info.useTLS()) {
-			if (!createTLSSocket()) {
-				return false;
-			}
-		} else {
-			if (!createPlainSocket()) {
-				return false;
-			}
-		}
-
-		const int status =
-			amqp_socket_open(m_socket, getHost(), getPort());
-		if (status != AMQP_STATUS_OK) {
-			const string context =
-				StringUtils::sprintf("open socket: %s:%u",
-						     getHost(),
-						     getPort());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-
-		m_socketOpened = true;
-		return true;
-	}
-
-	bool createTLSSocket(void)
-	{
-		m_socket = amqp_ssl_socket_new(m_connection);
-		if (!m_socket) {
-			MLPL_ERR("failed to create TLS socket\n");
-			return false;
-		}
-
-		if (!setTLSKey()) {
-			return false;
-		}
-		if (!setTLSCACertificate()) {
-			return false;
-		}
-		if (!setTLSVerification()) {
-			return false;
-		}
-
-		return true;
-	}
-
-	bool setTLSKey(void)
-	{
-		const int status =
-			amqp_ssl_socket_set_key(
-				m_socket,
-				getTLSCertificatePath().c_str(),
-				getTLSKeyPath().c_str());
-		if (status != AMQP_STATUS_OK) {
-			using StringUtils::sprintf;
-			const string context =
-				sprintf("set client certificate to SSL socket: "
-					"<%s>:<%s>",
-					getTLSCertificatePath().c_str(),
-					getTLSKeyPath().c_str());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-		return true;
-	}
-
-	bool setTLSCACertificate(void)
-	{
-		const int status =
-			amqp_ssl_socket_set_cacert(
-				m_socket,
-				getTLSCACertificatePath().c_str());
-		if (status != AMQP_STATUS_OK) {
-			using StringUtils::sprintf;
-			const string context =
-				sprintf("set CA certificate to SSL socket: <%s>",
-					getTLSCACertificatePath().c_str());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-		return true;
-	}
-
-	bool setTLSVerification(void)
-	{
-		amqp_ssl_socket_set_verify(m_socket, isTLSVerifyEnabled());
-		return true;
-	}
-
-	bool createPlainSocket(void)
-	{
-		m_socket = amqp_tcp_socket_new(m_connection);
-		if (!m_socket) {
-			MLPL_ERR("failed to create TCP socket\n");
-			return false;
-		}
-		return true;
-	}
-
-	bool login()
-	{
-		const int heartbeat = 1;
-		const amqp_rpc_reply_t reply =
-			amqp_login(m_connection,
-				   getVirtualHost(),
-				   AMQP_DEFAULT_MAX_CHANNELS,
-				   AMQP_DEFAULT_FRAME_SIZE,
-				   heartbeat,
-				   AMQP_SASL_METHOD_PLAIN,
-				   getUser(),
-				   getPassword());
-		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
-			const string context =
-				StringUtils::sprintf("login with <%s>",
-						     getUser());
-			logErrorResponse(context.c_str(), reply);
-			return false;
-		}
-		return true;
-	}
-
-	bool openChannel()
-	{
-		amqp_channel_open_ok_t *response;
-		m_channel = 1;
-		response = amqp_channel_open(m_connection, m_channel);
-		if (!response) {
-			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(m_connection);
-			logErrorResponse("open channel", reply);
-			m_channel = 0;
-			return false;
-		}
-		return true;
-	}
-
-	bool declareQueue()
-	{
-		const string &queueName = getQueueName();
-		const amqp_bytes_t queue = amqp_cstring_bytes(queueName.c_str());
-		MLPL_INFO("Queue: <%s>\n", queueName.c_str());
-		const amqp_boolean_t passive = false;
-		const amqp_boolean_t durable = false;
-		const amqp_boolean_t exclusive = false;
-		const amqp_boolean_t auto_delete = false;
-		const amqp_table_t arguments = amqp_empty_table;
-		const amqp_queue_declare_ok_t *response =
-			amqp_queue_declare(m_connection,
-					   m_channel,
-					   queue,
-					   passive,
-					   durable,
-					   exclusive,
-					   auto_delete,
-					   arguments);
-		if (!response) {
-			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(m_connection);
-			if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
-				logErrorResponse("declare queue", reply);
-				return false;
-			}
-		}
 		return true;
 	}
 
@@ -427,42 +128,6 @@ private:
 		}
 		return true;
 	}
-
-	void disposeConnection()
-	{
-		if (!m_connection)
-			return;
-
-		disposeChannel();
-		disposeSocket();
-		logErrorResponse("destroy connection",
-				 amqp_destroy_connection(m_connection));
-
-		m_socket = NULL;
-		m_connection = NULL;
-	}
-
-	void disposeChannel()
-	{
-		if (m_channel == 0)
-			return;
-
-		logErrorResponse("close channel",
-				 amqp_channel_close(m_connection, m_channel,
-						    AMQP_REPLY_SUCCESS));
-		m_channel = 0;
-	}
-
-	void disposeSocket()
-	{
-		if (!m_socketOpened)
-			return;
-
-		logErrorResponse("close connection",
-				 amqp_connection_close(m_connection,
-						       AMQP_REPLY_SUCCESS));
-		m_socketOpened = false;
-	}
 };
 
 AMQPConsumer::AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
@@ -478,7 +143,7 @@ AMQPConsumer::~AMQPConsumer()
 
 gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 {
-	AMQPConnection connection(m_connectionInfo);
+	AMQPConsumerConnection connection(m_connectionInfo);
 	while (!isExitRequested()) {
 		if (!connection.isConnected()) {
 			connection.connect();

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -59,14 +59,12 @@ gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 			continue;
 		}
 
-		amqp_envelope_t envelope;
-		Reaper<amqp_envelope_t> envelopeReaper(&envelope,
-						       amqp_destroy_envelope);
-		const bool consumed = m_connection->consume(envelope);
+		AMQPMessage message;
+		const bool consumed = m_connection->consume(message);
 		if (!consumed)
 			continue;
 
-		m_handler->handle(&envelope);
+		m_handler->handle(message);
 	}
 	return NULL;
 }

--- a/server/src/AMQPConsumer.cc
+++ b/server/src/AMQPConsumer.cc
@@ -31,7 +31,7 @@
 using namespace std;
 using namespace mlpl;
 
-AMQPConsumer::AMQPConsumer(const AMQPConnectionPtr &connection,
+AMQPConsumer::AMQPConsumer(AMQPConnectionPtr &connection,
 			   AMQPMessageHandler *handler)
 : m_connection(connection),
   m_handler(handler),

--- a/server/src/AMQPConsumer.h
+++ b/server/src/AMQPConsumer.h
@@ -27,9 +27,13 @@ class AMQPMessageHandler;
 
 class AMQPConsumer : public HatoholThreadBase {
 public:
+	AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
+		     AMQPMessageHandler *handle);
 	AMQPConsumer(AMQPConnectionPtr &connection,
 		     AMQPMessageHandler *handler);
 	virtual ~AMQPConsumer();
+
+	AMQPConnectionPtr getConnection(void);
 
 protected:
 	virtual gpointer mainThread(HatoholThreadArg *arg) override;

--- a/server/src/AMQPConsumer.h
+++ b/server/src/AMQPConsumer.h
@@ -27,7 +27,7 @@ class AMQPMessageHandler;
 
 class AMQPConsumer : public HatoholThreadBase {
 public:
-	AMQPConsumer(const AMQPConnectionPtr &connection,
+	AMQPConsumer(AMQPConnectionPtr &connection,
 		     AMQPMessageHandler *handler);
 	virtual ~AMQPConsumer();
 
@@ -35,7 +35,7 @@ protected:
 	virtual gpointer mainThread(HatoholThreadArg *arg) override;
 
 private:
-	const AMQPConnectionPtr &m_connection;
+	AMQPConnectionPtr m_connection;
 	AMQPMessageHandler *m_handler;
 	bool m_started;
 };

--- a/server/src/AMQPConsumer.h
+++ b/server/src/AMQPConsumer.h
@@ -39,9 +39,8 @@ protected:
 	virtual gpointer mainThread(HatoholThreadArg *arg) override;
 
 private:
-	AMQPConnectionPtr m_connection;
-	AMQPMessageHandler *m_handler;
-	bool m_started;
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
 };
 
 #endif // AMQPConsumer_h

--- a/server/src/AMQPConsumer.h
+++ b/server/src/AMQPConsumer.h
@@ -37,6 +37,7 @@ protected:
 private:
 	const AMQPConnectionPtr &m_connection;
 	AMQPMessageHandler *m_handler;
+	bool m_started;
 };
 
 #endif // AMQPConsumer_h

--- a/server/src/AMQPConsumer.h
+++ b/server/src/AMQPConsumer.h
@@ -21,13 +21,13 @@
 #define AMQPConsumer_h
 
 #include "HatoholThreadBase.h"
+#include "AMQPConnection.h"
 
-class AMQPConnectionInfo;
 class AMQPMessageHandler;
 
 class AMQPConsumer : public HatoholThreadBase {
 public:
-	AMQPConsumer(const AMQPConnectionInfo &connectionInfo,
+	AMQPConsumer(const AMQPConnectionPtr &connection,
 		     AMQPMessageHandler *handler);
 	virtual ~AMQPConsumer();
 
@@ -35,7 +35,7 @@ protected:
 	virtual gpointer mainThread(HatoholThreadArg *arg) override;
 
 private:
-	const AMQPConnectionInfo &m_connectionInfo;
+	const AMQPConnectionPtr &m_connection;
 	AMQPMessageHandler *m_handler;
 };
 

--- a/server/src/AMQPMessageHandler.cc
+++ b/server/src/AMQPMessageHandler.cc
@@ -27,7 +27,8 @@ AMQPMessageHandler::~AMQPMessageHandler()
 {
 }
 
-bool AMQPMessageHandler::handle(const AMQPMessage &message)
+bool AMQPMessageHandler::handle(AMQPConnection &connection,
+				const AMQPMessage &message)
 {
 	return true;
 }

--- a/server/src/AMQPMessageHandler.cc
+++ b/server/src/AMQPMessageHandler.cc
@@ -26,9 +26,3 @@ AMQPMessageHandler::AMQPMessageHandler()
 AMQPMessageHandler::~AMQPMessageHandler()
 {
 }
-
-bool AMQPMessageHandler::handle(AMQPConnection &connection,
-				const AMQPMessage &message)
-{
-	return true;
-}

--- a/server/src/AMQPMessageHandler.cc
+++ b/server/src/AMQPMessageHandler.cc
@@ -27,7 +27,7 @@ AMQPMessageHandler::~AMQPMessageHandler()
 {
 }
 
-bool AMQPMessageHandler::handle(const amqp_envelope_t *envelope)
+bool AMQPMessageHandler::handle(const AMQPMessage &message)
 {
 	return true;
 }

--- a/server/src/AMQPMessageHandler.h
+++ b/server/src/AMQPMessageHandler.h
@@ -20,21 +20,18 @@
 #ifndef AMQPMessageHandler_h
 #define AMQPMessageHandler_h
 
-#include <amqp.h>
-
 #include "Params.h"
+#include "AMQPConnection.h"
 
-struct AMQPMessage {
-	std::string contentType;
-	std::string body;
-};
+struct AMQPMessage;
 
 class AMQPMessageHandler {
 public:
 	AMQPMessageHandler();
 	virtual ~AMQPMessageHandler();
 
-	virtual bool handle(const AMQPMessage &message);
+	virtual bool handle(AMQPConnection &connection,
+			    const AMQPMessage &message) = 0;
 };
 
 #endif // AMQPMessageHandler_h

--- a/server/src/AMQPMessageHandler.h
+++ b/server/src/AMQPMessageHandler.h
@@ -24,12 +24,17 @@
 
 #include "Params.h"
 
+struct AMQPMessage {
+	std::string contentType;
+	std::string body;
+};
+
 class AMQPMessageHandler {
 public:
 	AMQPMessageHandler();
 	virtual ~AMQPMessageHandler();
 
-	virtual bool handle(const amqp_envelope_t *envelope);
+	virtual bool handle(const AMQPMessage &message);
 };
 
 #endif // AMQPMessageHandler_h

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -21,15 +21,30 @@
 #include "AMQPConnection.h"
 #include "AMQPMessageHandler.h"
 
+struct AMQPPublisher::Impl {
+	Impl()
+	: m_connection(NULL)
+	{
+	}
+
+	~Impl()
+	{
+	}
+
+	AMQPConnectionPtr m_connection;
+	AMQPMessage m_message;
+};
+
 AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo)
-: m_connection(NULL)
+: m_impl(new Impl())
 {
-	m_connection = AMQPConnection::create(connectionInfo);
+	m_impl->m_connection = AMQPConnection::create(connectionInfo);
 }
 
 AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection)
-: m_connection(connection)
+: m_impl(new Impl())
 {
+	m_impl->m_connection = connection;
 }
 
 AMQPPublisher::~AMQPPublisher()
@@ -38,23 +53,23 @@ AMQPPublisher::~AMQPPublisher()
 
 AMQPConnectionPtr AMQPPublisher::getConnection(void)
 {
-	return m_connection;
+	return m_impl->m_connection;
 }
 
 void AMQPPublisher::setMessage(const AMQPMessage &message)
 {
-	m_message = message;
+	m_impl->m_message = message;
 }
 
 void AMQPPublisher::clear(void)
 {
 	AMQPMessage message;
-	m_message = message;
+	m_impl->m_message = message;
 }
 
 bool AMQPPublisher::publish(void)
 {
-	if (!m_connection->isConnected())
-		m_connection->connect();
-	return m_connection->publish(m_message);
+	if (!m_impl->m_connection->isConnected())
+		m_impl->m_connection->connect();
+	return m_impl->m_connection->publish(m_message);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -33,8 +33,7 @@ using namespace mlpl;
 class AMQPPublisherConnection : public AMQPConnection {
 public:
 	AMQPPublisherConnection(const AMQPConnectionInfo &info)
-	: AMQPConnection(info),
-	  m_connection(NULL)
+	: AMQPConnection(info)
 	{
 	}
 
@@ -58,7 +57,7 @@ public:
 		amqp_bytes_t body_bytes;
 		body_bytes.bytes = const_cast<char *>(body.data());
 		body_bytes.len = body.length();
-		response = amqp_basic_publish(m_connection,
+		response = amqp_basic_publish(getConnection(),
 					      getChannel(),
 					      queue,
 					      consumer_tag,
@@ -68,7 +67,7 @@ public:
 					      amqp_bytes_malloc_dup(body_bytes));
 		if (response != AMQP_STATUS_OK) {
 			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(m_connection);
+				amqp_get_rpc_reply(getConnection());
 			if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
 				logErrorResponse("start publishing", reply);
 				return false;
@@ -76,9 +75,6 @@ public:
 		}
 		return true;
 	}
-
-private:
-	amqp_connection_state_t m_connection;
 };
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo,

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -19,10 +19,9 @@
 
 #include "AMQPPublisher.h"
 #include "AMQPConnection.h"
-#include "AMQPConnectionInfo.h"
 #include "AMQPMessageHandler.h"
 
-AMQPPublisher::AMQPPublisher(const AMQPConnectionPtr &connection,
+AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection,
 			     const AMQPMessage &message)
 : m_connection(connection),
   m_message(message)

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -43,8 +43,7 @@ void AMQPPublisher::clear(void)
 
 bool AMQPPublisher::publish(void)
 {
-	if (!m_connection->isConnected()) {
+	if (!m_connection->isConnected())
 		m_connection->connect();
-	}
 	return m_connection->publish(m_message);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -18,6 +18,7 @@
  */
 
 #include "AMQPPublisher.h"
+#include "AMQPConnection.h"
 #include "AMQPConnectionInfo.h"
 #include "AMQPMessageHandler.h"
 #include <unistd.h>
@@ -29,45 +30,18 @@
 using namespace std;
 using namespace mlpl;
 
-class AMQPConnection {
+class AMQPPublisherConnection : public AMQPConnection {
 public:
-	AMQPConnection(const AMQPConnectionInfo &info)
-	: m_info(info),
+	AMQPPublisherConnection(const AMQPConnectionInfo &info)
+	: AMQPConnection(info),
+	  m_info(info),
 	  m_connection(NULL),
-	  m_socket(NULL),
-	  m_socketOpened(false),
 	  m_channel(0)
 	{
-		const char *virtualHost = getVirtualHost();
-		if (string(virtualHost) == "/") {
-			virtualHost = "";
-		}
-		MLPL_INFO("Broker URL: <%s://%s:%d/%s>\n",
-			  getScheme(),
-			  getHost(),
-			  getPort(),
-			  virtualHost);
 	}
 
-	~AMQPConnection()
+	~AMQPPublisherConnection()
 	{
-		disposeConnection();
-	}
-
-	bool connect()
-	{
-		m_connection = amqp_new_connection();
-		if (initializeConnection()) {
-			return true;
-		} else {
-			disposeConnection();
-			return false;
-		}
-	}
-
-	bool isConnected()
-	{
-		return m_connection;
 	}
 
 	bool publish(string &body)
@@ -109,328 +83,7 @@ public:
 private:
 	const AMQPConnectionInfo &m_info;
 	amqp_connection_state_t m_connection;
-	amqp_socket_t *m_socket;
-	bool m_socketOpened;
 	amqp_channel_t m_channel;
-
-	const char *getScheme(void)
-	{
-		if (m_info.useTLS()) {
-			return "amqps";
-		} else {
-			return "amqp";
-		}
-	}
-
-	const char *getHost()
-	{
-		return m_info.getHost();
-	}
-
-	guint getPort()
-	{
-		return m_info.getPort();
-	}
-
-	const char *getUser()
-	{
-		return m_info.getUser();
-	}
-
-	const char *getPassword()
-	{
-		return m_info.getPassword();
-	}
-
-	const char *getVirtualHost(void)
-	{
-		return m_info.getVirtualHost();
-	}
-
-	const string &getQueueName()
-	{
-		return m_info.getQueueName();
-	}
-
-	time_t getTimeout(void)
-	{
-		return m_info.getTimeout();
-	}
-
-	const string &getTLSCertificatePath(void)
-	{
-		return m_info.getTLSCertificatePath();
-	}
-
-	const string &getTLSKeyPath(void)
-	{
-		return m_info.getTLSKeyPath();
-	}
-
-	const string &getTLSCACertificatePath(void)
-	{
-		return m_info.getTLSCACertificatePath();
-	}
-
-	bool isTLSVerifyEnabled(void)
-	{
-		return m_info.isTLSVerifyEnabled();
-	}
-
-	void logErrorResponse(const char *context, int status)
-	{
-		logErrorResponse(context, static_cast<amqp_status_enum>(status));
-	}
-
-	void logErrorResponse(const char *context, amqp_status_enum status)
-	{
-		if (status == AMQP_STATUS_OK)
-			return;
-		MLPL_ERR("failed to %s: %d: %s\n",
-			 context,
-			 status,
-			 amqp_error_string2(status));
-	}
-
-	void logErrorResponse(const char *context,
-			      const amqp_rpc_reply_t &reply)
-	{
-		switch (reply.reply_type) {
-		case AMQP_RESPONSE_NORMAL:
-			break;
-		case AMQP_RESPONSE_NONE:
-			MLPL_ERR("%s: RPC reply type is missing\n", context);
-			break;
-		case AMQP_RESPONSE_LIBRARY_EXCEPTION:
-			MLPL_ERR("failed to %s: %s\n",
-				 context,
-				 amqp_error_string2(reply.library_error));
-			break;
-		case AMQP_RESPONSE_SERVER_EXCEPTION:
-			// TODO: show more messages
-			MLPL_ERR("%s: server exception\n",
-				 context);
-			break;
-		}
-		return;
-	}
-
-	bool initializeConnection()
-	{
-		if (!openSocket())
-			return false;
-		if (!login())
-			return false;
-		if (!openChannel())
-			return false;
-		if (!declareQueue())
-			return false;
-		return true;
-	}
-
-	bool openSocket()
-	{
-		if (m_info.useTLS()) {
-			if (!createTLSSocket()) {
-				return false;
-			}
-		} else {
-			if (!createPlainSocket()) {
-				return false;
-			}
-		}
-
-		const int status =
-			amqp_socket_open(m_socket, getHost(), getPort());
-		if (status != AMQP_STATUS_OK) {
-			const string context =
-				StringUtils::sprintf("open socket: %s:%u",
-						     getHost(),
-						     getPort());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-
-		m_socketOpened = true;
-		return true;
-	}
-
-	bool createTLSSocket(void)
-	{
-		m_socket = amqp_ssl_socket_new(m_connection);
-		if (!m_socket) {
-			MLPL_ERR("failed to create TLS socket\n");
-			return false;
-		}
-
-		if (!setTLSKey()) {
-			return false;
-		}
-		if (!setTLSCACertificate()) {
-			return false;
-		}
-		if (!setTLSVerification()) {
-			return false;
-		}
-
-		return true;
-	}
-
-	bool setTLSKey(void)
-	{
-		const int status =
-			amqp_ssl_socket_set_key(
-				m_socket,
-				getTLSCertificatePath().c_str(),
-				getTLSKeyPath().c_str());
-		if (status != AMQP_STATUS_OK) {
-			using StringUtils::sprintf;
-			const string context =
-				sprintf("set client certificate to SSL socket: "
-					"<%s>:<%s>",
-					getTLSCertificatePath().c_str(),
-					getTLSKeyPath().c_str());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-		return true;
-	}
-
-	bool setTLSCACertificate(void)
-	{
-		const int status =
-			amqp_ssl_socket_set_cacert(
-				m_socket,
-				getTLSCACertificatePath().c_str());
-		if (status != AMQP_STATUS_OK) {
-			using StringUtils::sprintf;
-			const string context =
-				sprintf("set CA certificate to SSL socket: <%s>",
-					getTLSCACertificatePath().c_str());
-			logErrorResponse(context.c_str(), status);
-			return false;
-		}
-		return true;
-	}
-
-	bool setTLSVerification(void)
-	{
-		amqp_ssl_socket_set_verify(m_socket, isTLSVerifyEnabled());
-		return true;
-	}
-
-	bool createPlainSocket(void)
-	{
-		m_socket = amqp_tcp_socket_new(m_connection);
-		if (!m_socket) {
-			MLPL_ERR("failed to create TCP socket\n");
-			return false;
-		}
-		return true;
-	}
-
-	bool login()
-	{
-		const int heartbeat = 1;
-		const amqp_rpc_reply_t reply =
-			amqp_login(m_connection,
-				   getVirtualHost(),
-				   AMQP_DEFAULT_MAX_CHANNELS,
-				   AMQP_DEFAULT_FRAME_SIZE,
-				   heartbeat,
-				   AMQP_SASL_METHOD_PLAIN,
-				   getUser(),
-				   getPassword());
-		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
-			const string context =
-				StringUtils::sprintf("login with <%s>",
-						     getUser());
-			logErrorResponse(context.c_str(), reply);
-			return false;
-		}
-		return true;
-	}
-
-	bool openChannel()
-	{
-		amqp_channel_open_ok_t *response;
-		m_channel = 1;
-		response = amqp_channel_open(m_connection, m_channel);
-		if (!response) {
-			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(m_connection);
-			logErrorResponse("open channel", reply);
-			m_channel = 0;
-			return false;
-		}
-		return true;
-	}
-
-	bool declareQueue()
-	{
-		const string &queueName = getQueueName();
-		const amqp_bytes_t queue = amqp_cstring_bytes(queueName.c_str());
-		MLPL_INFO("Queue: <%s>\n", queueName.c_str());
-		const amqp_boolean_t passive = false;
-		const amqp_boolean_t durable = false;
-		const amqp_boolean_t exclusive = false;
-		const amqp_boolean_t auto_delete = false;
-		const amqp_table_t arguments = amqp_empty_table;
-		const amqp_queue_declare_ok_t *response =
-			amqp_queue_declare(m_connection,
-					   m_channel,
-					   queue,
-					   passive,
-					   durable,
-					   exclusive,
-					   auto_delete,
-					   arguments);
-		if (!response) {
-			const amqp_rpc_reply_t reply =
-				amqp_get_rpc_reply(m_connection);
-			if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
-				logErrorResponse("declare queue", reply);
-				return false;
-			}
-		}
-		return true;
-	}
-
-	void disposeConnection()
-	{
-		if (!m_connection)
-			return;
-
-		disposeChannel();
-		disposeSocket();
-		logErrorResponse("destroy connection",
-				 amqp_destroy_connection(m_connection));
-
-		m_socket = NULL;
-		m_connection = NULL;
-	}
-
-	void disposeChannel()
-	{
-		if (m_channel == 0)
-			return;
-
-		logErrorResponse("close channel",
-				 amqp_channel_close(m_connection, m_channel,
-						    AMQP_REPLY_SUCCESS));
-		m_channel = 0;
-	}
-
-	void disposeSocket()
-	{
-		if (!m_socketOpened)
-			return;
-
-		logErrorResponse("close connection",
-				 amqp_connection_close(m_connection,
-						       AMQP_REPLY_SUCCESS));
-		m_socketOpened = false;
-	}
 };
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo,
@@ -446,6 +99,6 @@ AMQPPublisher::~AMQPPublisher()
 
 bool AMQPPublisher::publish()
 {
-	AMQPConnection connection(m_connectionInfo);
+	AMQPPublisherConnection connection(m_connectionInfo);
 	return connection.publish(m_body);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -95,5 +95,8 @@ AMQPPublisher::~AMQPPublisher()
 bool AMQPPublisher::publish()
 {
 	AMQPPublisherConnection connection(m_connectionInfo);
+	if (!connection.isConnected()) {
+		connection.connect();
+	}
 	return connection.publish(m_body);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -34,7 +34,6 @@ class AMQPPublisherConnection : public AMQPConnection {
 public:
 	AMQPPublisherConnection(const AMQPConnectionInfo &info)
 	: AMQPConnection(info),
-	  m_info(info),
 	  m_connection(NULL),
 	  m_channel(0)
 	{
@@ -81,7 +80,6 @@ public:
 
 
 private:
-	const AMQPConnectionInfo &m_info;
 	amqp_connection_state_t m_connection;
 	amqp_channel_t m_channel;
 };

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -43,9 +43,9 @@ public:
 
 	bool publish(string &body)
 	{
+		const amqp_bytes_t exchange = amqp_empty_bytes;
 		const amqp_bytes_t queue =
 			amqp_cstring_bytes(getQueueName().c_str());
-		const amqp_bytes_t consumer_tag = amqp_empty_bytes;
 		const amqp_boolean_t no_mandatory = false;
 		const amqp_boolean_t no_immediate = false;
 		int response;
@@ -59,8 +59,8 @@ public:
 		body_bytes.len = body.length();
 		response = amqp_basic_publish(getConnection(),
 					      getChannel(),
+					      exchange,
 					      queue,
-					      consumer_tag,
 					      no_mandatory,
 					      no_immediate,
 					      &props,

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -30,9 +30,9 @@
 using namespace std;
 using namespace mlpl;
 
-AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo,
+AMQPPublisher::AMQPPublisher(const AMQPConnectionPtr &connection,
 			     string body)
-: m_connectionInfo(connectionInfo),
+: m_connection(connection),
   m_body(body)
 {
 }
@@ -43,9 +43,8 @@ AMQPPublisher::~AMQPPublisher()
 
 bool AMQPPublisher::publish(void)
 {
-	AMQPConnection connection(m_connectionInfo);
-	if (!connection.isConnected()) {
-		connection.connect();
+	if (!m_connection->isConnected()) {
+		m_connection->connect();
 	}
-	return connection.publish(m_body);
+	return m_connection->publish(m_body);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -78,7 +78,6 @@ public:
 		return true;
 	}
 
-
 private:
 	amqp_connection_state_t m_connection;
 	amqp_channel_t m_channel;

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -21,11 +21,6 @@
 #include "AMQPConnection.h"
 #include "AMQPConnectionInfo.h"
 #include "AMQPMessageHandler.h"
-#include <unistd.h>
-#include <Logger.h>
-#include <StringUtils.h>
-
-using namespace std;
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionPtr &connection,
 			     const AMQPMessage &message)

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -21,6 +21,12 @@
 #include "AMQPConnection.h"
 #include "AMQPMessageHandler.h"
 
+AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo)
+: m_connection(NULL)
+{
+	m_connection = AMQPConnection::create(connectionInfo);
+}
+
 AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection)
 : m_connection(connection)
 {
@@ -28,6 +34,11 @@ AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection)
 
 AMQPPublisher::~AMQPPublisher()
 {
+}
+
+AMQPConnectionPtr AMQPPublisher::getConnection(void)
+{
+	return m_connection;
 }
 
 void AMQPPublisher::setMessage(const AMQPMessage &message)

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -71,5 +71,5 @@ bool AMQPPublisher::publish(void)
 {
 	if (!m_impl->m_connection->isConnected())
 		m_impl->m_connection->connect();
-	return m_impl->m_connection->publish(m_message);
+	return m_impl->m_connection->publish(m_impl->m_message);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -444,22 +444,8 @@ AMQPPublisher::~AMQPPublisher()
 {
 }
 
-gpointer AMQPPublisher::mainThread(HatoholThreadArg *arg)
+bool AMQPPublisher::publish()
 {
 	AMQPConnection connection(m_connectionInfo);
-	while (!isExitRequested()) {
-		if (!connection.isConnected()) {
-			connection.connect();
-		}
-
-		if (!connection.isConnected()) {
-			sleep(1); // TODO: Make retry interval customizable
-			continue;
-		}
-
-		const bool published = connection.publish(m_body);
-		if (!published)
-			continue;
-	}
-	return NULL;
+	return connection.publish(m_body);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -31,8 +31,10 @@ using namespace std;
 using namespace mlpl;
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionPtr &connection,
+			     string contentType,
 			     string body)
 : m_connection(connection),
+  m_contentType(contentType),
   m_body(body)
 {
 }
@@ -46,5 +48,8 @@ bool AMQPPublisher::publish(void)
 	if (!m_connection->isConnected()) {
 		m_connection->connect();
 	}
-	return m_connection->publish(m_body);
+	AMQPMessage message;
+	message.contentType = m_contentType;
+	message.body = m_body;
+	return m_connection->publish(message);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -24,18 +24,13 @@
 #include <unistd.h>
 #include <Logger.h>
 #include <StringUtils.h>
-#include <amqp_tcp_socket.h>
-#include <amqp_ssl_socket.h>
 
 using namespace std;
-using namespace mlpl;
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionPtr &connection,
-			     string contentType,
-			     string body)
+			     const AMQPMessage &message)
 : m_connection(connection),
-  m_contentType(contentType),
-  m_body(body)
+  m_message(message)
 {
 }
 
@@ -48,8 +43,5 @@ bool AMQPPublisher::publish(void)
 	if (!m_connection->isConnected()) {
 		m_connection->connect();
 	}
-	AMQPMessage message;
-	message.contentType = m_contentType;
-	message.body = m_body;
-	return m_connection->publish(message);
+	return m_connection->publish(m_message);
 }

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -88,7 +88,7 @@ AMQPPublisher::~AMQPPublisher()
 {
 }
 
-bool AMQPPublisher::publish()
+bool AMQPPublisher::publish(void)
 {
 	AMQPPublisherConnection connection(m_connectionInfo);
 	if (!connection.isConnected()) {

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -34,8 +34,7 @@ class AMQPPublisherConnection : public AMQPConnection {
 public:
 	AMQPPublisherConnection(const AMQPConnectionInfo &info)
 	: AMQPConnection(info),
-	  m_connection(NULL),
-	  m_channel(0)
+	  m_connection(NULL)
 	{
 	}
 
@@ -60,7 +59,7 @@ public:
 		body_bytes.bytes = const_cast<char *>(body.data());
 		body_bytes.len = body.length();
 		response = amqp_basic_publish(m_connection,
-					      m_channel,
+					      getChannel(),
 					      queue,
 					      consumer_tag,
 					      no_mandatory,
@@ -80,7 +79,6 @@ public:
 
 private:
 	amqp_connection_state_t m_connection;
-	amqp_channel_t m_channel;
 };
 
 AMQPPublisher::AMQPPublisher(const AMQPConnectionInfo &connectionInfo,

--- a/server/src/AMQPPublisher.cc
+++ b/server/src/AMQPPublisher.cc
@@ -21,15 +21,24 @@
 #include "AMQPConnection.h"
 #include "AMQPMessageHandler.h"
 
-AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection,
-			     const AMQPMessage &message)
-: m_connection(connection),
-  m_message(message)
+AMQPPublisher::AMQPPublisher(AMQPConnectionPtr &connection)
+: m_connection(connection)
 {
 }
 
 AMQPPublisher::~AMQPPublisher()
 {
+}
+
+void AMQPPublisher::setMessage(const AMQPMessage &message)
+{
+	m_message = message;
+}
+
+void AMQPPublisher::clear(void)
+{
+	AMQPMessage message;
+	m_message = message;
 }
 
 bool AMQPPublisher::publish(void)

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -20,12 +20,13 @@
 #ifndef AMQPPublisher_h
 #define AMQPPublisher_h
 
-#include "HatoholThreadBase.h"
+#include <glib.h>
+#include "Params.h"
 
 class AMQPConnectionInfo;
 class AMQPMessageHandler;
 
-class AMQPPublisher : public HatoholThreadBase {
+class AMQPPublisher {
 public:
 	AMQPPublisher(const AMQPConnectionInfo &connectionInfo,
 	              std::string body);

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -27,6 +27,7 @@ class AMQPMessageHandler;
 
 class AMQPPublisher {
 public:
+	AMQPPublisher(const AMQPConnectionInfo &connectionInfo);
 	AMQPPublisher(AMQPConnectionPtr &connection);
 	virtual ~AMQPPublisher();
 

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -29,6 +29,7 @@ class AMQPMessageHandler;
 class AMQPPublisher {
 public:
 	AMQPPublisher(const AMQPConnectionPtr &connection,
+		      std::string contentType,
 	              std::string body);
 	virtual ~AMQPPublisher();
 
@@ -37,6 +38,7 @@ public:
 
 private:
 	const AMQPConnectionPtr &m_connection;
+	std::string m_contentType;
 	std::string m_body;
 };
 

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -27,7 +27,7 @@ class AMQPMessageHandler;
 
 class AMQPPublisher {
 public:
-	AMQPPublisher(const AMQPConnectionPtr &connection,
+	AMQPPublisher(AMQPConnectionPtr &connection,
 		      const AMQPMessage &message);
 	virtual ~AMQPPublisher();
 
@@ -35,7 +35,7 @@ public:
 	virtual bool publish(void) override;
 
 private:
-	const AMQPConnectionPtr &m_connection;
+	AMQPConnectionPtr m_connection;
 	AMQPMessage m_message;
 };
 

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -32,7 +32,7 @@ public:
 	              std::string body);
 	virtual ~AMQPPublisher();
 
-protected:
+	//protected:
 	virtual bool publish(void) override;
 
 private:

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -31,7 +31,6 @@ public:
 		      const AMQPMessage &message);
 	virtual ~AMQPPublisher();
 
-	//protected:
 	virtual bool publish(void) override;
 
 private:

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -31,7 +31,7 @@ public:
 		      const AMQPMessage &message);
 	virtual ~AMQPPublisher();
 
-	virtual bool publish(void) override;
+	virtual bool publish(void);
 
 private:
 	AMQPConnectionPtr m_connection;

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -33,7 +33,7 @@ public:
 	virtual ~AMQPPublisher();
 
 protected:
-	virtual bool publish() override;
+	virtual bool publish(void) override;
 
 private:
 	const AMQPConnectionInfo &m_connectionInfo;

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -29,8 +29,7 @@ class AMQPMessageHandler;
 class AMQPPublisher {
 public:
 	AMQPPublisher(const AMQPConnectionPtr &connection,
-		      std::string contentType,
-	              std::string body);
+		      const AMQPMessage &message);
 	virtual ~AMQPPublisher();
 
 	//protected:
@@ -38,8 +37,7 @@ public:
 
 private:
 	const AMQPConnectionPtr &m_connection;
-	std::string m_contentType;
-	std::string m_body;
+	AMQPMessage m_message;
 };
 
 #endif // AMQPPublisher_h

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -31,9 +31,10 @@ public:
 	AMQPPublisher(AMQPConnectionPtr &connection);
 	virtual ~AMQPPublisher();
 
-	virtual void setMessage(const AMQPMessage &message);
-	virtual void clear(void);
-	virtual bool publish(void);
+	AMQPConnectionPtr getConnection(void);
+	void setMessage(const AMQPMessage &message);
+	void clear(void);
+	bool publish(void);
 
 private:
 	AMQPConnectionPtr m_connection;

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -39,10 +39,6 @@ public:
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
-
-private:
-	AMQPConnectionPtr m_connection;
-	AMQPMessage m_message;
 };
 
 #endif // AMQPPublisher_h

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -27,10 +27,11 @@ class AMQPMessageHandler;
 
 class AMQPPublisher {
 public:
-	AMQPPublisher(AMQPConnectionPtr &connection,
-		      const AMQPMessage &message);
+	AMQPPublisher(AMQPConnectionPtr &connection);
 	virtual ~AMQPPublisher();
 
+	virtual void setMessage(const AMQPMessage &message);
+	virtual void clear(void);
 	virtual bool publish(void);
 
 private:

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -20,7 +20,6 @@
 #ifndef AMQPPublisher_h
 #define AMQPPublisher_h
 
-#include <glib.h>
 #include "Params.h"
 #include "AMQPConnection.h"
 

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -37,6 +37,10 @@ public:
 	bool publish(void);
 
 private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+
+private:
 	AMQPConnectionPtr m_connection;
 	AMQPMessage m_message;
 };

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -22,13 +22,13 @@
 
 #include <glib.h>
 #include "Params.h"
+#include "AMQPConnection.h"
 
-class AMQPConnectionInfo;
 class AMQPMessageHandler;
 
 class AMQPPublisher {
 public:
-	AMQPPublisher(const AMQPConnectionInfo &connectionInfo,
+	AMQPPublisher(const AMQPConnectionPtr &connection,
 	              std::string body);
 	virtual ~AMQPPublisher();
 
@@ -36,7 +36,7 @@ public:
 	virtual bool publish(void) override;
 
 private:
-	const AMQPConnectionInfo &m_connectionInfo;
+	const AMQPConnectionPtr &m_connection;
 	std::string m_body;
 };
 

--- a/server/src/AMQPPublisher.h
+++ b/server/src/AMQPPublisher.h
@@ -32,7 +32,7 @@ public:
 	virtual ~AMQPPublisher();
 
 protected:
-	virtual gpointer mainThread(HatoholThreadArg *arg) override;
+	virtual bool publish() override;
 
 private:
 	const AMQPConnectionInfo &m_connectionInfo;

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -43,24 +43,18 @@ public:
 		initializeHosts();
 	}
 
-	bool handle(const amqp_envelope_t *envelope)
+	bool handle(const AMQPMessage &message)
 	{
-		const amqp_bytes_t *content_type =
-			&(envelope->message.properties.content_type);
 		// TODO: check content-type
-		const amqp_bytes_t *body = &(envelope->message.body);
-
-		MLPL_DBG("message: <%.*s>/<%.*s>\n",
-			 static_cast<int>(content_type->len),
-			 static_cast<char *>(content_type->bytes),
-			 static_cast<int>(body->len),
-			 static_cast<char *>(body->bytes));
+		MLPL_DBG("message: <%s>/<%s>\n",
+			 message.contentType.c_str(),
+			 message.body.c_str());
 
 		JsonParser *parser = json_parser_new();
 		GError *error = NULL;
 		if (json_parser_load_from_data(parser,
-					       static_cast<char *>(body->bytes),
-					       static_cast<int>(body->len),
+					       message.body.c_str(),
+					       message.body.size(),
 					       &error)) {
 			process(json_parser_get_root(parser));
 		} else {

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -197,7 +197,8 @@ struct HatoholArmPluginGateJSON::Impl
 			armPluginInfo.isTLSVerifyEnabled());
 
 		m_handler = new AMQPJSONMessageHandler(serverInfo);
-		AMQPConnectionPtr connection = new AMQPConnection(m_connectionInfo);
+		AMQPConnectionPtr connection =
+			AMQPConnection::create(m_connectionInfo);
 		m_consumer = new AMQPConsumer(connection, m_handler);
 	}
 

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -43,7 +43,7 @@ public:
 		initializeHosts();
 	}
 
-	bool handle(const AMQPMessage &message)
+	bool handle(AMQPConnection &connection, const AMQPMessage &message)
 	{
 		// TODO: check content-type
 		MLPL_DBG("message: <%s>/<%s>\n",

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -191,9 +191,7 @@ struct HatoholArmPluginGateJSON::Impl
 			armPluginInfo.isTLSVerifyEnabled());
 
 		m_handler = new AMQPJSONMessageHandler(serverInfo);
-		AMQPConnectionPtr connection =
-			AMQPConnection::create(m_connectionInfo);
-		m_consumer = new AMQPConsumer(connection, m_handler);
+		m_consumer = new AMQPConsumer(m_connectionInfo, m_handler);
 	}
 
 	~Impl()

--- a/server/src/HatoholArmPluginGateJSON.cc
+++ b/server/src/HatoholArmPluginGateJSON.cc
@@ -197,7 +197,8 @@ struct HatoholArmPluginGateJSON::Impl
 			armPluginInfo.isTLSVerifyEnabled());
 
 		m_handler = new AMQPJSONMessageHandler(serverInfo);
-		m_consumer = new AMQPConsumer(m_connectionInfo, m_handler);
+		AMQPConnectionPtr connection = new AMQPConnection(m_connectionInfo);
+		m_consumer = new AMQPConsumer(connection, m_handler);
 	}
 
 	~Impl()

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -88,6 +88,7 @@ testHatohol_la_SOURCES = \
 if HAVE_LIBRABBITMQ
 testHatohol_la_SOURCES += \
 	testAMQPConnectionInfo.cc \
+	testAMQPConnection.cc \
 	testGateJSONEventMessage.cc
 endif
 

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -127,9 +127,10 @@ namespace testAMQPConnection {
 
 	void test_publisher(void)
 	{
-		AMQPPublisher publisher(connection,
-					"application/json",
-					"{\"body\":\"example\"}");
+		AMQPMessage message;
+		message.contentType = "application/json";
+		message.body = "{\"body\":\"example\"}";
+		AMQPPublisher publisher(connection, message);
 		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -86,6 +86,18 @@ namespace testAMQPConnection {
 		cppcut_assert_equal(true, connection->connect());
 	}
 
+	void test_consumeWithoutConnection(void)
+	{
+		AMQPMessage message;
+		cppcut_assert_equal(false, connection->consume(message));
+	}
+
+	void test_publishWithoutConnection(void)
+	{
+		string body = "hoge";
+		cppcut_assert_equal(false, connection->publish(body));
+	}
+
 	void test_consumer(void)
 	{
 		string body = "{\"body\":\"example\"}";

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -73,7 +73,7 @@ namespace testAMQPConnection {
 	void cut_teardown(void)
 	{
 		if (connection.hasData())
-			connection->purge();
+			connection->deleteQueue();
 		connection = NULL;
 	}
 

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -88,11 +88,13 @@ namespace testAMQPConnection {
 		return timer;
 	}
 
-	void test_connect(void) {
+	void test_connect(void)
+	{
 		cppcut_assert_equal(true, connection->connect());
 	}
 
-	void test_consumer(void) {
+	void test_consumer(void)
+	{
 		string body = "{\"body\":\"example\"}";
 		connection->connect();
 		connection->publish(body);
@@ -114,7 +116,8 @@ namespace testAMQPConnection {
 		cppcut_assert_equal(body, handler.m_body);
 	}
 
-	void test_publisher(void) {
+	void test_publisher(void)
+	{
 		AMQPPublisher publisher(connection, "{\"body\":\"example\"}");
 		cppcut_assert_equal(true, publisher.publish());
 	}

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -64,14 +64,16 @@ namespace testAMQPConnection {
 
 	void test_consumer(void) {
 		TestHandler handler;
-		AMQPConsumer consumer(*info, &handler);
+		AMQPConnectionPtr connection = new AMQPConnection(*info);
+		AMQPConsumer consumer(connection, &handler);
 		consumer.start();
 		// TODO: add assertion
 		consumer.exitSync();
 	}
 
 	void test_publisher(void) {
-		AMQPPublisher publisher(*info, "{\"body\":\"example\"}");
+		AMQPConnectionPtr connection = new AMQPConnection(*info);
+		AMQPPublisher publisher(connection, "{\"body\":\"example\"}");
 		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -34,9 +34,9 @@ namespace testAMQPConnection {
 	AMQPConnectionInfo *info;
 	AMQPConnectionPtr connection;
 
-	class TestHandler : public AMQPMessageHandler {
+	class TestMessageHandler : public AMQPMessageHandler {
 	public:
-		TestHandler()
+		TestMessageHandler()
 		: m_gotMessage(false)
 		{
 		}
@@ -104,7 +104,7 @@ namespace testAMQPConnection {
 		connection->connect();
 		connection->publish(body);
 
-		TestHandler handler;
+		TestMessageHandler handler;
 		AMQPConsumer consumer(connection, &handler);
 		consumer.start();
 		gdouble timeout = 2 * G_USEC_PER_SEC, elapsed = 0.0;

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -123,7 +123,7 @@ namespace testAMQPConnection {
 		TestMessageHandler handler;
 		AMQPConsumer consumer(*connectionInfo, &handler);
 		consumer.start();
-		gdouble timeout = 2 * G_USEC_PER_SEC, elapsed = 0.0;
+		gdouble timeout = 2.0, elapsed = 0.0;
 		GTimer *timer = startTimer();
 		while (!handler.m_gotMessage && elapsed < timeout) {
 			g_usleep(0.1 * G_USEC_PER_SEC);

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -94,15 +94,18 @@ namespace testAMQPConnection {
 
 	void test_publishWithoutConnection(void)
 	{
-		string body = "hoge";
-		cppcut_assert_equal(false, connection->publish(body));
+		AMQPMessage message;
+		message.body = "hoge";
+		cppcut_assert_equal(false, connection->publish(message));
 	}
 
 	void test_consumer(void)
 	{
-		string body = "{\"body\":\"example\"}";
+		AMQPMessage message;
+		message.contentType = "application/json";
+		message.body = "{\"body\":\"example\"}";
 		connection->connect();
-		connection->publish(body);
+		connection->publish(message);
 
 		TestMessageHandler handler;
 		AMQPConsumer consumer(connection, &handler);
@@ -116,14 +119,17 @@ namespace testAMQPConnection {
 		consumer.exitSync();
 
 		cut_assert_true(elapsed < timeout);
-		cppcut_assert_equal(string("application/json"),
+		cppcut_assert_equal(message.contentType,
 				    handler.m_message.contentType);
-		cppcut_assert_equal(body, handler.m_message.body);
+		cppcut_assert_equal(message.body,
+				    handler.m_message.body);
 	}
 
 	void test_publisher(void)
 	{
-		AMQPPublisher publisher(connection, "{\"body\":\"example\"}");
+		AMQPPublisher publisher(connection,
+					"application/json",
+					"{\"body\":\"example\"}");
 		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -114,8 +114,7 @@ namespace testAMQPConnection {
 
 	void test_transferMessage(void)
 	{
-		AMQPMessage message;
-		message.contentType = "application/json";
+		AMQPJSONMessage message;
 		message.body = "{\"body\":\"example\"}";
 		AMQPPublisher publisher(*connectionInfo);
 		publisher.setMessage(message);

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -112,14 +112,14 @@ namespace testAMQPConnection {
 		cppcut_assert_equal(false, connection->publish(message));
 	}
 
-	void test_consumer(void)
+	void test_transferMessage(void)
 	{
 		AMQPMessage message;
 		message.contentType = "application/json";
 		message.body = "{\"body\":\"example\"}";
-		connection = getConnection();
-		connection->connect();
-		connection->publish(message);
+		AMQPPublisher publisher(*connectionInfo);
+		publisher.setMessage(message);
+		cppcut_assert_equal(true, publisher.publish());
 
 		TestMessageHandler handler;
 		AMQPConsumer consumer(*connectionInfo, &handler);
@@ -137,15 +137,5 @@ namespace testAMQPConnection {
 				    handler.m_message.contentType);
 		cppcut_assert_equal(message.body,
 				    handler.m_message.body);
-	}
-
-	void test_publisher(void)
-	{
-		AMQPMessage message;
-		message.contentType = "application/json";
-		message.body = "{\"body\":\"example\"}";
-		AMQPPublisher publisher(*connectionInfo);
-		publisher.setMessage(message);
-		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <gcutter.h>
+#include <cppcutter.h>
+
+#include <AMQPConnection.h>
+
+using namespace std;
+
+namespace testAMQPConnection {
+	AMQPConnectionInfo *info;
+
+	void cut_setup(void)
+	{
+		const char *url = getenv("TEST_AMQP_URL");
+		//url = "amqp://hatohol:hatohol@localhost:5672/hatohol";
+		if (!url)
+			cut_omit("TEST_AMQP_URL isn't set");
+
+		info = new AMQPConnectionInfo();
+		info->setURL(url);
+		info->setQueueName("test.1");
+	}
+	
+	void cut_teardown(void)
+	{
+		delete info;
+	}
+
+	void test_connect(void) {
+		AMQPConnection connection(*info);
+		cppcut_assert_equal(true, connection.connect());
+	}
+} // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -40,7 +40,8 @@ namespace testAMQPConnection {
 		{
 		}
 
-		virtual bool handle(const AMQPMessage &message) override
+		virtual bool handle(AMQPConnection &connection,
+				    const AMQPMessage &message) override
 		{
 			m_gotMessage = true;
 			m_message = message;

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -41,22 +41,15 @@ namespace testAMQPConnection {
 		{
 		}
 
-		virtual bool handle(const amqp_envelope_t *envelope) override
+		virtual bool handle(const AMQPMessage &message) override
 		{
-			const amqp_bytes_t *contentType =
-			  &(envelope->message.properties.content_type);
-			const amqp_bytes_t *body = &(envelope->message.body);
-			m_contentType.assign(static_cast<char*>(contentType->bytes),
-					     static_cast<int>(contentType->len));
-			m_body.assign(static_cast<char*>(body->bytes),
-				      static_cast<int>(body->len));
 			m_gotMessage = true;
+			m_message = message;
 			return true;
 		}
 
 		AtomicValue<bool> m_gotMessage;
-		string m_contentType;
-		string m_body;
+		AMQPMessage m_message;
 	};
 
 	void cut_setup(void)
@@ -112,8 +105,8 @@ namespace testAMQPConnection {
 
 		cut_assert_true(elapsed < timeout);
 		cppcut_assert_equal(string("application/json"),
-				    handler.m_contentType);
-		cppcut_assert_equal(body, handler.m_body);
+				    handler.m_message.contentType);
+		cppcut_assert_equal(body, handler.m_message.body);
 	}
 
 	void test_publisher(void)

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -51,6 +51,9 @@ namespace testAMQPConnection {
 	
 	void cut_teardown(void)
 	{
+		AMQPConnection connection(*info);
+		connection.connect();
+		connection.purge();
 		delete info;
 	}
 

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -21,11 +21,21 @@
 #include <cppcutter.h>
 
 #include <AMQPConnection.h>
+#include <AMQPConsumer.h>
+#include <AMQPPublisher.h>
+#include <AMQPMessageHandler.h>
 
 using namespace std;
 
 namespace testAMQPConnection {
 	AMQPConnectionInfo *info;
+
+	class TestHandler : public AMQPMessageHandler {
+		virtual bool handle(const amqp_envelope_t *envelope) override
+		{
+			return true;
+		}
+	};
 
 	void cut_setup(void)
 	{
@@ -47,5 +57,18 @@ namespace testAMQPConnection {
 	void test_connect(void) {
 		AMQPConnection connection(*info);
 		cppcut_assert_equal(true, connection.connect());
+	}
+
+	void test_consumer(void) {
+		TestHandler handler;
+		AMQPConsumer consumer(*info, &handler);
+		consumer.start();
+		// TODO: add assertion
+		consumer.exitSync();
+	}
+
+	void test_publisher(void) {
+		AMQPPublisher publisher(*info, "{\"body\":\"example\"}");
+		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -140,7 +140,8 @@ namespace testAMQPConnection {
 		message.contentType = "application/json";
 		message.body = "{\"body\":\"example\"}";
 		connection = getConnection();
-		AMQPPublisher publisher(connection, message);
+		AMQPPublisher publisher(connection);
+		publisher.setMessage(message);
 		cppcut_assert_equal(true, publisher.publish());
 	}
 } // namespace testAMQPConnection

--- a/server/test/testAMQPConnection.cc
+++ b/server/test/testAMQPConnection.cc
@@ -31,6 +31,8 @@ using namespace std;
 using namespace mlpl;
 
 namespace testAMQPConnection {
+	AMQPConnectionPtr connection;
+
 	class TestMessageHandler : public AMQPMessageHandler {
 	public:
 		TestMessageHandler()
@@ -49,14 +51,6 @@ namespace testAMQPConnection {
 		AMQPMessage m_message;
 	};
 
-	void cut_setup(void)
-	{
-	}
-	
-	void cut_teardown(void)
-	{
-	}
-
 	AMQPConnectionPtr getConnection(const char *url = NULL)
 	{
 		// e.g.) url = "amqp://hatohol:hatohol@localhost:5672/hatohol";
@@ -72,6 +66,17 @@ namespace testAMQPConnection {
 		return AMQPConnection::create(info);
 	}
 
+	void cut_setup(void)
+	{
+	}
+
+	void cut_teardown(void)
+	{
+		if (connection.hasData())
+			connection->purge();
+		connection = NULL;
+	}
+
 	GTimer *startTimer(void)
 	{
 		GTimer *timer = g_timer_new();
@@ -82,31 +87,31 @@ namespace testAMQPConnection {
 
 	void test_connect(void)
 	{
-		AMQPConnectionPtr connection = getConnection();
+		connection = getConnection();
 		cppcut_assert_equal(true, connection->connect());
 	}
 
 	void test_consumeWithoutConnection(void)
 	{
-		AMQPConnectionPtr connection = getConnection();
 		AMQPMessage message;
+		connection = getConnection();
 		cppcut_assert_equal(false, connection->consume(message));
 	}
 
 	void test_publishWithoutConnection(void)
 	{
-		AMQPConnectionPtr connection = getConnection();
 		AMQPMessage message;
 		message.body = "hoge";
+		connection = getConnection();
 		cppcut_assert_equal(false, connection->publish(message));
 	}
 
 	void test_consumer(void)
 	{
-		AMQPConnectionPtr connection = getConnection();
 		AMQPMessage message;
 		message.contentType = "application/json";
 		message.body = "{\"body\":\"example\"}";
+		connection = getConnection();
 		connection->connect();
 		connection->publish(message);
 
@@ -130,10 +135,10 @@ namespace testAMQPConnection {
 
 	void test_publisher(void)
 	{
-		AMQPConnectionPtr connection = getConnection();
 		AMQPMessage message;
 		message.contentType = "application/json";
 		message.body = "{\"body\":\"example\"}";
+		connection = getConnection();
 		AMQPPublisher publisher(connection, message);
 		cppcut_assert_equal(true, publisher.publish());
 	}


### PR DESCRIPTION
AMQPConnection (which is a wrapper class for rabbitmq-c) doesn't have an ability to send a message.
@cosmo0920 and I added an ad-hoc implementation of it.
Although I'll heavily modify it later to introduce an abstraction layer of the communication,
I want to merge the current code to implement the skeleton of the server side of HAPI-2.0 ASAP.
