### PR TITLE
[HatoholServerEditDialogParameterized] Enable to select HAPI2 server types

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog_parameterized.js
+++ b/client/static/js/hatohol_server_edit_dialog_parameterized.js
@@ -121,6 +121,8 @@ HatoholServerEditDialogParameterized.prototype.createMainElement = function() {
   }
 
   function replyCallback(reply, parser) {
+    var type;
+
     if (!(reply.serverType instanceof Array)) {
       hatoholErrorMsgBox("[Malformed reply] Not found array: serverType");
       return;
@@ -134,7 +136,10 @@ HatoholServerEditDialogParameterized.prototype.createMainElement = function() {
         hatoholErrorMsgBox("[Malformed reply] Not found element: name");
         return;
       }
-      var type = serverTypeInfo.type;
+
+      type = serverTypeInfo.type;
+      if (type == hatohol.MONITORING_SYSTEM_HAPI2)
+	type = serverTypeInfo.uuid;
       if (type == undefined) {
         hatoholErrorMsgBox("[Malformed reply] Not found element: type");
         return;
@@ -154,7 +159,10 @@ HatoholServerEditDialogParameterized.prototype.createMainElement = function() {
 
     if (self.server) {
       var selectElem = $("#selectServerType");
-      selectElem.val(self.server.type);
+      type = self.server.type;
+      if (type == hatohol.MONITORING_SYSTEM_HAPI2)
+	type = self.server.uuid;
+      selectElem.val(type);
       selectElem.change();
     }
   }


### PR DESCRIPTION
Should use "uuid" instead of "type" to distinguish each HAPI2
server type, because the "type" value of HAPI2 server types always
"7" (hatohol.MONITORING_SYSTEM_HAPI2).