### PR TITLE
[HatoholArmPluginGateHAPI2] Fix a build error in #1260

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -190,12 +190,8 @@ struct HatoholArmPluginGateHAPI2::Impl
 			m_impl.parseExchangeProfileParams(parser, errObj);
 			parser.endObject();
 
-			if (errObj.hasErrors()) {
-				MLPL_WARN("Received an error on parsing "
-					  "exchangeProfile: %s\n",
-					  errorMessage.c_str());
+			if (errObj.hasErrors())
 				return;
-			}
 
 			m_impl.m_hapi2.setEstablished(true);
 		}


### PR DESCRIPTION
MLPL_WARN() in it isn't needed because warning messages are
output on parsing a response of exchangeProfile.