### PR TITLE
Add a basic mechanism for WebUI plugins

### DIFF
--- a/client/static/js.plugins/hap1-ceilometer.js
+++ b/client/static/js.plugins/hap1-ceilometer.js
@@ -1,7 +1,7 @@
 (function(hatohol) {
-  var self = hatohol.addNamespace("hatohol.hap_6");
-  // 6 == hatohol.MONITORING_SYSTEM_CEILOMETER
+  var type = hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER;
+  var self = hatohol.addNamespace("hatohol.hap_" + type);
 
-  self.type = hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER;
+  self.type = type;
   self.label = "Ceilometer";
 }(hatohol));

--- a/client/static/js.plugins/hap1-ceilometer.js
+++ b/client/static/js.plugins/hap1-ceilometer.js
@@ -1,5 +1,7 @@
-(function(global, namespace) {
-  var self = hatohol.addNamespace(namespace);
+(function(hatohol) {
+  var self = hatohol.addNamespace("hatohol.hap_6");
+  // 6 == hatohol.MONITORING_SYSTEM_CEILOMETER
+
   self.type = hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER;
   self.label = "Ceilometer";
-}(this, "hatohol.hap_6")); // 6 == hatohol.MONITORING_SYSTEM_CEILOMETER
+}(hatohol));

--- a/client/static/js.plugins/hap1-ceilometer.js
+++ b/client/static/js.plugins/hap1-ceilometer.js
@@ -1,0 +1,5 @@
+(function(global, namespace) {
+  var self = hatohol.addNamespace(namespace);
+  self.type = hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER;
+  self.label = "Ceilometer";
+}(this, "hatohol.hap_6")); // 6 == hatohol.MONITORING_SYSTEM_CEILOMETER

--- a/client/static/js.plugins/hap1-zabbix.js
+++ b/client/static/js.plugins/hap1-zabbix.js
@@ -1,8 +1,8 @@
 (function(hatohol) {
-  var self = hatohol.addNamespace("hatohol.hap_2");
-  // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX
+  var type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
+  var self = hatohol.addNamespace("hatohol.hap_" + type);
 
-  self.type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
+  self.type = type;
   self.label = "Zabbix (HAPI)";
 
   self.getTopURL = function(server) {

--- a/client/static/js.plugins/hap1-zabbix.js
+++ b/client/static/js.plugins/hap1-zabbix.js
@@ -1,5 +1,6 @@
-(function(global, namespace) {
-    var self = hatohol.addNamespace(namespace);
+(function(hatohol) {
+    var self = hatohol.addNamespace("hatohol.hap_2");
+    // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX
 
     self.type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
     self.label = "Zabbix (HAPI)";
@@ -40,4 +41,4 @@
 	location += "maps.php";
 	return location;
     };
-}(this, "hatohol.hap_2")); // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX
+}(hatohol));

--- a/client/static/js.plugins/hap1-zabbix.js
+++ b/client/static/js.plugins/hap1-zabbix.js
@@ -1,44 +1,44 @@
 (function(hatohol) {
-    var self = hatohol.addNamespace("hatohol.hap_2");
-    // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX
+  var self = hatohol.addNamespace("hatohol.hap_2");
+  // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX
 
-    self.type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
-    self.label = "Zabbix (HAPI)";
+  self.type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
+  self.label = "Zabbix (HAPI)";
 
-    self.getTopURL = function(server) {
-        var ipAddress, port, url;
+  self.getTopURL = function(server) {
+    var ipAddress, port, url;
 
-        if (!server)
-            return undefined;
+    if (!server)
+      return undefined;
 
-        ipAddress = server["ipAddress"];
-        port = server["port"];
-        if (hatohol.isIPv4(ipAddress))
-            url = "http://" + ipAddress;
-        else // maybe IPv6
-            url = "http://[" + ipAddress + "]";
-        if (!isNaN(port) && port != "80")
-            url += ":" + port;
-        url += "/zabbix/";
+    ipAddress = server["ipAddress"];
+    port = server["port"];
+    if (hatohol.isIPv4(ipAddress))
+      url = "http://" + ipAddress;
+    else // maybe IPv6
+      url = "http://[" + ipAddress + "]";
+    if (!isNaN(port) && port != "80")
+      url += ":" + port;
+    url += "/zabbix/";
 
-        return url ? hatohol.escapeHTML(url) : url;
-    };
+    return url ? hatohol.escapeHTML(url) : url;
+  };
 
-    self.getItemGraphURL = function(server, itemId) {
-	var location = self.getTopURL(server);
-	if (!location)
-	    return undefined;
+  self.getItemGraphURL = function(server, itemId) {
+    var location = self.getTopURL(server);
+    if (!location)
+      return undefined;
 
-	location += "history.php?action=showgraph&amp;itemid=" + itemId;
-	return location;
-    };
+    location += "history.php?action=showgraph&amp;itemid=" + itemId;
+    return location;
+  };
 
-    self.getMapsURL = function(server) {
-	var location = self.getTopURL(server);
-	if (!location)
-	    return undefined;
+  self.getMapsURL = function(server) {
+    var location = self.getTopURL(server);
+    if (!location)
+      return undefined;
 
-	location += "maps.php";
-	return location;
-    };
+    location += "maps.php";
+    return location;
+  };
 }(hatohol));

--- a/client/static/js.plugins/hap1-zabbix.js
+++ b/client/static/js.plugins/hap1-zabbix.js
@@ -1,0 +1,43 @@
+(function(global, namespace) {
+    var self = hatohol.addNamespace(namespace);
+
+    self.type = hatohol.MONITORING_SYSTEM_HAPI_ZABBIX;
+    self.label = "Zabbix (HAPI)";
+
+    self.getTopURL = function(server) {
+        var ipAddress, port, url;
+
+        if (!server)
+            return undefined;
+
+        ipAddress = server["ipAddress"];
+        port = server["port"];
+        if (hatohol.isIPv4(ipAddress))
+            url = "http://" + ipAddress;
+        else // maybe IPv6
+            url = "http://[" + ipAddress + "]";
+        if (!isNaN(port) && port != "80")
+            url += ":" + port;
+        url += "/zabbix/";
+
+        return url ? hatohol.escapeHTML(url) : url;
+    };
+
+    self.getItemGraphURL = function(server, itemId) {
+	var location = self.getTopURL(server);
+	if (!location)
+	    return undefined;
+
+	location += "history.php?action=showgraph&amp;itemid=" + itemId;
+	return location;
+    };
+
+    self.getMapsURL = function(server) {
+	var location = self.getTopURL(server);
+	if (!location)
+	    return undefined;
+
+	location += "maps.php";
+	return location;
+    };
+}(this, "hatohol.hap_2")); // 2 == hatohol.MONITORING_SYSTEM_HAPI_ZABBIX

--- a/client/static/js.plugins/hapi-json.js
+++ b/client/static/js.plugins/hapi-json.js
@@ -1,5 +1,7 @@
-(function(global, namespace) {
-  var self = hatohol.addNamespace(namespace);
+(function(hatohol) {
+  var self = hatohol.addNamespace("hatohol.hap_4");
+  // 4 == hatohol.MONITORING_SYSTEM_NAGIOS
+
   self.type = hatohol.MONITORING_SYSTEM_HAPI_JSON;
   self.label = "General Plugin";
-}(this, "hatohol.hap_4")); // 4 == hatohol.MONITORING_SYSTEM_NAGIOS
+}(hatohol));

--- a/client/static/js.plugins/hapi-json.js
+++ b/client/static/js.plugins/hapi-json.js
@@ -1,0 +1,5 @@
+(function(global, namespace) {
+  var self = hatohol.addNamespace(namespace);
+  self.type = hatohol.MONITORING_SYSTEM_HAPI_JSON;
+  self.label = "General Plugin";
+}(this, "hatohol.hap_4")); // 4 == hatohol.MONITORING_SYSTEM_NAGIOS

--- a/client/static/js.plugins/hapi-json.js
+++ b/client/static/js.plugins/hapi-json.js
@@ -1,7 +1,7 @@
 (function(hatohol) {
-  var self = hatohol.addNamespace("hatohol.hap_4");
-  // 4 == hatohol.MONITORING_SYSTEM_NAGIOS
+  var type = hatohol.MONITORING_SYSTEM_HAPI_JSON;
+  var self = hatohol.addNamespace("hatohol.hap_" + type);
 
-  self.type = hatohol.MONITORING_SYSTEM_HAPI_JSON;
+  self.type = type;
   self.label = "General Plugin";
 }(hatohol));

--- a/client/static/js.plugins/nagios.js
+++ b/client/static/js.plugins/nagios.js
@@ -1,5 +1,6 @@
-(function(global, namespace) {
-  var self = hatohol.addNamespace(namespace);
+(function(hatohol) {
+  var self = hatohol.addNamespace("hatohol.hap_1");
+  // 1 == hatohol.MONITORING_SYSTEM_NAGIOS
 
   self.type = hatohol.MONITRING_SYSETEM_NAGIOS;
   self.label = "Nagios";
@@ -18,4 +19,4 @@
     }
     return url ? hatohol.escapeHTML(url) : url;
   };
-}(this, "hatohol.hap_1")); // 1 == hatohol.MONITORING_SYSTEM_NAGIOS
+}(hatohol));

--- a/client/static/js.plugins/nagios.js
+++ b/client/static/js.plugins/nagios.js
@@ -1,0 +1,21 @@
+(function(global, namespace) {
+  var self = hatohol.addNamespace(namespace);
+
+  self.type = hatohol.MONITRING_SYSETEM_NAGIOS;
+  self.label = "Nagios";
+
+  self.getTopURL = function(server) {
+    var url;
+
+    if (!server)
+      return undefined;
+
+    if (server["baseURL"]) {
+      url = server["baseURL"];
+    } else {
+      url = undefined; // issue-839
+
+    }
+    return url ? hatohol.escapeHTML(url) : url;
+  };
+}(this, "hatohol.hap_1")); // 1 == hatohol.MONITORING_SYSTEM_NAGIOS

--- a/client/static/js.plugins/nagios.js
+++ b/client/static/js.plugins/nagios.js
@@ -1,8 +1,8 @@
 (function(hatohol) {
-  var self = hatohol.addNamespace("hatohol.hap_1");
-  // 1 == hatohol.MONITORING_SYSTEM_NAGIOS
+  var type = hatohol.MONITORING_SYSTEM_NAGIOS;
+  var self = hatohol.addNamespace("hatohol.hap_" + type);
 
-  self.type = hatohol.MONITRING_SYSETEM_NAGIOS;
+  self.type = type;
   self.label = "Nagios";
 
   self.getTopURL = function(server) {

--- a/client/static/js.plugins/zabbix.js
+++ b/client/static/js.plugins/zabbix.js
@@ -1,5 +1,6 @@
-(function(global, namespace) {
-  var self = hatohol.addNamespace(namespace);
+(function(hatohol) {
+  var self = hatohol.addNamespace("hatohol.hap_0");
+  // 0 == hatohol.MONITORING_SYSTEM_ZABBIX
 
   self.type = hatohol.MONITRING_SYSETEM_ZABBIX;
   self.label = "Zabbix";
@@ -40,4 +41,4 @@
     location += "maps.php";
     return location;
   };
-}(this, "hatohol.hap_0")); // 0 == hatohol.MONITORING_SYSTEM_ZABBIX
+}(hatohol));

--- a/client/static/js.plugins/zabbix.js
+++ b/client/static/js.plugins/zabbix.js
@@ -1,8 +1,8 @@
 (function(hatohol) {
-  var self = hatohol.addNamespace("hatohol.hap_0");
-  // 0 == hatohol.MONITORING_SYSTEM_ZABBIX
+  var type = hatohol.MONITORING_SYSTEM_ZABBIX;
+  var self = hatohol.addNamespace("hatohol.hap_" + type);
 
-  self.type = hatohol.MONITRING_SYSETEM_ZABBIX;
+  self.type = type;
   self.label = "Zabbix";
 
   self.getTopURL = function(server) {

--- a/client/static/js.plugins/zabbix.js
+++ b/client/static/js.plugins/zabbix.js
@@ -1,0 +1,43 @@
+(function(global, namespace) {
+  var self = hatohol.addNamespace(namespace);
+
+  self.type = hatohol.MONITRING_SYSETEM_ZABBIX;
+  self.label = "Zabbix";
+
+  self.getTopURL = function(server) {
+    var ipAddress, port, url;
+
+    if (!server)
+      return undefined;
+
+    ipAddress = server["ipAddress"];
+    port = server["port"];
+    if (hatohol.isIPv4(ipAddress))
+      url = "http://" + ipAddress;
+    else // maybe IPv6
+      url = "http://[" + ipAddress + "]";
+    if (!isNaN(port) && port != "80")
+      url += ":" + port;
+    url += "/zabbix/";
+
+    return url ? hatohol.escapeHTML(url) : url;
+  };
+
+  self.getItemGraphURL = function(server, itemId) {
+    var location = self.getTopURL(server);
+    if (!location)
+      return undefined;
+
+    location += "history.php?action=showgraph&amp;itemid=" + itemId;
+    return location;
+  };
+
+  self.getMapsURL = function(server) {
+    var location = self.getTopURL(server);
+    if (!location)
+      return undefined;
+
+    location += "maps.php";
+    return location;
+  };
+}(this, "hatohol.hap_0")); // 0 == hatohol.MONITORING_SYSTEM_ZABBIX

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -170,26 +170,6 @@ var ServersView = function(userProfile) {
     hatoholInfoMsgBox("Reloading...");
   }
 
-  function getServerTypeLabel(type) {
-    switch(type) {
-    case hatohol.MONITORING_SYSTEM_ZABBIX:
-      return gettext("Zabbix");
-    case hatohol.MONITORING_SYSTEM_NAGIOS:
-      return gettext("Nagios");
-    case hatohol.MONITORING_SYSTEM_HAPI_ZABBIX:
-      return gettext("Zabbix (HAPI)");
-    case hatohol.MONITORING_SYSTEM_HAPI_NAGIOS:
-      return gettext("Nagios (HAPI)");
-    case hatohol.MONITORING_SYSTEM_HAPI_JSON:
-      return gettext("General Plugin");
-    case hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER:
-      return gettext("Ceilometer");
-    default:
-      break;
-    }
-    return gettext("Unknown");
-  }
-
   function drawTableBody(rd) {
     var x;
     var s;
@@ -216,7 +196,7 @@ var ServersView = function(userProfile) {
              "data-trigger='hover' " +
              "data-container='body' " +
            ">" + escapeHTML(gettext("Checking")) + "</td>";
-      s += "<td>" + getServerTypeLabel(o["type"]) + "</td>";
+      s += "<td>" + makeMonitoringSystemTypeLabel(o["type"]) + "</td>";
       if (serverURL) {
         s += "<td class='server-url-link'><a href='" + serverURL + "' target='_blank'>"
              + escapeHTML(o["hostName"])  + "</a></td>";

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -104,7 +104,7 @@ function isIPv4(ipAddress) {
 function getServerTypeId(server) {
   if (!server)
     return null;
-  if (server.type == 7 /* hatohol.MONITORING_SYSTEM_HAPI2 */)
+  if (server.type == hatohol.MONITORING_SYSTEM_HAPI2)
       return server.uuid;
   return server.type;
 }

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -350,8 +350,8 @@ function formatItemPrevValue(item) {
     var i, here = global;
     for (i = 0; i < spaces.length; i++) {
       if (typeof(here[spaces[i]]) == 'undefined')
-	  here[spaces[i]] = {};
-        here = here[spaces[i]];
+        here[spaces[i]] = {};
+      here = here[spaces[i]];
     }
     return here;
   }

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -348,8 +348,9 @@ function formatItemPrevValue(item) {
   function Namespace(str) {
     var spaces = str.split('.');
     var i, here = global;
-    for (i = 0; i < spaces.length; i++){
-      if (typeof(here[spaces[i]]) == 'undefined') here[spaces[i]] = {};
+    for (i = 0; i < spaces.length; i++) {
+      if (typeof(here[spaces[i]]) == 'undefined')
+	  here[spaces[i]] = {};
         here = here[spaces[i]];
     }
     return here;

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -344,7 +344,7 @@ function formatItemPrevValue(item) {
   return formatItemValue(item["prevValue"], item["unit"]);
 }
 
-(function(global, namespace) {
+(function(global) {
   function Namespace(str) {
     var spaces = str.split('.');
     var i, here = global;
@@ -356,8 +356,8 @@ function formatItemPrevValue(item) {
     return here;
   }
 
-  var hatohol = Namespace(namespace);
+  var hatohol = Namespace("hatohol");
   hatohol.addNamespace = Namespace;
   hatohol.isIPv4 = isIPv4;
   hatohol.escapeHTML = escapeHTML;
-}(this, "hatohol"));
+}(this));

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -114,6 +114,9 @@
     <script src="{{ STATIC_URL }}js/hatohol_pager.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_version.js"></script>
     <script src="{{ STATIC_URL }}js/utils.js"></script>
+    {% for file in plugin_js_files %}
+    <script src="{{ STATIC_URL }}js.plugins/{{ file }}"></script>
+    {% endfor %}
     <script type="text/javascript">
       var userProfile;
       var params = deparam();

--- a/client/viewer/urls.py
+++ b/client/viewer/urls.py
@@ -16,46 +16,46 @@
 # <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import patterns, url
-from django.views.generic import TemplateView
 
 from hatohol import hatohol_def
+from views import HatoholView
 
 urlpatterns = patterns(
     '',
     url(r'^$',
-        TemplateView.as_view(template_name='viewer/dashboard_ajax.html')),
+        HatoholView.as_view(template_name='viewer/dashboard_ajax.html')),
     url(r'^ajax_dashboard$',
-        TemplateView.as_view(
+        HatoholView.as_view(
             template_name='viewer/dashboard_ajax.html')),
     url(r'^ajax_overview_triggers$',
-        TemplateView.as_view(
+        HatoholView.as_view(
             template_name='viewer/overview_triggers_ajax.html')),
     url(r'^ajax_overview_items$',
-        TemplateView.as_view(
+        HatoholView.as_view(
             template_name='viewer/overview_items_ajax.html')),
     url(r'^ajax_latest$',
-        TemplateView.as_view(template_name='viewer/latest_ajax.html')),
+        HatoholView.as_view(template_name='viewer/latest_ajax.html')),
     url(r'^ajax_triggers$',
-        TemplateView.as_view(template_name='viewer/triggers_ajax.html')),
+        HatoholView.as_view(template_name='viewer/triggers_ajax.html')),
     url(r'^ajax_events$',
-        TemplateView.as_view(template_name='viewer/events_ajax.html')),
+        HatoholView.as_view(template_name='viewer/events_ajax.html')),
     url(r'^ajax_servers$',
-        TemplateView.as_view(template_name='viewer/servers_ajax.html'),
+        HatoholView.as_view(template_name='viewer/servers_ajax.html'),
         kwargs={'hatohol': hatohol_def}),
     url(r'^ajax_actions$',
-        TemplateView.as_view(template_name='viewer/actions_ajax.html')),
+        HatoholView.as_view(template_name='viewer/actions_ajax.html')),
     url(r'^ajax_incident_settings$',
-        TemplateView.as_view(
+        HatoholView.as_view(
             template_name='viewer/incident_settings_ajax.html')),
     url(r'^ajax_log_search_systems$',
-        TemplateView.as_view(
+        HatoholView.as_view(
             template_name='viewer/log_search_systems_ajax.html')),
     url(r'^ajax_graphs$',
-        TemplateView.as_view(template_name='viewer/graphs_ajax.html')),
+        HatoholView.as_view(template_name='viewer/graphs_ajax.html')),
     url(r'^ajax_users$',
-        TemplateView.as_view(template_name='viewer/users_ajax.html')),
+        HatoholView.as_view(template_name='viewer/users_ajax.html')),
     url(r'^ajax_hosts$',
-        TemplateView.as_view(template_name='viewer/hosts_ajax.html')),
+        HatoholView.as_view(template_name='viewer/hosts_ajax.html')),
     url(r'^ajax_history$',
-        TemplateView.as_view(template_name='viewer/history_ajax.html')),
+        HatoholView.as_view(template_name='viewer/history_ajax.html')),
 )

--- a/client/viewer/views.py
+++ b/client/viewer/views.py
@@ -1,1 +1,15 @@
 # Create your views here.
+
+import os
+import glob
+from django.views.generic import TemplateView
+
+
+class HatoholView(TemplateView):
+    plugin_js_files = map(os.path.basename,
+                          glob.glob("static/js.plugins/*.js"))
+
+    def get_context_data(self, **kwargs):
+        context = super(HatoholView, self).get_context_data(**kwargs)
+        context.update({'plugin_js_files': self.plugin_js_files})
+        return context

--- a/server/tools/hatohol-def-src-file-generator.cc
+++ b/server/tools/hatohol-def-src-file-generator.cc
@@ -162,6 +162,7 @@ static void makeDefSourceValues(string &s, LanguageType langType)
 	ADD_LINE(s, langType, MONITORING_SYSTEM_HAPI_NAGIOS);
 	ADD_LINE(s, langType, MONITORING_SYSTEM_HAPI_JSON);
 	ADD_LINE(s, langType, MONITORING_SYSTEM_HAPI_CEILOMETER);
+	ADD_LINE(s, langType, MONITORING_SYSTEM_HAPI2);
 	ADD_LINE(s, langType, MONITORING_SYSTEM_UNKNOWN);
 	APPEND(s, "\n");
 


### PR DESCRIPTION
* Plugin files are loaded from /static/js.plugins
* The file names should be {Plugins's UUID}.js
* A plugin must define a new object hatohol.hap_{UUID}
  * Obsolete types (zabbix, nagios, ...) use "type" value instead of UUID
* The plugin implementation should be added to the object.
  * type: UUID
  * label: string
  * getTopURL()
  * getItemGraphURL()
  * getMapsURL()
