### PR TITLE
[DBTablesConfig][RestResourceServer] Fix an issue that can't find an appropriate HAPI2 server type

### DIFF
--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -122,7 +122,8 @@ public:
 	void registerServerType(const ServerTypeInfo &serverType);
 
 	static std::string getDefaultPluginPath(
-	  const MonitoringSystemType &type);
+	  const MonitoringSystemType &type,
+	  const std::string &uuid);
 
 	/**
 	 * Get the registered ServerTypeInfo.
@@ -137,11 +138,13 @@ public:
 	 *
 	 * @param serverTypes The obtained information is stored to this.
 	 * @param type        The monitoring system type.
+	 * @param type        The UUID of the monitoring system type.
 	 * @return
 	 * true if the server type is found. Otherwise false.
 	 */
 	bool getServerType(ServerTypeInfo &serverType,
-	                   const MonitoringSystemType &type);
+			   const MonitoringSystemType &type,
+			   const std::string &uuid);
 
 	HatoholError addTargetServer(
 	  MonitoringServerInfo *monitoringServerInfo,

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -277,7 +277,7 @@ void test_getDefaultPluginPath(gconstpointer data)
 {
 	const string expect = gcut_data_get_string(data, "expect") ? : "";
 	const string actual = DBTablesConfig::getDefaultPluginPath(
-	    (MonitoringSystemType)gcut_data_get_int(data, "type"));
+	    (MonitoringSystemType)gcut_data_get_int(data, "type"), "");
 	cppcut_assert_equal(expect, actual);
 }
 
@@ -300,9 +300,11 @@ void test_getServerType(void)
 	DECLARE_DBTABLES_CONFIG(dbConfig);
 	for (size_t i = 0; i < NumTestServerTypeInfo; i++) {
 		const ServerTypeInfo &expect = testServerTypeInfo[i];
+		if (expect.type == MONITORING_SYSTEM_HAPI2)
+			continue;
 		ServerTypeInfo actual;
 		cppcut_assert_equal(true,
-		   dbConfig.getServerType(actual, expect.type));
+		  dbConfig.getServerType(actual, expect.type, expect.uuid));
 		cppcut_assert_equal(expect.type, actual.type);
 		cppcut_assert_equal(expect.name, actual.name);
 		cppcut_assert_equal(expect.parameters, actual.parameters);
@@ -317,7 +319,7 @@ void test_getServerTypeExpectFalse(void)
 	const MonitoringSystemType type = NUM_MONITORING_SYSTEMS;
 	DECLARE_DBTABLES_CONFIG(dbConfig);
 	ServerTypeInfo actual;
-	cppcut_assert_equal(false, dbConfig.getServerType(actual, type));
+	cppcut_assert_equal(false, dbConfig.getServerType(actual, type, ""));
 }
 
 void test_createTableServers(void)

--- a/server/test/testFaceRestServer.cc
+++ b/server/test/testFaceRestServer.cc
@@ -57,7 +57,8 @@ static void setupArmPluginInfo(
 	armPluginInfo.id = AUTO_INCREMENT_VALUE;
 	armPluginInfo.type = serverInfo.type;
 	armPluginInfo.path =
-	  DBTablesConfig::getDefaultPluginPath(armPluginInfo.type);
+	  DBTablesConfig::getDefaultPluginPath(armPluginInfo.type,
+					       armPluginInfo.uuid);
 	armPluginInfo.brokerUrl = "abc.example.com:22222";
 	armPluginInfo.staticQueueAddress = "";
 	armPluginInfo.serverId = serverInfo.id;


### PR DESCRIPTION
"uuid" is required on searching a HAPI2 server type