### PR TITLE
[hap2][CommandQueue] Fix an inappropriate timeout value for Queue.get()

### DIFF
--- a/server/hap2/haplib.py
+++ b/server/hap2/haplib.py
@@ -249,7 +249,7 @@ class CommandQueue(Callback):
 
     def pop_all(self):
         while not self.__q.empty():
-            self.__wait(0)
+            self.__wait(None)
 
 
 class MonitoringServerInfo:


### PR DESCRIPTION
The combination of block=True and timeout=0 causes busy loop.
The "timeout" out should be None or a positive value when blocking
process is needed.

https://docs.python.org/2.7/library/queue.html#Queue.Queue.get