### PR TITLE
[test][EventsView] Fix broken tests

### DIFF
--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -193,9 +193,15 @@ describe('EventsView', function() {
     }
   });
 
-  afterEach(function() {
-    restoreAjax();
-    $("#" + TEST_FIXTURE_ID).remove();
+  afterEach(function(done) {
+    setTimeout(function() {
+      // Wait completing stupidsort() in EventsView
+      // TODO: Don't use stupidtable then remove this setTimeout()
+      // (EventsView doesn't use its sort function anymore).
+      restoreAjax();
+      $("#" + TEST_FIXTURE_ID).remove();
+      done();
+    }, 20);
   });
 
   it('new with empty data', function() {


### PR DESCRIPTION
EventsView calls stupidsort() of stupidtable, and it calls
setTimeout(function(){...}, 10) implicitly. It breaks tests of
EvensView.

This modification avoid it by waiting 20 ms.