### PR TITLE
[server][DBTablesMonitoring] Remove DBTablesHost.h include directive

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -31,10 +31,6 @@
 #include "DBClientJoinBuilder.h"
 #include "DBTermCStringProvider.h"
 
-// TODO: remove the follwoing include file after we complete migration of
-// host management with DBTablesHost.
-#include "DBTablesHost.h"
-
 // TODO: rmeove the followin two include files!
 // This class should not be aware of it.
 #include "DBAgentSQLite3.h"


### PR DESCRIPTION
Because new host management migration is already done.