### PR TITLE
[server][DBTablesHost][DBTablesMonitoring] Implement sync & delete series APIs

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -101,6 +101,8 @@ typedef std::map<TriggerIdType, TriggerInfo *> TriggerIdInfoMap;
 typedef TriggerIdInfoMap::iterator             TriggerIdInfoMapIterator;
 typedef TriggerIdInfoMap::const_iterator       TriggerIdInfoMapConstIterator;
 
+typedef std::list<TriggerIdType> TriggerIdList;
+
 enum EventType {
 	EVENT_TYPE_GOOD,
 	EVENT_TYPE_BAD,

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1341,4 +1341,3 @@ DBTables::SetupInfo &DBTablesHost::getSetupInfo(void)
 	};
 	return SETUP_INFO;
 }
-

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1408,7 +1408,9 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	}
 
 	GenericIdList invalidHostgroupMemberIdList;
-	for (auto invalidHostgroupMemberPair : currValidHostgroupMemberMap) {
+	map<GenericIdType, const HostgroupMember *> invalidHostgroupMemberMap =
+		move(currValidHostgroupMemberMap);
+	for (auto invalidHostgroupMemberPair : invalidHostgroupMemberMap) {
 		HostgroupMember invalidHostgroupMember = *invalidHostgroupMemberPair.second;
 		invalidHostgroupMemberIdList.push_back(invalidHostgroupMember.id);
 	}

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -994,7 +994,8 @@ HatoholError DBTablesHost::syncHostgroups(
 		Hostgroup invalidHostgroup = *invalidHostgroupPair.second;
 		invalidHostgroupIdList.push_back(invalidHostgroup.id);
 	}
-	err = deleteHostgroupList(invalidHostgroupIdList);
+	if (invalidHostgroupIdList.size() > 0)
+		err = deleteHostgroupList(invalidHostgroupIdList);
 	return err;
 }
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -972,7 +972,7 @@ HatoholError DBTablesHost::syncHostgroups(
 		return err;
 	const HostgroupVect &currHostgroups(_currHostgroups);
 
-	map<string, const Hostgroup *> currValidHostgroupMap;
+	map<HostgroupIdType, const Hostgroup *> currValidHostgroupMap;
 	for (auto hostgroup : currHostgroups) {
 		const Hostgroup &svHostgroup = hostgroup;
 		currValidHostgroupMap[svHostgroup.idInServer] = &svHostgroup;

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1383,7 +1383,7 @@ HatoholError DBTablesHost::syncHostgroups(
 }
 
 HatoholError DBTablesHost::syncHostgroupMembers(
-  HostgroupMemberVect &svHostgroupMembers,
+  HostgroupMemberVect &incomingHostgroupMembers,
   const ServerIdType &serverId)
 {
 	HostgroupMembersQueryOption option(USER_ID_SYSTEM);
@@ -1400,11 +1400,11 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 
 	//Pick up hostgroupMember to be added.
 	HostgroupMemberVect serverHostgroupMembers;
-	for (auto newSvHostgroupMember : svHostgroupMembers) {
-		if(currValidHostgroupMemberMap.erase(newSvHostgroupMember.id) >= 1) {
+	for (auto hostgroupMember : incomingHostgroupMembers) {
+		if(currValidHostgroupMemberMap.erase(hostgroupMember.id) >= 1) {
 			continue;
 		}
-		serverHostgroupMembers.push_back(move(newSvHostgroupMember));
+		serverHostgroupMembers.push_back(move(hostgroupMember));
 	}
 
 	GenericIdList invalidHostgroupMemberIdList;

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1128,17 +1128,16 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 		return err;
 	const HostgroupMemberVect &currHostgroupMembers(_currHostgroupMembers);
 	// TODO: more strict valid hostgroup sampling
-	map<LocalHostIdType, const HostgroupMember *> currValidHostgroupMemberMap;
+	map<GenericIdType, const HostgroupMember *> currValidHostgroupMemberMap;
 	for (auto hostgroupMember : currHostgroupMembers) {
 		const HostgroupMember &svHostgroupMember = hostgroupMember;
-		currValidHostgroupMemberMap[svHostgroupMember.hostIdInServer] =
-			&svHostgroupMember;
+		currValidHostgroupMemberMap[svHostgroupMember.id] = &svHostgroupMember;
 	}
 
 	//Pick up hostgroupMember to be added.
 	HostgroupMemberVect serverHostgroupMembers;
 	for (auto newSvHostgroupMember : svHostgroupMembers) {
-		if(currValidHostgroupMemberMap.erase(newSvHostgroupMember.hostIdInServer) >= 1) {
+		if(currValidHostgroupMemberMap.erase(newSvHostgroupMember.id) >= 1) {
 			continue;
 		}
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1354,9 +1354,8 @@ HatoholError DBTablesHost::syncHostgroups(
 	const HostgroupVect &currHostgroups(_currHostgroups);
 
 	map<HostgroupIdType, const Hostgroup *> currValidHostgroupMap;
-	for (auto hostgroup : currHostgroups) {
-		const Hostgroup &svHostgroup = hostgroup;
-		currValidHostgroupMap[svHostgroup.idInServer] = &svHostgroup;
+	for (auto& hostgroup : currHostgroups) {
+		currValidHostgroupMap[hostgroup.idInServer] = &hostgroup;
 	}
 
 	// Pick up hostgroups to be added.

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1342,7 +1342,7 @@ HatoholError DBTablesHost::syncHosts(
 }
 
 HatoholError DBTablesHost::syncHostgroups(
-  HostgroupVect &svHostgroups,
+  HostgroupVect &incomingHostgroups,
   const ServerIdType &serverId)
 {
 	HostgroupsQueryOption option(USER_ID_SYSTEM);
@@ -1360,12 +1360,12 @@ HatoholError DBTablesHost::syncHostgroups(
 
 	// Pick up hostgroups to be added.
 	HostgroupVect serverHostgroups;
-	for (auto newSvHostgroup : svHostgroups) {
-		if (currValidHostgroupMap.erase(newSvHostgroup.idInServer) >= 1) {
+	for (auto hostgroup : incomingHostgroups) {
+		if (currValidHostgroupMap.erase(hostgroup.idInServer) >= 1) {
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
-		serverHostgroups.push_back(move(newSvHostgroup));
+		serverHostgroups.push_back(move(hostgroup));
 	}
 
 	GenericIdList invalidHostgroupIdList;

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1389,11 +1389,9 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	if (err != HTERR_OK)
 		return err;
 	const HostgroupMemberVect &currHostgroupMembers(_currHostgroupMembers);
-	// TODO: more strict valid hostgroup sampling
 	map<GenericIdType, const HostgroupMember *> currValidHostgroupMemberMap;
-	for (auto hostgroupMember : currHostgroupMembers) {
-		const HostgroupMember &svHostgroupMember = hostgroupMember;
-		currValidHostgroupMemberMap[svHostgroupMember.id] = &svHostgroupMember;
+	for (auto& hostgroupMember : currHostgroupMembers) {
+		currValidHostgroupMemberMap[hostgroupMember.id] = &hostgroupMember;
 	}
 
 	//Pick up hostgroupMember to be added.
@@ -1402,7 +1400,6 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 		if(currValidHostgroupMemberMap.erase(newSvHostgroupMember.id) >= 1) {
 			continue;
 		}
-
 		serverHostgroupMembers.push_back(move(newSvHostgroupMember));
 	}
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1351,7 +1351,7 @@ HatoholError DBTablesHost::syncHostgroups(
 	HatoholError err = getHostgroups(_currHostgroups, option);
 	if (err != HTERR_OK)
 		return err;
-	const HostgroupVect &currHostgroups = move(_currHostgroups);
+	const HostgroupVect currHostgroups = move(_currHostgroups);
 
 	map<HostgroupIdType, const Hostgroup *> currValidHostgroupMap;
 	for (auto& hostgroup : currHostgroups) {
@@ -1388,7 +1388,7 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	HatoholError err = getHostgroupMembers(_currHostgroupMembers, option);
 	if (err != HTERR_OK)
 		return err;
-	const HostgroupMemberVect &currHostgroupMembers = move(_currHostgroupMembers);
+	const HostgroupMemberVect currHostgroupMembers = move(_currHostgroupMembers);
 	map<GenericIdType, const HostgroupMember *> currValidHostgroupMemberMap;
 	for (auto& hostgroupMember : currHostgroupMembers) {
 		currValidHostgroupMemberMap[hostgroupMember.id] = &hostgroupMember;

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -902,7 +902,7 @@ HatoholError DBTablesHost::getHostgroups(HostgroupVect &hostgroups,
 	return HTERR_OK;
 }
 
-static string makeHostgroupIdListCondition(const HostgroupIdList &idList)
+static string makeIdListCondition(const GenericIdList &idList)
 {
 	string condition;
 	const ColumnDef &colId = COLUMN_DEF_HOSTGROUP_LIST[IDX_HOSTGROUP_LIST_ID];
@@ -917,14 +917,14 @@ static string makeHostgroupIdListCondition(const HostgroupIdList &idList)
 	return condition;
 }
 
-static string makeConditionForDeleteHostgroup(const HostgroupIdList &idList)
+static string makeConditionForDelete(const GenericIdList &idList)
 {
-	string condition = makeHostgroupIdListCondition(idList);
+	string condition = makeIdListCondition(idList);
 
 	return condition;
 }
 
-HatoholError DBTablesHost::deleteHostgroupList(const HostgroupIdList &idList)
+HatoholError DBTablesHost::deleteHostgroupList(const GenericIdList &idList)
 {
 	if (idList.empty()) {
 		MLPL_WARN("idList is empty.\n");
@@ -947,7 +947,7 @@ HatoholError DBTablesHost::deleteHostgroupList(const HostgroupIdList &idList)
 			numAffectedRows = dbAgent.getNumberOfAffectedRows();
 		}
 	} trx;
-	trx.arg.condition = makeConditionForDeleteHostgroup(idList);
+	trx.arg.condition = makeConditionForDelete(idList);
 	getDBAgent().runTransaction(trx);
 
 	// Check the result
@@ -989,7 +989,7 @@ HatoholError DBTablesHost::syncHostgroups(
 		serverHostgroups.push_back(newSvHostgroup);
 	}
 
-	HostgroupIdList invalidHostgroupIdList;
+	GenericIdList invalidHostgroupIdList;
 	for (auto invalidHostgroupPair : currValidHostgroupMap) {
 		Hostgroup invalidHostgroup = *invalidHostgroupPair.second;
 		invalidHostgroupIdList.push_back(invalidHostgroup.id);

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1351,7 +1351,7 @@ HatoholError DBTablesHost::syncHostgroups(
 	HatoholError err = getHostgroups(_currHostgroups, option);
 	if (err != HTERR_OK)
 		return err;
-	const HostgroupVect &currHostgroups(_currHostgroups);
+	const HostgroupVect &currHostgroups = move(_currHostgroups);
 
 	map<HostgroupIdType, const Hostgroup *> currValidHostgroupMap;
 	for (auto& hostgroup : currHostgroups) {
@@ -1388,7 +1388,7 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	HatoholError err = getHostgroupMembers(_currHostgroupMembers, option);
 	if (err != HTERR_OK)
 		return err;
-	const HostgroupMemberVect &currHostgroupMembers(_currHostgroupMembers);
+	const HostgroupMemberVect &currHostgroupMembers = move(_currHostgroupMembers);
 	map<GenericIdType, const HostgroupMember *> currValidHostgroupMemberMap;
 	for (auto& hostgroupMember : currHostgroupMembers) {
 		currValidHostgroupMemberMap[hostgroupMember.id] = &hostgroupMember;

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1353,15 +1353,15 @@ HatoholError DBTablesHost::syncHostgroups(
 		return err;
 	const HostgroupVect currHostgroups = move(_currHostgroups);
 
-	map<HostgroupIdType, const Hostgroup *> currValidHostgroupMap;
+	map<HostgroupIdType, const Hostgroup *> currentHostgroupMap;
 	for (auto& hostgroup : currHostgroups) {
-		currValidHostgroupMap[hostgroup.idInServer] = &hostgroup;
+		currentHostgroupMap[hostgroup.idInServer] = &hostgroup;
 	}
 
 	// Pick up hostgroups to be added.
 	HostgroupVect serverHostgroups;
 	for (auto hostgroup : incomingHostgroups) {
-		if (currValidHostgroupMap.erase(hostgroup.idInServer) >= 1) {
+		if (currentHostgroupMap.erase(hostgroup.idInServer) >= 1) {
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
@@ -1370,7 +1370,7 @@ HatoholError DBTablesHost::syncHostgroups(
 
 	GenericIdList invalidHostgroupIdList;
 	map<HostgroupIdType, const Hostgroup *> invalidHostgroupMap =
-		move(currValidHostgroupMap);
+		move(currentHostgroupMap);
 	for (auto invalidHostgroupPair : invalidHostgroupMap) {
 		Hostgroup invalidHostgroup = *invalidHostgroupPair.second;
 		invalidHostgroupIdList.push_back(invalidHostgroup.id);
@@ -1393,15 +1393,15 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	if (err != HTERR_OK)
 		return err;
 	const HostgroupMemberVect currHostgroupMembers = move(_currHostgroupMembers);
-	map<GenericIdType, const HostgroupMember *> currValidHostgroupMemberMap;
+	map<GenericIdType, const HostgroupMember *> currentHostgroupMemberMap;
 	for (auto& hostgroupMember : currHostgroupMembers) {
-		currValidHostgroupMemberMap[hostgroupMember.id] = &hostgroupMember;
+		currentHostgroupMemberMap[hostgroupMember.id] = &hostgroupMember;
 	}
 
 	//Pick up hostgroupMember to be added.
 	HostgroupMemberVect serverHostgroupMembers;
 	for (auto hostgroupMember : incomingHostgroupMembers) {
-		if(currValidHostgroupMemberMap.erase(hostgroupMember.id) >= 1) {
+		if(currentHostgroupMemberMap.erase(hostgroupMember.id) >= 1) {
 			continue;
 		}
 		serverHostgroupMembers.push_back(move(hostgroupMember));
@@ -1409,7 +1409,7 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 
 	GenericIdList invalidHostgroupMemberIdList;
 	map<GenericIdType, const HostgroupMember *> invalidHostgroupMemberMap =
-		move(currValidHostgroupMemberMap);
+		move(currentHostgroupMemberMap);
 	for (auto invalidHostgroupMemberPair : invalidHostgroupMemberMap) {
 		HostgroupMember invalidHostgroupMember = *invalidHostgroupMemberPair.second;
 		invalidHostgroupMemberIdList.push_back(invalidHostgroupMember.id);

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1375,6 +1375,8 @@ HatoholError DBTablesHost::syncHostgroups(
 	}
 	if (invalidHostgroupIdList.size() > 0)
 		err = deleteHostgroupList(invalidHostgroupIdList);
+	if (serverHostgroups.size() > 0)
+		upsertHostgroups(serverHostgroups);
 	return err;
 }
 
@@ -1410,6 +1412,8 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	}
 	if (invalidHostgroupMemberIdList.size() > 0)
 		err = deleteHostgroupMemberList(invalidHostgroupMemberIdList);
+	if (serverHostgroupMembers.size() > 0)
+		upsertHostgroupMembers(serverHostgroupMembers);
 	return HTERR_OK;
 }
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1369,7 +1369,9 @@ HatoholError DBTablesHost::syncHostgroups(
 	}
 
 	GenericIdList invalidHostgroupIdList;
-	for (auto invalidHostgroupPair : currValidHostgroupMap) {
+	map<HostgroupIdType, const Hostgroup *> invalidHostgroupMap =
+		move(currValidHostgroupMap);
+	for (auto invalidHostgroupPair : invalidHostgroupMap) {
 		Hostgroup invalidHostgroup = *invalidHostgroupPair.second;
 		invalidHostgroupIdList.push_back(invalidHostgroup.id);
 	}

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1320,8 +1320,7 @@ HatoholError DBTablesHost::syncHosts(
 			// The host already exits. We have nothing to do.
 			continue;
 		}
-		// TODO: avoid the copy
-		serverHostDefs.push_back(newSvHostDef);
+		serverHostDefs.push_back(move(newSvHostDef));
 	}
 
 	// Add hosts to be marked as invalid
@@ -1367,8 +1366,7 @@ HatoholError DBTablesHost::syncHostgroups(
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
-		// TODO: avoid the copy
-		serverHostgroups.push_back(newSvHostgroup);
+		serverHostgroups.push_back(move(newSvHostgroup));
 	}
 
 	GenericIdList invalidHostgroupIdList;
@@ -1406,8 +1404,7 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 			continue;
 		}
 
-		// TODO: avoid the copy
-		serverHostgroupMembers.push_back(newSvHostgroupMember);
+		serverHostgroupMembers.push_back(move(newSvHostgroupMember));
 	}
 
 	GenericIdList invalidHostgroupMemberIdList;

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -319,6 +319,8 @@ public:
 
 	HatoholError deleteHostgroupMemberList(const GenericIdList &idList);
 
+	HatoholError syncHostgroupMembers(HostgroupMemberVect &hostgroupMembers,
+	                                  const ServerIdType &serverId);
 	/**
 	 * Get the virtual mechines
 	 *

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -73,6 +73,10 @@ typedef std::vector<Hostgroup>        HostgroupVect;
 typedef HostgroupVect::iterator       HostgroupVectIterator;
 typedef HostgroupVect::const_iterator HostgroupVectConstIterator;
 
+typedef std::list<GenericIdType>         HostgroupIdList;
+typedef HostgroupIdList::iterator        HostgroupIdListIterator;
+typedef HostgroupIdList::const_iterator  HostgroupIdListConstIterator;
+
 struct HostgroupMember {
 	GenericIdType   id;
 	ServerIdType    serverId;
@@ -289,6 +293,7 @@ public:
 	 */
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
+	HatoholError deleteHostgroupList(const HostgroupIdList &idList);
 
 	/**
 	 * Insert or update a record to/in the hostgroup_member table

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -380,6 +380,8 @@ public:
 	HatoholError syncHosts(
 	  const ServerHostDefVect &svHostDefs, const ServerIdType &serverId,
 	  HostHostIdMap *hostHostIdMapPtr = NULL);
+	HatoholError syncHostgroups(HostgroupVect &hostgroups,
+	                            const ServerIdType &serverId);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -317,6 +317,8 @@ public:
 	  HostgroupMemberVect &hostgrpMembers,
 	  const HostgroupMembersQueryOption &option);
 
+	HatoholError deleteHostgroupMemberList(const GenericIdList &idList);
+
 	/**
 	 * Get the virtual mechines
 	 *

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -73,10 +73,6 @@ typedef std::vector<Hostgroup>        HostgroupVect;
 typedef HostgroupVect::iterator       HostgroupVectIterator;
 typedef HostgroupVect::const_iterator HostgroupVectConstIterator;
 
-typedef std::list<GenericIdType>         HostgroupIdList;
-typedef HostgroupIdList::iterator        HostgroupIdListIterator;
-typedef HostgroupIdList::const_iterator  HostgroupIdListConstIterator;
-
 struct HostgroupMember {
 	GenericIdType   id;
 	ServerIdType    serverId;
@@ -88,6 +84,10 @@ struct HostgroupMember {
 typedef std::vector<HostgroupMember>        HostgroupMemberVect;
 typedef HostgroupMemberVect::iterator       HostgroupMemberVectIterator;
 typedef HostgroupMemberVect::const_iterator HostgroupMemberVectConstIterator;
+
+typedef std::list<GenericIdType>         GenericIdList;
+typedef GenericIdList::iterator          GenericIdListIterator;
+typedef GenericIdList::const_iterator    GenericIdListConstIterator;
 
 enum {
 	IDX_HOST_LIST_ID,

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -319,8 +319,6 @@ public:
 
 	HatoholError deleteHostgroupMemberList(const GenericIdList &idList);
 
-	HatoholError syncHostgroupMembers(HostgroupMemberVect &hostgroupMembers,
-	                                  const ServerIdType &serverId);
 	/**
 	 * Get the virtual mechines
 	 *
@@ -386,6 +384,8 @@ public:
 	  HostHostIdMap *hostHostIdMapPtr = NULL);
 	HatoholError syncHostgroups(HostgroupVect &hostgroups,
 	                            const ServerIdType &serverId);
+	HatoholError syncHostgroupMembers(HostgroupMemberVect &hostgroupMembers,
+	                                  const ServerIdType &serverId);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -293,7 +293,7 @@ public:
 	 */
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
-	HatoholError deleteHostgroupList(const HostgroupIdList &idList);
+	HatoholError deleteHostgroupList(const GenericIdList &idList);
 
 	/**
 	 * Insert or update a record to/in the hostgroup_member table

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -338,6 +338,8 @@ public:
 	HatoholError getVirtualMachines(HostIdVector &virtualMachines,
 	                                const HostIdType &hypervisorHostId,
 	                                const HostsQueryOption &option);
+	HatoholError deleteVMInfoList(const GenericIdList &idList);
+
 	/**
 	 * Get the hyperviosr.
 	 *

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1650,9 +1650,8 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 	const TriggerInfoList &currTriggers(_currTriggers);
 
 	map<TriggerIdType, const TriggerInfo *> currValidTriggerMap;
-	for (auto trigger : currTriggers) {
-		const TriggerInfo &svTriggerInfo = trigger;
-		currValidTriggerMap[svTriggerInfo.id] = &svTriggerInfo;
+	for (auto& trigger : currTriggers) {
+		currValidTriggerMap[trigger.id] = &trigger;
 	}
 
 	// Pick up triggers to be added

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1647,7 +1647,7 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 	TriggerInfoList _currTriggers;
 	getTriggerInfoList(_currTriggers, option);
 
-	const TriggerInfoList &currTriggers = move(_currTriggers);
+	const TriggerInfoList currTriggers = move(_currTriggers);
 
 	map<TriggerIdType, const TriggerInfo *> currValidTriggerMap;
 	for (auto& trigger : currTriggers) {

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1647,7 +1647,7 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 	TriggerInfoList _currTriggers;
 	getTriggerInfoList(_currTriggers, option);
 
-	const TriggerInfoList &currTriggers(_currTriggers);
+	const TriggerInfoList &currTriggers = move(_currTriggers);
 
 	map<TriggerIdType, const TriggerInfo *> currValidTriggerMap;
 	for (auto& trigger : currTriggers) {

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1589,14 +1589,21 @@ static string makeTriggerIdListCondition(const TriggerIdList &idList)
 	return condition;
 }
 
-static string makeConditionForDelete(const TriggerIdList &idList)
+static string makeConditionForDelete(const TriggerIdList &idList,
+				     const ServerIdType &serverId)
 {
 	string condition = makeTriggerIdListCondition(idList);
+	condition += " AND ";
+	string columnName =
+		tableProfileTriggers.columnDefs[IDX_TRIGGERS_SERVER_ID].columnName;
+	condition += StringUtils::sprintf("%s=%" FMT_SERVER_ID,
+	                                  columnName.c_str(), serverId);
 
 	return condition;
 }
 
-HatoholError DBTablesMonitoring::deleteTriggerInfo(const TriggerIdList &idList)
+HatoholError DBTablesMonitoring::deleteTriggerInfo(const TriggerIdList &idList,
+                                                   const ServerIdType &serverId)
 {
 	if (idList.empty()) {
 		MLPL_WARN("idList is empty.\n");
@@ -1619,7 +1626,7 @@ HatoholError DBTablesMonitoring::deleteTriggerInfo(const TriggerIdList &idList)
 			numAffectedRows = dbAgent.getNumberOfAffectedRows();
 		}
 	} trx;
-	trx.arg.condition = makeConditionForDelete(idList);
+	trx.arg.condition = makeConditionForDelete(idList, serverId);
 	getDBAgent().runTransaction(trx);
 
 	// Check the result

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1665,7 +1665,9 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &incomingTriggerIn
 	}
 
 	TriggerIdList invalidTriggerIdList;
-	for (auto invalidTriggerPair : currValidTriggerMap) {
+	map<TriggerIdType, const TriggerInfo *> invalidTriggerMap =
+		move(currValidTriggerMap);
+	for (auto invalidTriggerPair : invalidTriggerMap) {
 		TriggerInfo invalidTrigger = *invalidTriggerPair.second;
 		invalidTriggerIdList.push_back(invalidTrigger.id);
 	}

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1639,7 +1639,7 @@ HatoholError DBTablesMonitoring::deleteTriggerInfo(const TriggerIdList &idList,
 	return HTERR_OK;
 }
 
-HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList,
+HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &incomingTriggerInfoList,
                                               const ServerIdType &serverId)
 {
 	TriggersQueryOption option(USER_ID_SYSTEM);
@@ -1656,12 +1656,12 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 
 	// Pick up triggers to be added
 	TriggerInfoList serverTriggers;
-	for (auto newSvTrigger : svTriggerInfoList) {
-		if (currValidTriggerMap.erase(newSvTrigger.id) >= 1) {
+	for (auto trigger : incomingTriggerInfoList) {
+		if (currValidTriggerMap.erase(trigger.id) >= 1) {
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
-		serverTriggers.push_back(move(newSvTrigger));
+		serverTriggers.push_back(move(trigger));
 	}
 
 	TriggerIdList invalidTriggerIdList;

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1669,9 +1669,12 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 		TriggerInfo invalidTrigger = *invalidTriggerPair.second;
 		invalidTriggerIdList.push_back(invalidTrigger.id);
 	}
+	HatoholError err = HTERR_OK;
 	if (invalidTriggerIdList.size() > 0)
-		return deleteTriggerInfo(invalidTriggerIdList, serverId);
-	return HTERR_OK;
+		err = deleteTriggerInfo(invalidTriggerIdList, serverId);
+	if (serverTriggers.size() > 0)
+		addTriggerInfoList(serverTriggers);
+	return err;
 }
 
 void DBTablesMonitoring::addEventInfo(EventInfo *eventInfo)

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1574,7 +1574,7 @@ void DBTablesMonitoring::updateTrigger(const TriggerInfoList &triggerInfoList,
 	addTriggerInfoList(updateTriggerList);
 }
 
-static string makeIdListCondition(const TriggerIdList &idList)
+static string makeTriggerIdListCondition(const TriggerIdList &idList)
 {
 	string condition;
 	const ColumnDef &colId = COLUMN_DEF_TRIGGERS[IDX_TRIGGERS_ID];
@@ -1591,7 +1591,7 @@ static string makeIdListCondition(const TriggerIdList &idList)
 
 static string makeConditionForDelete(const TriggerIdList &idList)
 {
-	string condition = makeIdListCondition(idList);
+	string condition = makeTriggerIdListCondition(idList);
 
 	return condition;
 }

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1649,15 +1649,15 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &incomingTriggerIn
 
 	const TriggerInfoList currTriggers = move(_currTriggers);
 
-	map<TriggerIdType, const TriggerInfo *> currValidTriggerMap;
+	map<TriggerIdType, const TriggerInfo *> currentTriggerMap;
 	for (auto& trigger : currTriggers) {
-		currValidTriggerMap[trigger.id] = &trigger;
+		currentTriggerMap[trigger.id] = &trigger;
 	}
 
 	// Pick up triggers to be added
 	TriggerInfoList serverTriggers;
 	for (auto trigger : incomingTriggerInfoList) {
-		if (currValidTriggerMap.erase(trigger.id) >= 1) {
+		if (currentTriggerMap.erase(trigger.id) >= 1) {
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
@@ -1666,7 +1666,7 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &incomingTriggerIn
 
 	TriggerIdList invalidTriggerIdList;
 	map<TriggerIdType, const TriggerInfo *> invalidTriggerMap =
-		move(currValidTriggerMap);
+		move(currentTriggerMap);
 	for (auto invalidTriggerPair : invalidTriggerMap) {
 		TriggerInfo invalidTrigger = *invalidTriggerPair.second;
 		invalidTriggerIdList.push_back(invalidTrigger.id);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1662,8 +1662,7 @@ HatoholError DBTablesMonitoring::syncTriggers(TriggerInfoList &svTriggerInfoList
 			// If the hostgroup already exists, we have nothing to do.
 			continue;
 		}
-		// TODO: avoid the copy
-		serverTriggers.push_back(newSvTrigger);
+		serverTriggers.push_back(move(newSvTrigger));
 	}
 
 	TriggerIdList invalidTriggerIdList;

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -135,7 +135,8 @@ public:
 
 	void updateTrigger(const TriggerInfoList &triggerInfoList,
 			   const ServerIdType &serverId);
-	HatoholError deleteTriggerInfo(const TriggerIdList &idList);
+	HatoholError deleteTriggerInfo(const TriggerIdList &idList,
+	                               const ServerIdType &serverId);
 
 	/**
 	 * Get the trigger information with the specified server ID and

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -135,6 +135,7 @@ public:
 
 	void updateTrigger(const TriggerInfoList &triggerInfoList,
 			   const ServerIdType &serverId);
+	HatoholError deleteTriggerInfo(const TriggerIdList &idList);
 
 	/**
 	 * Get the trigger information with the specified server ID and

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -137,6 +137,8 @@ public:
 			   const ServerIdType &serverId);
 	HatoholError deleteTriggerInfo(const TriggerIdList &idList,
 	                               const ServerIdType &serverId);
+	HatoholError syncTriggers(TriggerInfoList &triggerInfoList,
+	                          const ServerIdType &serverId);
 
 	/**
 	 * Get the trigger information with the specified server ID and

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -704,6 +704,35 @@ void test_getHostgroupMembers(void)
 	  makeMapHostsHostgroupsOutput(actualMembers[1], id1));
 }
 
+void test_deleteHostgroupMemberList(void)
+{
+	DECLARE_DBTABLES_HOST(dbHost);
+	HostgroupMemberVect hostgroupMembers;
+	DBAgent &dbAgent = dbHost.getDBAgent();
+	string statement = "SELECT * FROM ";
+	statement += tableProfileHostgroupMember.name;
+	string expect;
+
+	for (size_t i = 0; i < NumTestHostgroupMember; i++) {
+		const HostgroupMember &hostgrpMember = testHostgroupMember[i];
+		hostgroupMembers.push_back(hostgrpMember);
+		expect += makeMapHostsHostgroupsOutput(hostgrpMember, i);
+	}
+	dbHost.upsertHostgroupMembers(hostgroupMembers);
+	assertDBContent(&dbAgent, statement, expect);
+
+	GenericIdList idList = { 3, 5 };
+	dbHost.deleteHostgroupMemberList(idList);
+	for (auto id : idList) {
+		string statementAfterDelete = "SELECT * FROM ";
+		statementAfterDelete += tableProfileHostgroupMember.name;
+		statementAfterDelete +=
+			StringUtils::sprintf("WHERE id = %" FMT_GEN_ID, id);
+		const string expectAfterDelete = "";
+		assertDBContent(&dbAgent, statementAfterDelete, expectAfterDelete);
+	}
+}
+
 void test_getHypervisor(void)
 {
 	loadTestDBVMInfo();

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -742,15 +742,15 @@ void test_syncHostgroupMembers(void)
 	DECLARE_DBTABLES_HOST(dbHost);
 
 	constexpr const ServerIdType targetServerId = 1;
-	const LocalHostIdType targetHostIdInServer = "1129";
-	map<LocalHostIdType, const HostgroupMember *> hostgroupMemberMap;
+	const LocalHostIdType dropTargetHostIdInServer = "1129";
+	map<GenericIdType, const HostgroupMember *> hostgroupMemberMap;
 	for (size_t i = 0; i < NumTestHostgroupMember; i++) {
 		const HostgroupMember &svHostgroupMember = testHostgroupMember[i];
 		if (svHostgroupMember.serverId != targetServerId)
 			continue;
-		if (svHostgroupMember.hostIdInServer == targetHostIdInServer)
+		if (svHostgroupMember.hostIdInServer == dropTargetHostIdInServer)
 			continue;
-		hostgroupMemberMap[svHostgroupMember.hostIdInServer] = &svHostgroupMember;
+		hostgroupMemberMap[i] = &svHostgroupMember;
 	}
 
 	HostgroupMemberVect svHostgroupMembers =
@@ -759,11 +759,18 @@ void test_syncHostgroupMembers(void)
 			2,                               // id
 			1,                               // serverId
 			"235012",                        // hostIdInServer
-			"2",                             // hostgroupIdInServer
+			"1",                             // hostgroupIdInServer
 			10,                              // hostId
 		},
 		{
 			3,                               // id
+			1,                               // serverId
+			"235012",                        // hostIdInServer
+			"2",                             // hostgroupIdInServer
+			10,                              // hostId
+		},
+		{
+			4,                               // id
 			1,                               // serverId
 			"235013",                        // hostIdInServer
 			"2",                             // hostgroupIdInServer

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -429,6 +429,38 @@ void test_addHostgroupList(void)
 	assertDBContent(&dbAgent, statement, expect);
 }
 
+void test_getHostgroups(void)
+{
+	loadTestDBServer();
+	loadTestDBHostgroup();
+
+	DECLARE_DBTABLES_HOST(dbHost);
+	HostgroupVect hostgroups;
+	DBAgent &dbAgent = dbHost.getDBAgent();
+	constexpr const ServerIdType targetServerId = 1;
+	HostgroupsQueryOption option(USER_ID_SYSTEM);
+	option.setTargetServerId(targetServerId);
+	const ColumnDef *colDef = tableProfileHostgroupList.columnDefs;
+	string statement = StringUtils::sprintf(
+	  "select * from %s where %s=%" FMT_SERVER_ID,
+	  tableProfileHostgroupList.name,
+	  colDef[IDX_HOSTGROUP_LIST_SERVER_ID].columnName,
+	  targetServerId);
+	dbHost.getHostgroups(hostgroups, option);
+	cppcut_assert_equal(false, hostgroups.empty());
+
+	string expect;
+	for (size_t i = 0; i < NumTestHostgroup; i++) {
+		const Hostgroup &hostgrp = testHostgroup[i];
+		if (testHostgroup[i].serverId != targetServerId)
+			continue;
+
+		hostgroups.push_back(hostgrp);
+		expect += makeHostgroupsOutput(hostgrp, i);
+	}
+	assertDBContent(&dbAgent, statement, expect);
+}
+
 void test_deleteHostgroupList(void)
 {
 	DECLARE_DBTABLES_HOST(dbHost);

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -429,6 +429,35 @@ void test_addHostgroupList(void)
 	assertDBContent(&dbAgent, statement, expect);
 }
 
+void test_deleteHostgroupList(void)
+{
+	DECLARE_DBTABLES_HOST(dbHost);
+	HostgroupVect hostgroups;
+	DBAgent &dbAgent = dbHost.getDBAgent();
+	string statement = "SELECT * FROM ";
+	statement += tableProfileHostgroupList.name;
+	string expect;
+
+	for (size_t i = 0; i < NumTestHostgroup; i++) {
+		const Hostgroup &hostgrp = testHostgroup[i];
+		hostgroups.push_back(hostgrp);
+		expect += makeHostgroupsOutput(hostgrp, i);
+	}
+	dbHost.upsertHostgroups(hostgroups);
+	assertDBContent(&dbAgent, statement, expect);
+
+	HostgroupIdList idList = { 2, 3 };
+	dbHost.deleteHostgroupList(idList);
+	for (auto id : idList) {
+		string statementAfterDelete = "SELECT * FROM ";
+		statementAfterDelete += tableProfileHostgroupList.name;
+		statementAfterDelete +=
+			StringUtils::sprintf("WHERE id = %" FMT_GEN_ID, id);
+		const string expectAfterDelete = "";
+		assertDBContent(&dbAgent, statementAfterDelete, expectAfterDelete);
+	}
+}
+
 void test_upsertHostgroupListUpdate(void)
 {
 	Hostgroup hostgroup;

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -478,7 +478,7 @@ void test_deleteHostgroupList(void)
 	dbHost.upsertHostgroups(hostgroups);
 	assertDBContent(&dbAgent, statement, expect);
 
-	HostgroupIdList idList = { 2, 3 };
+	GenericIdList idList = { 2, 3 };
 	dbHost.deleteHostgroupList(idList);
 	for (auto id : idList) {
 		string statementAfterDelete = "SELECT * FROM ";

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1292,7 +1292,7 @@ void test_syncHostgroupMembers(void)
 	DECLARE_DBTABLES_HOST(dbHost);
 
 	constexpr const ServerIdType targetServerId = 1;
-	const LocalHostIdType dropTargetHostIdInServer = "1129";
+	const LocalHostIdType dropTargetHostIdInServer = "235012";
 	map<GenericIdType, const HostgroupMember *> hostgroupMemberMap;
 	for (size_t i = 0; i < NumTestHostgroupMember; i++) {
 		const HostgroupMember &svHostgroupMember = testHostgroupMember[i];
@@ -1306,25 +1306,18 @@ void test_syncHostgroupMembers(void)
 	HostgroupMemberVect svHostgroupMembers =
 	{
 		{
-			2,                               // id
-			1,                               // serverId
-			"235012",                        // hostIdInServer
-			"1",                             // hostgroupIdInServer
-			10,                              // hostId
-		},
-		{
 			3,                               // id
-			1,                               // serverId
-			"235012",                        // hostIdInServer
-			"2",                             // hostgroupIdInServer
-			10,                              // hostId
-		},
-		{
-			4,                               // id
 			1,                               // serverId
 			"235013",                        // hostIdInServer
 			"2",                             // hostgroupIdInServer
 			11,                              // hostId
+		},
+		{
+			4,                               // id
+			1,                               // serverId
+			"1129",                          // hostIdInServer
+			"1",                             // hostgroupIdInServer
+			30,                              // hostId
 		},
 	};
 

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -157,7 +157,7 @@ static string makeHostsOutput(const ServerHostDef &svHostDef, const size_t &id)
 static string makeVMInfoOutput(const VMInfo &vmInfo, const size_t &id)
 {
 	string expectedOut = StringUtils::sprintf(
-	  "%" FMT_GEN_ID "|%" FMT_HOST_ID "|%" FMT_HOST_ID "\n",
+	  "%zd|%" FMT_HOST_ID "|%" FMT_HOST_ID "\n",
 	  id + 1, vmInfo.hostId, vmInfo.hypervisorHostId);
 
 	return expectedOut;
@@ -872,7 +872,7 @@ void test_deleteVMInfoList(void)
 	// check existence VMInfo
 	for (size_t i = 0; i < NumTestVMInfo; i++) {
 		const string statement = StringUtils::sprintf(
-			"SELECT * FROM %s WHERE %s = %" FMT_GEN_ID,
+			"SELECT * FROM %s WHERE %s = %zd",
 			tableProfileVMList.name,
 			coldef[IDX_HOST_VM_LIST_ID].columnName,
 			i + 1);

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1236,7 +1236,6 @@ void test_syncHostgroups(void)
 	DECLARE_DBTABLES_HOST(dbHost);
 	constexpr const ServerIdType targetServerId = 1;
 	constexpr const GenericIdType targetHostgroupId = 2;
-	constexpr const GenericIdType remainingHostgroupId = 1;
 
 	map<HostgroupIdType, const Hostgroup *> hostgroupMap;
 	for (size_t i = 0; i < NumTestHostgroup; i++) {
@@ -1252,10 +1251,10 @@ void test_syncHostgroups(void)
 	{
 		{
 			// Set id manually. Because id is auto increment.
-			remainingHostgroupId,
-			testHostgroup[remainingHostgroupId - 1].serverId,
-			testHostgroup[remainingHostgroupId - 1].idInServer,
-			testHostgroup[remainingHostgroupId - 1].name
+			targetHostgroupId,
+			testHostgroup[targetHostgroupId - 1].serverId,
+			testHostgroup[targetHostgroupId - 1].idInServer,
+			testHostgroup[targetHostgroupId - 1].name
 		}
 	};
 

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -774,7 +774,6 @@ void test_syncHostgroupMembers(void)
 	// sanity check if we use the proper data
 	cppcut_assert_equal(false, svHostgroupMembers.empty());
 
-	printf("hostgroupMemberMap.size(): %zd\n", hostgroupMemberMap.size());
 	// Prepare for the expected result.
 	string expect;
 	for (auto hostgroupMemberPair : hostgroupMemberMap) {
@@ -798,7 +797,6 @@ void test_syncHostgroupMembers(void)
 	  coldef[IDX_HOSTGROUP_MEMBER_SERVER_ID].columnName,
 	  targetServerId,
 	  coldef[IDX_HOSTGROUP_MEMBER_SERVER_ID].columnName);
-	printf("statement: %s\n", statement.c_str());
 	assertDBContent(&dbAgent, statement, expect);
 }
 

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1290,7 +1290,6 @@ void test_syncHostgroupsAddNewHostgroup(void)
 	loadTestDBHostgroup();
 	DECLARE_DBTABLES_HOST(dbHost);
 	constexpr const ServerIdType targetServerId = 1;
-	constexpr const GenericIdType targetHostgroupId = 2;
 	Hostgroup newHostgroup = {
 		AUTO_INCREMENT_VALUE, // id
 		1,                    // serverId
@@ -1301,8 +1300,6 @@ void test_syncHostgroupsAddNewHostgroup(void)
 	for (size_t i = 0; i < NumTestHostgroup; i++) {
 		const Hostgroup &svHostgroup = testHostgroup[i];
 		if (svHostgroup.serverId != targetServerId)
-			continue;
-		if (svHostgroup.idInServer != StringUtils::toString(targetHostgroupId))
 			continue;
 		if (svHostgroup.idInServer == newHostgroup.idInServer)
 			cut_fail("We use the wrong test data");

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1360,18 +1360,18 @@ void test_syncHostgroupMembers(void)
 	HostgroupMemberVect svHostgroupMembers =
 	{
 		{
-			3,                               // id
-			1,                               // serverId
-			"235013",                        // hostIdInServer
-			"2",                             // hostgroupIdInServer
-			11,                              // hostId
+			3,                                          // id
+			testHostgroupMember[2].serverId,            // serverId
+			testHostgroupMember[2].hostIdInServer,      // hostIdInServer
+			testHostgroupMember[2].hostgroupIdInServer, // hostgroupIdInServer
+			testHostgroupMember[2].hostId               // hostId
 		},
 		{
-			4,                               // id
-			1,                               // serverId
-			"1129",                          // hostIdInServer
-			"1",                             // hostgroupIdInServer
-			30,                              // hostId
+			4,                                          // id
+			testHostgroupMember[3].serverId,            // serverId
+			testHostgroupMember[3].hostIdInServer,      // hostIdInServer
+			testHostgroupMember[3].hostgroupIdInServer, // hostgroupIdInServer
+			testHostgroupMember[3].hostId               // hostId
 		},
 	};
 

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -497,13 +497,14 @@ void test_syncHostgroups(void)
 	DECLARE_DBTABLES_HOST(dbHost);
 	constexpr const ServerIdType targetServerId = 1;
 	constexpr const GenericIdType targetHostgroupId = 2;
+	constexpr const GenericIdType remainingHostgroupId = 1;
 
 	map<HostgroupIdType, const Hostgroup *> hostgroupMap;
 	for (size_t i = 0; i < NumTestHostgroup; i++) {
 		const Hostgroup &svHostgroup = testHostgroup[i];
 		if (svHostgroup.serverId != targetServerId)
 			continue;
-		if (svHostgroup.idInServer == StringUtils::toString(targetHostgroupId))
+		if (svHostgroup.idInServer != StringUtils::toString(targetHostgroupId))
 			continue;
 		hostgroupMap[svHostgroup.idInServer] = &svHostgroup;
 	}
@@ -512,10 +513,10 @@ void test_syncHostgroups(void)
 	{
 		{
 			// Set id manually. Because id is auto increment.
-			targetHostgroupId,
-			testHostgroup[targetHostgroupId - 1].serverId,
-			testHostgroup[targetHostgroupId - 1].idInServer,
-			testHostgroup[targetHostgroupId - 1].name
+			remainingHostgroupId,
+			testHostgroup[remainingHostgroupId - 1].serverId,
+			testHostgroup[remainingHostgroupId - 1].idInServer,
+			testHostgroup[remainingHostgroupId - 1].name
 		}
 	};
 

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1346,7 +1346,7 @@ void test_syncHostgroupMembers(void)
 	  tableProfileHostgroupMember.name,
 	  coldef[IDX_HOSTGROUP_MEMBER_SERVER_ID].columnName,
 	  targetServerId,
-	  coldef[IDX_HOSTGROUP_MEMBER_SERVER_ID].columnName);
+	  coldef[IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER].columnName);
 	assertDBContent(&dbAgent, statement, expect);
 }
 } // namespace testDBTablesHost

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -356,6 +356,31 @@ void test_addTriggerInfo(void)
 	assertDBContent(&dbMonitoring.getDBAgent(), sql, expectedOut);
 }
 
+void test_deleteTriggerInfo(void)
+{
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	loadTestDBTriggers();
+
+	// check triggerInfo existence
+	string sql = StringUtils::sprintf("SELECT * FROM triggers");
+	string expectedOut;
+	for (size_t i = 0; i < NumTestTriggerInfo; i++)
+		expectedOut += makeTriggerOutput(testTriggerInfo[i]);
+	assertDBContent(&dbMonitoring.getDBAgent(), sql, expectedOut);
+
+	TriggerIdList triggerIdList = { "2", "3" };
+	constexpr ServerIdType targetServerId = 1;
+	dbMonitoring.deleteTriggerInfo(triggerIdList, targetServerId);
+	for (auto triggerId : triggerIdList) {
+		string statement = StringUtils::sprintf("SELECT * FROM triggers");
+		statement += StringUtils::sprintf(
+		  " WHERE trigger_id = %s AND server_id = %" FMT_SERVER_ID,
+		  triggerId.c_str(), targetServerId);
+		string expected = "";
+		assertDBContent(&dbMonitoring.getDBAgent(), statement, expected);
+	}
+}
+
 void test_getTriggerInfo(void)
 {
 	loadTestDBTriggers();

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -398,12 +398,19 @@ void test_syncTriggers(void)
 	constexpr const ServerIdType targetServerId = 1;
 	const TriggerIdType targetTriggerId = "2";
 	constexpr const int testTriggerDataId = 2;
+	const TriggerIdList targetServerTriggerIds = {"1", "2", "3", "4", "5"};
 
-	// check triggerInfo existence
 	string sql = StringUtils::sprintf("SELECT * FROM triggers");
+	sql += StringUtils::sprintf(
+	  " WHERE server_id = %" FMT_SERVER_ID " ORDER BY server_id ASC",
+	  targetServerId);
+
 	string expectedOut;
-	for (size_t i = 0; i < NumTestTriggerInfo; i++)
-		expectedOut += makeTriggerOutput(testTriggerInfo[i]);
+	// check triggerInfo existence
+	for (auto triggerId : targetServerTriggerIds) {
+		int64_t targetId = StringUtils::toUint64(triggerId) - 1;
+		expectedOut += makeTriggerOutput(testTriggerInfo[targetId]);
+	}
 	assertDBContent(&dbMonitoring.getDBAgent(), sql, expectedOut);
 
 	map<TriggerIdType, const TriggerInfo *> triggerMap;

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -370,7 +370,9 @@ void test_deleteTriggerInfo(void)
 
 	TriggerIdList triggerIdList = { "2", "3" };
 	constexpr ServerIdType targetServerId = 1;
-	dbMonitoring.deleteTriggerInfo(triggerIdList, targetServerId);
+	HatoholError err =
+		dbMonitoring.deleteTriggerInfo(triggerIdList, targetServerId);
+	assertHatoholError(HTERR_OK, err);
 	for (auto triggerId : triggerIdList) {
 		string statement = StringUtils::sprintf("SELECT * FROM triggers");
 		statement += StringUtils::sprintf(

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -374,7 +374,7 @@ void test_deleteTriggerInfo(void)
 	for (auto triggerId : triggerIdList) {
 		string statement = StringUtils::sprintf("SELECT * FROM triggers");
 		statement += StringUtils::sprintf(
-		  " WHERE trigger_id = %s AND server_id = %" FMT_SERVER_ID,
+		  " WHERE trigger_id = %" FMT_TRIGGER_ID " AND server_id = %" FMT_SERVER_ID,
 		  triggerId.c_str(), targetServerId);
 		string expected = "";
 		assertDBContent(&dbMonitoring.getDBAgent(), statement, expected);

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -450,6 +450,62 @@ void test_syncTriggers(void)
 	assertDBContent(&dbAgent, statement, expect);
 }
 
+void test_syncTriggersAddNewTrigger(void)
+{
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	loadTestDBTriggers();
+	constexpr const ServerIdType targetServerId = 1;
+
+	TriggerInfo newTriggerInfo = {
+		1,                        // serverId
+		"7",                      // id
+		TRIGGER_STATUS_OK,        // status
+		TRIGGER_SEVERITY_INFO,    // severity
+		{1362958197,0},           // lastChangeTime
+		10,                       // globalHostId,
+		"235013",                 // hostIdInServer,
+		"hostX2",                 // hostName,
+		"TEST New Trigger 1",     // brief,
+		"",                       // extendedInfo
+		TRIGGER_VALID,            // validity
+	};
+
+	for (size_t i = 0; i < NumTestTriggerInfo; i++) {
+		const TriggerInfo &svTriggerInfo = testTriggerInfo[i];
+		if (svTriggerInfo.serverId != targetServerId)
+			continue;
+		if (svTriggerInfo.id == newTriggerInfo.id)
+			cut_fail("We use the wrong test data");
+	}
+
+	string expect;
+	TriggerInfoList svTriggers;
+	{
+		size_t i = 0;
+		for (; i < NumTestTriggerInfo; i++) {
+			const TriggerInfo &svTriggerInfo = testTriggerInfo[i];
+			if (svTriggerInfo.serverId != targetServerId)
+				continue;
+			svTriggers.push_back(svTriggerInfo);
+			expect += makeTriggerOutput(svTriggerInfo);
+		}
+		// sanity check if we use the proper data
+		cppcut_assert_equal(false, svTriggers.empty());
+
+		// Add newTriggerInfo to the expected result
+		svTriggers.push_back(newTriggerInfo);
+		expect += makeTriggerOutput(newTriggerInfo);
+	}
+	HatoholError err = dbMonitoring.syncTriggers(svTriggers, targetServerId);
+	assertHatoholError(HTERR_OK, err);
+	DBAgent &dbAgent = dbMonitoring.getDBAgent();
+	string statement = StringUtils::sprintf(
+	  "select * from triggers"
+	  " where server_id=%" FMT_SERVER_ID " order by id asc;",
+	  targetServerId);
+	assertDBContent(&dbAgent, statement, expect);
+}
+
 void test_getTriggerInfo(void)
 {
 	loadTestDBTriggers();


### PR DESCRIPTION
Because these APIs are requested HAPI2.0 specification: `updateType=ALL`.

## Implemented APIs list

### DBTablesHost

* deleteHostgroupList
* syncHostgroups
* deleteVMInfoList
* deleteHostgroupMemberList
* deleteHostgroupMembers

### DBTablesMonitoring

* deleteTriggerInfo
* syncTriggers

## Not implemented API

* syncVMInfo(syncHostParents)
  - `hostParents` procedure specification is not frozen, still disscussed [here](https://github.com/project-hatohol/HAPI-2.0-Specification/pull/22).
