### PR TITLE
Can give the plugin name.

### DIFF
--- a/server/hap2/haplib.py
+++ b/server/hap2/haplib.py
@@ -678,13 +678,17 @@ class BaseMainPlugin(HapiProcessor):
     __COMPONENT_CODE = 0x10
     CB_UPDATE_MONITORING_SERVER_INFO = 1
 
-    def __init__(self, transporter_args):
+    def __init__(self, transporter_args, name=None):
         self.__detect_implemented_procedures()
         self.__sender = Sender(transporter_args)
         self.__rpc_queue = multiprocessing.Queue()
         HapiProcessor.__init__(self, self.__sender, "Main",
                                self.__COMPONENT_CODE)
         self.__callback = Callback()
+        if name is not None:
+            self.__plugin_name = name
+        else:
+            self.__plugin_name = self.__class__.__name__
 
         # launch dispatcher process
         self.__dispatcher = Dispatcher(self.__rpc_queue)
@@ -727,13 +731,13 @@ class BaseMainPlugin(HapiProcessor):
     def get_dispatcher(self):
         return self.__dispatcher
 
+    def get_plugin_name(self):
+        return self.__plugin_name
+
     def exchange_profile(self, response_id=None):
-        name = sys.argv[0]
-        if ".py" == name[-3:len(name)]:
-            name = name[0:-3]
         HapiProcessor.exchange_profile(
             self, self.__implemented_procedures.keys(),
-            response_id=response_id, name=name)
+            response_id=response_id, name=self.__plugin_name)
 
     def hap_exchange_profile(self, params, request_id):
         Utils.optimize_server_procedures(SERVER_PROCEDURES,

--- a/server/hap2/test/TestHaplib.py
+++ b/server/hap2/test/TestHaplib.py
@@ -634,7 +634,18 @@ class Dispatcher(unittest.TestCase):
         common.assertNotRaises(dispatcher)
 
 
+class BaseMainPluginTestee(haplib.BaseMainPlugin):
+    def __init__(self, **kwargs):
+        transporter_args = {"class": transporter.Transporter}
+        haplib.BaseMainPlugin.__init__(self, transporter_args, **kwargs)
+
+    @staticmethod
+    def create(**kwargs):
+        return BaseMainPluginTestee(**kwargs)
+
+
 class BaseMainPlugin(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         transporter_args = {"class": transporter.Transporter}
@@ -678,6 +689,14 @@ class BaseMainPlugin(unittest.TestCase):
     def test_get_dispatcher(self):
         dispatcher = common.returnPrivObj(self.__main_plugin, "__dispatcher")
         self.assertEquals(dispatcher, self.__main_plugin.get_dispatcher())
+
+    def test_plugin_name(self):
+        main = BaseMainPluginTestee.create(name="Love Sweets")
+        self.assertEquals(main.get_plugin_name(), "Love Sweets")
+
+    def test_plugin_name_default(self):
+        main = BaseMainPluginTestee.create()
+        self.assertEquals(main.get_plugin_name(), "BaseMainPluginTestee")
 
     def test_exchange_profile(self):
         self.__main_plugin._HapiProcessor__reply_queue = DummyQueue()


### PR DESCRIPTION
The previous implementation forcely name the plugin from its
file name. This patch enables developers to name it something to like.
If the name is not given, the class name is used by default.