### PR TITLE
[ReleaseNote] Add description about HAPI2.0

### DIFF
--- a/ReleaseNote
+++ b/ReleaseNote
@@ -1,6 +1,8 @@
 2015-07-10 Masayuki Nakagawa <masayuki.nakagawa@miraclelinux.com> 15.06
 
 	* New Features
+	- [Server] Initial support of Hatohol Arm Plugin Interface 2.0
+	  (https://github.com/project-hatohol/HAPI-2.0-Specification) over AMQP.
 
 	* Bug Fixes
 


### PR DESCRIPTION
一通りPRをチェックしましたが、 @ashie および @cosmo0920 は今回ほぼ HAPI 2.0 のサーバサイド
しかやっていませんので、ひとまずHAPI2.0を実装したことのみ記述しておきます。

実装されていない機能やTODOがいくつかありますが、どこまで書くべきか判断がついていません。

* プラグインの自動起動(今からスクリプト作成着手)
* updateMonitoringServerInfo
* セルフモニタリング
* putHostParentsのupdateType=ALL
* クライアント側procedureコールのタイムアウト処理
* ...
