### PR TITLE
[client] Avoid using "valueType" in items

### DIFF
--- a/client/static/js/hatohol_graph.js
+++ b/client/static/js/hatohol_graph.js
@@ -94,18 +94,18 @@ HatoholGraph.prototype.draw = function(beginSec, endSec) {
   }
 
   function getYAxesOptions() {
-    var i, item, label, axis, axes = [], table = {}, isInt;
+    var i, item, label, axis, axes = [], table = {}, isInteger;
     for (i = 0; i < self.loaders.length; i++) {
       item = self.loaders[i].getItem();
       label = item ? item.unit : "";
       axis = item ? table[item.unit] : undefined;
-      isInt = item && (item.valueType == hatohol.ITEM_INFO_VALUE_TYPE_INTEGER);
+      isInteger = item && (isInt(item.lastValue));
       if (axis) {
-        if (!isInt)
+        if (!isInteger)
           delete axis.minTickSize;
       } else {
         axis = getYAxisOptions(label);
-        if (isInt)
+        if (isInteger)
           axis.minTickSize = 1;
         if (axes.length % 2 == 1)
           axis.position = "right";

--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -156,11 +156,8 @@ var LatestView = function(userProfile) {
   }
 
   function getGraphLink(item) {
-    if (!item || !item["valueType"] ||
-        (item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_FLOAT &&
-         item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_INTEGER)) {
+    if (!item || !item["lastValue"] || isNaN(item["lastValue"]))
       return "";
-    }
     var link = "<a href='" + getGraphURL(item) + "'>";
     link += gettext("Graph");
     link += "</a>";

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -366,6 +366,16 @@ function formatItemValue(value, unit) {
     return formatMetricPrefix(value, unit);
 };
 
+function isInt(value) {
+  // Caution: It doesn't work correctly against a number like 1.0.
+  return !isNaN(value) && !isFloat(value);
+}
+
+function isFloat(value) {
+  // Caution: It doesn't work correctly against a number like 1.0.
+  return !isNaN(value) && value.toString().indexOf('.') != -1;
+}
+
 function formatItemLastValue(item) {
   if (isNaN(item["lastValue"]))
     return escapeHTML(item["lastValue"]);

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -367,17 +367,13 @@ function formatItemValue(value, unit) {
 };
 
 function formatItemLastValue(item) {
-  if (item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_FLOAT &&
-      item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_INTEGER) {
+  if (isNaN(item["lastValue"]))
     return escapeHTML(item["lastValue"]);
-  }
   return formatItemValue(item["lastValue"], item["unit"]);
 }
 
 function formatItemPrevValue(item) {
-  if (item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_FLOAT &&
-      item["valueType"] != hatohol.ITEM_INFO_VALUE_TYPE_INTEGER) {
-    return escapeHTML(item["lastValue"]);
-  }
+  if (isNaN(item["prevValue"]))
+    return escapeHTML(item["prevValue"]);
   return formatItemValue(item["prevValue"], item["unit"]);
 }

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -1,5 +1,45 @@
 describe('Utils', function() {
 
+describe('isFloat', function() {
+  it('0 (number)', function() {
+    expect(isFloat(0)).to.be(false);
+  });
+
+  it('0.0 (number)', function() {
+    // It's treated as "0".
+    // It's a limitation of JavaScript.
+    expect(isFloat(0.0)).to.be(false);
+  });
+
+  it('0.0 (string)', function() {
+    expect(isFloat("0.0")).to.be(true);
+  });
+
+  it('1 (number)', function() {
+    // It's treated as "1".
+    // It's a limitation of JavaScript.
+    expect(isFloat(1)).to.be(false);
+  });
+
+  it('1.0 (number)', function() {
+    expect(isFloat(1.0)).to.be(false);
+  });
+
+  it('1.0 (string)', function() {
+    expect(isFloat("1.0")).to.be(true);
+  });
+});
+
+describe('isInt', function() {
+  it('1', function() {
+    expect(isInt(1)).to.be(true);
+  });
+
+  it('1.1', function() {
+    expect(isInt(1.1)).to.be(false);
+  });
+});
+
 describe('getServerLocation', function() {
   it('with valid zabbix server', function() {
     var server = {


### PR DESCRIPTION
Because we are going to remove it in HAPI 2.0.
See also https://github.com/project-hatohol/HAPI-2.0-Specification/issues/43

It also fix a bug that an incorrect "prevValue" is shown for a string item.
