### PR TITLE
[HAPI2] Initial support of starting & stopping HAPI2 plugins automatically

### DIFF
--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -410,11 +410,6 @@ HatoholArmPluginInterfaceHAPI2::~HatoholArmPluginInterfaceHAPI2()
 {
 }
 
-void HatoholArmPluginInterfaceHAPI2::stop(void)
-{
-	m_impl->stop();
-}
-
 void HatoholArmPluginInterfaceHAPI2::setArmPluginInfo(
   const ArmPluginInfo &pluginInfo)
 {
@@ -481,6 +476,11 @@ void HatoholArmPluginInterfaceHAPI2::start(void)
 {
 	onSetPluginInitialInfo();
 	m_impl->start();
+}
+
+void HatoholArmPluginInterfaceHAPI2::stop(void)
+{
+	m_impl->stop();
 }
 
 void HatoholArmPluginInterfaceHAPI2::send(const std::string &message)

--- a/server/common/HatoholArmPluginInterfaceHAPI2.h
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.h
@@ -145,6 +145,7 @@ public:
 	void handleResponse(const std::string id, JSONParser &parser);
 
 	virtual void start(void);
+	virtual void stop(void);
 	virtual void send(const std::string &message);
 	virtual void send(const std::string &message,
 			  const int64_t id,
@@ -159,7 +160,6 @@ protected:
 	typedef std::map<HAPI2ProcedureName, ProcedureHandler> ProcedureHandlerMap;
 
 	virtual ~HatoholArmPluginInterfaceHAPI2();
-	void stop(void);
 
 	void setArmPluginInfo(const ArmPluginInfo &pluginInfo);
 	std::mt19937 getRandomEngine(void);

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -323,14 +323,32 @@ struct HatoholArmPluginGateHAPI2::Impl
 		}
 	};
 
+	bool isPluginControlScriptAvailable(void)
+	{
+		if (m_pluginInfo.path.empty())
+			return false;
+		bool executable = g_file_test(m_pluginInfo.path.c_str(),
+					      G_FILE_TEST_IS_EXECUTABLE);
+		if (!executable)
+			MLPL_DBG("The plugin control script isn't executable:"
+				 " %s\n", m_pluginInfo.path.c_str());
+		return executable;
+	}
+
 	bool startPlugin(void)
 	{
-		return runPluginControlScript("start");
+		if (isPluginControlScriptAvailable())
+			return runPluginControlScript("start");
+		else
+			return false;
 	}
 
 	bool stopPlugin(void)
 	{
-		return runPluginControlScript("stop");
+		if (isPluginControlScriptAvailable())
+			return runPluginControlScript("stop");
+		else
+			return false;
 	}
 
 	bool runPluginControlScript(const string command)
@@ -392,13 +410,13 @@ struct HatoholArmPluginGateHAPI2::Impl
 		  m_pluginInfo.staticQueueAddress.c_str()));
 		ChildProcessManager::getInstance()->create(arg);
 		if (!eventCb->succeededInCreation) {
-			MLPL_ERR("Failed to execute: (%d) %s\n",
-				 m_pluginInfo.type, m_pluginInfo.path.c_str());
+			MLPL_ERR("Failed to %s: %s\n",
+				 command.c_str(), m_pluginInfo.path.c_str());
 			return false;
 		}
 
-		MLPL_INFO("Started: plugin (%d) %s\n",
-			  m_pluginInfo.type, m_pluginInfo.path.c_str());
+		MLPL_INFO("Succeeded to %s: %s\n",
+			  command.c_str(), m_pluginInfo.path.c_str());
 
 		return true;
 }

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1635,7 +1635,7 @@ void HatoholArmPluginGateHAPI2::upsertLastInfo(string lastInfoValue, LastInfoTyp
 bool HatoholArmPluginGateHAPI2::launchPluginProcess(
   const ArmPluginInfo &armPluginInfo)
 {
-	const char *ENV_NAME_QUEUE_ADDR = "HAPI_QUEUE_ADDR";
+	const char *ENV_NAME_AMQP_BROKER_URL = "HAPI_AMQP_BROKER_URL";
 	struct EventCb : public ChildProcessManager::EventCallback {
 
 		HatoholArmPluginGateHAPI2 *hapg;
@@ -1680,7 +1680,7 @@ bool HatoholArmPluginGateHAPI2::launchPluginProcess(
 	arg.eventCb = eventCb;
 	arg.envs.push_back(StringUtils::sprintf(
 	  "%s=%s",
-	  ENV_NAME_QUEUE_ADDR,
+	  ENV_NAME_AMQP_BROKER_URL,
 	  armPluginInfo.brokerUrl.c_str()));
 	ChildProcessManager::getInstance()->create(arg);
 	if (!eventCb->succeededInCreation) {

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -330,8 +330,8 @@ struct HatoholArmPluginGateHAPI2::Impl
 		bool executable = g_file_test(m_pluginInfo.path.c_str(),
 					      G_FILE_TEST_IS_EXECUTABLE);
 		if (!executable)
-			MLPL_DBG("The plugin control script isn't executable:"
-				 " %s\n", m_pluginInfo.path.c_str());
+			MLPL_WARN("The plugin control script isn't executable:"
+				  " %s\n", m_pluginInfo.path.c_str());
 		return executable;
 	}
 

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -487,6 +487,13 @@ void HatoholArmPluginGateHAPI2::start(void)
 {
 	HatoholArmPluginInterfaceHAPI2::start();
 	m_impl->start();
+	m_impl->startPlugin();
+}
+
+void HatoholArmPluginGateHAPI2::stop(void)
+{
+	m_impl->stopPlugin();
+	HatoholArmPluginInterfaceHAPI2::stop();
 }
 
 bool HatoholArmPluginGateHAPI2::isEstablished(void)

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1636,6 +1636,7 @@ bool HatoholArmPluginGateHAPI2::launchPluginProcess(
   const ArmPluginInfo &armPluginInfo)
 {
 	const char *ENV_NAME_AMQP_BROKER_URL = "HAPI_AMQP_BROKER_URL";
+	const char *ENV_NAME_AMQP_QUEUE_NAME = "HAPI_AMQP_QUEUE_NAME";
 	struct EventCb : public ChildProcessManager::EventCallback {
 
 		HatoholArmPluginGateHAPI2 *hapg;
@@ -1659,6 +1660,7 @@ bool HatoholArmPluginGateHAPI2::launchPluginProcess(
 	} *eventCb = new EventCb(this);
 
 	ChildProcessManager::CreateArg arg;
+	arg.eventCb = eventCb;
 	arg.args.push_back(armPluginInfo.path);
 	arg.addFlag(G_SPAWN_SEARCH_PATH);
 
@@ -1677,11 +1679,14 @@ bool HatoholArmPluginGateHAPI2::launchPluginProcess(
 		arg.envs.push_back(env);
 	}
 
-	arg.eventCb = eventCb;
 	arg.envs.push_back(StringUtils::sprintf(
 	  "%s=%s",
 	  ENV_NAME_AMQP_BROKER_URL,
 	  armPluginInfo.brokerUrl.c_str()));
+	arg.envs.push_back(StringUtils::sprintf(
+	  "%s=%s",
+	  ENV_NAME_AMQP_QUEUE_NAME,
+	  armPluginInfo.staticQueueAddress.c_str()));
 	ChildProcessManager::getInstance()->create(arg);
 	if (!eventCb->succeededInCreation) {
 		MLPL_ERR("Failed to execute: (%d) %s\n",

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1639,11 +1639,11 @@ bool HatoholArmPluginGateHAPI2::launchPluginProcess(
 	const char *ENV_NAME_AMQP_QUEUE_NAME = "HAPI_AMQP_QUEUE_NAME";
 	struct EventCb : public ChildProcessManager::EventCallback {
 
-		HatoholArmPluginGateHAPI2 *hapg;
+		HatoholArmPluginGateHAPI2 *gate;
 		bool succeededInCreation;
 
-		EventCb(HatoholArmPluginGateHAPI2 *_hapg)
-		: hapg(_hapg),
+		EventCb(HatoholArmPluginGateHAPI2 *_gate)
+		: gate(_gate),
 		  succeededInCreation(false)
 		{
 		}

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -323,7 +323,17 @@ struct HatoholArmPluginGateHAPI2::Impl
 		}
 	};
 
-	bool launchPluginProcess(void)
+	bool startPlugin(void)
+	{
+		return runPluginControlScript("start");
+	}
+
+	bool stopPlugin(void)
+	{
+		return runPluginControlScript("stop");
+	}
+
+	bool runPluginControlScript(const string command)
 	{
 		const char *ENV_NAME_AMQP_BROKER_URL = "HAPI_AMQP_BROKER_URL";
 		const char *ENV_NAME_AMQP_QUEUE_NAME = "HAPI_AMQP_QUEUE_NAME";
@@ -353,6 +363,7 @@ struct HatoholArmPluginGateHAPI2::Impl
 		ChildProcessManager::CreateArg arg;
 		arg.eventCb = eventCb;
 		arg.args.push_back(m_pluginInfo.path);
+		arg.args.push_back(command);
 		arg.addFlag(G_SPAWN_SEARCH_PATH);
 
 		// Envrionment variables passsed to the plugin process

--- a/server/src/HatoholArmPluginGateHAPI2.h
+++ b/server/src/HatoholArmPluginGateHAPI2.h
@@ -62,7 +62,6 @@ public:
 protected:
 	virtual ~HatoholArmPluginGateHAPI2();
 	void upsertLastInfo(std::string lastInfoValue, LastInfoType type);
-	bool launchPluginProcess(const ArmPluginInfo &armPluginInfo);
 
 private:
 	std::string procedureHandlerExchangeProfile(JSONParser &parser);

--- a/server/src/HatoholArmPluginGateHAPI2.h
+++ b/server/src/HatoholArmPluginGateHAPI2.h
@@ -37,6 +37,7 @@ public:
 	  &getMonitoringServerInfo(void) const override;
 	virtual const ArmStatus &getArmStatus(void) const override;
 	virtual void start(void) override;
+	virtual void stop(void) override;
 	bool isEstablished(void);
 
 	virtual bool isFetchItemsSupported(void);

--- a/server/src/HatoholArmPluginGateHAPI2.h
+++ b/server/src/HatoholArmPluginGateHAPI2.h
@@ -62,6 +62,7 @@ public:
 protected:
 	virtual ~HatoholArmPluginGateHAPI2();
 	void upsertLastInfo(std::string lastInfoValue, LastInfoType type);
+	bool launchPluginProcess(const ArmPluginInfo &armPluginInfo);
 
 private:
 	std::string procedureHandlerExchangeProfile(JSONParser &parser);


### PR DESCRIPTION
If armPluginInfo.path isn't empty, execute it with an argument "start" or "stop" when a instance of
HatoholArmPluginGateHAPI2 starts or stops.
