### PR TITLE
hap2: Improvement the recover mechanism (#1366)

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -482,7 +482,7 @@ class Hap2CeilometerPoller(haplib.BasePoller, Common):
 
 class Hap2CeilometerMain(haplib.BaseMainPlugin, Common):
     def __init__(self, *args, **kwargs):
-        haplib.BaseMainPlugin.__init__(self, kwargs["transporter_args"])
+        haplib.BaseMainPlugin.__init__(self)
         Common.__init__(self)
 
     def hap_fetch_triggers(self, params, request_id):

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -31,7 +31,7 @@ from hatohol import standardhap
 class Hap2FluentdMain(haplib.BaseMainPlugin):
 
     def __init__(self, *args, **kwargs):
-        haplib.BaseMainPlugin.__init__(self, kwargs["transporter_args"])
+        haplib.BaseMainPlugin.__init__(self)
 
         self.__manager = None
         self.__default_host = "UNKNOWN"

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -362,7 +362,7 @@ class Hap2NagiosNDOUtilsPoller(haplib.BasePoller, Common):
 
 class Hap2NagiosNDOUtilsMain(haplib.BaseMainPlugin, Common):
     def __init__(self, *args, **kwargs):
-        haplib.BaseMainPlugin.__init__(self, kwargs["transporter_args"])
+        haplib.BaseMainPlugin.__init__(self)
         Common.__init__(self)
 
     def hap_fetch_triggers(self, params, request_id):

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -44,7 +44,7 @@ class ZabbixAPIConductor:
         self.__previous_hosts_info = PreviousHostsInfo()
         self.__trigger_last_info = None
         self.__component_code = self.get_component_code()
-        self.__sender = self.get_sender()
+
 
     def reset(self):
         self.__api = None
@@ -130,7 +130,6 @@ class Hap2ZabbixAPIPoller(haplib.BasePoller, ZabbixAPIConductor):
     def __init__(self, *args, **kwargs):
         haplib.BasePoller.__init__(self, *args, **kwargs)
         ZabbixAPIConductor.__init__(self)
-        self.__sender = kwargs["sender"]
 
     # @override
     def poll(self):
@@ -142,7 +141,7 @@ class Hap2ZabbixAPIPoller(haplib.BasePoller, ZabbixAPIConductor):
 
 class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
     def __init__(self, *args, **kwargs):
-        haplib.BaseMainPlugin.__init__(self, kwargs["transporter_args"])
+        haplib.BaseMainPlugin.__init__(self)
         ZabbixAPIConductor.__init__(self)
 
     def hap_fetch_items(self, params, request_id):

--- a/server/hap2/hatohol/test/TestHap2Ceilometer.py
+++ b/server/hap2/hatohol/test/TestHap2Ceilometer.py
@@ -751,14 +751,13 @@ class MainPluginForTest(TraceableTestCommon,
                         hap2_ceilometer.Hap2CeilometerMain):
     def __init__(self):
         TraceableTestCommon.__init__(self)
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        hap2_ceilometer.Hap2CeilometerMain.__init__(self, **kwargs)
+        hap2_ceilometer.Hap2CeilometerMain.__init__(self)
+        self.setup({"class": transporter.Transporter})
 
 
 class Hap2CeilometerMain(unittest.TestCase):
     def test_constructor(self):
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        main = hap2_ceilometer.Hap2CeilometerMain(**kwargs)
+        main = hap2_ceilometer.Hap2CeilometerMain()
 
     def test_hap_fetch_triggers(self):
         main = MainPluginForTest()

--- a/server/hap2/hatohol/test/TestHap2Fluentd.py
+++ b/server/hap2/hatohol/test/TestHap2Fluentd.py
@@ -27,8 +27,7 @@ import datetime
 
 class Hap2FluentdMainTestee(hap2_fluentd.Hap2FluentdMain):
     def __init__(self):
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        hap2_fluentd.Hap2FluentdMain.__init__(self, **kwargs)
+        hap2_fluentd.Hap2FluentdMain.__init__(self)
         self.stores = {}
 
     def get_launch_args(self):
@@ -47,8 +46,7 @@ class Hap2FluentdMainTestee(hap2_fluentd.Hap2FluentdMain):
 
 class Hap2FluentdMain(unittest.TestCase):
     def test_constructor(self):
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        main = hap2_fluentd.Hap2FluentdMain(**kwargs)
+        main = hap2_fluentd.Hap2FluentdMain()
 
     def test_set_arguments(self):
         main = Hap2FluentdMainTestee()
@@ -182,7 +180,6 @@ class Hap2Fluentd(unittest.TestCase):
         arg.fluentd_launch = ""
         arg.tag = "^hatohol.*"
         hap.on_parsed_argument(arg)
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        main_plugin = hap.create_main_plugin(**kwargs)
+        main_plugin = hap.create_main_plugin()
         expect_class = hap2_fluentd.Hap2FluentdMain
         self.assertTrue(isinstance(main_plugin, expect_class))

--- a/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
+++ b/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
@@ -309,15 +309,14 @@ class Hap2NagiosNDOUtilsPoller(unittest.TestCase):
 class MainPluginForTest(TraceableTestCommon,
                         hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain):
     def __init__(self):
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain.__init__(self, **kwargs)
+        hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain.__init__(self)
+        self.setup({"class": transporter.Transporter})
         TraceableTestCommon.__init__(self)
 
 
 class Hap2NagiosNDOUtilsMain(unittest.TestCase):
     def test_constructor(self):
-        kwargs = {"transporter_args":{"class": transporter.Transporter}}
-        main = hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain(**kwargs)
+        main = hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain()
 
     def test_hap_fetch_triggers(self):
         main = MainPluginForTest()
@@ -345,8 +344,7 @@ class Hap2NagiosNDOUtilsMain(unittest.TestCase):
 class Hap2NagiosNDOUtils(unittest.TestCase):
     def test_create_main_plugin(self):
         hap = hap2_nagios_ndoutils.Hap2NagiosNDOUtils()
-        kwargs = {"transporter_args": {"class": transporter.Transporter}}
-        main_plugin = hap.create_main_plugin(**kwargs)
+        main_plugin = hap.create_main_plugin()
         expect_class = hap2_nagios_ndoutils.Hap2NagiosNDOUtilsMain
         self.assertTrue(isinstance(main_plugin, expect_class))
 

--- a/server/hap2/hatohol/test/TestHap2ZabbixApi.py
+++ b/server/hap2/hatohol/test/TestHap2ZabbixApi.py
@@ -115,12 +115,13 @@ class ZabbixAPIConductor(unittest.TestCase):
         common.assertNotRaises(self.conductor.update_hosts_and_host_group_membership)
 
 
-class Hap2ZabbixAPIMain(unittest.TestCase, hap2_zabbix_api.Hap2ZabbixAPIMain):
+class Hap2ZabbixAPIMain(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         transporter_args = {"class": transporter.Transporter}
         sender = haplib.Sender(transporter_args)
-        cls.main = hap2_zabbix_api.Hap2ZabbixAPIMain(transporter_args=transporter_args)
+        cls.main = hap2_zabbix_api.Hap2ZabbixAPIMain()
+        cls.main.setup(transporter_args)
 
         cls.main._ZabbixAPIConductor__api =  APIForTest()
         def null_func(self, *args, **kwargs):

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -420,7 +420,7 @@ class HapiProcessor(unittest.TestCase):
         cls.__test_queue = DummyQueue()
         transporter_args = {"class": transporter.Transporter}
         cls.sender = haplib.Sender(transporter_args)
-        cls.processor = haplib.HapiProcessor(cls.sender, "test", 0x01)
+        cls.processor = haplib.HapiProcessor("test", 0x01, cls.sender)
         cls.processor.set_dispatch_queue(cls.__test_queue)
         cls.reply_queue = cls.processor.get_reply_queue()
         cls.connector = ConnectorForTest(cls.reply_queue)
@@ -576,6 +576,34 @@ class HapiProcessor(unittest.TestCase):
         self.assertRaises(Queue.Empty, wait_response, test_id)
 
 
+class ChildProcess(unittest.TestCase):
+
+    class TestChild(haplib.ChildProcess):
+        def __call__(self):
+            pass
+
+    def test_constructor(self):
+        common.assertNotRaises(haplib.ChildProcess)
+
+    def test_get_process_before_deamonize(self):
+        cp = haplib.ChildProcess()
+        self.assertEquals(cp.get_process(), None)
+
+    def test_daemonize(self):
+        cp = ChildProcess.TestChild()
+        cp.daemonize()
+        self.assertNotEquals(cp.get_process(), None)
+
+    def test_terminate_before_daemonize(self):
+        cp = ChildProcess.TestChild()
+        cp.terminate()
+
+    def test_terminate(self):
+        cp = ChildProcess.TestChild()
+        cp.daemonize()
+        cp.terminate()
+
+
 class Receiver(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -671,12 +699,14 @@ class Dispatcher(unittest.TestCase):
 
 class BaseMainPluginTestee(haplib.BaseMainPlugin):
     def __init__(self, **kwargs):
-        transporter_args = {"class": transporter.Transporter}
-        haplib.BaseMainPlugin.__init__(self, transporter_args, **kwargs)
+        haplib.BaseMainPlugin.__init__(self, **kwargs)
 
     @staticmethod
     def create(**kwargs):
-        return BaseMainPluginTestee(**kwargs)
+        transporter_args = {"class": transporter.Transporter}
+        plugin = BaseMainPluginTestee(**kwargs)
+        plugin.setup(transporter_args)
+        return plugin
 
 
 class BaseMainPlugin(unittest.TestCase):
@@ -684,7 +714,8 @@ class BaseMainPlugin(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         transporter_args = {"class": transporter.Transporter}
-        cls.__main_plugin = haplib.BaseMainPlugin(transporter_args)
+        cls.__main_plugin = haplib.BaseMainPlugin()
+        cls.__main_plugin.setup(transporter_args)
 
     def test_hap_update_monitoring_server_info(self):
         test_params = {"serverId": None, "url": None, "nickName": None,


### PR DESCRIPTION
This patch devides constructor into two phases. One is, of course,
__init__() which is called when the object is created. In it,
we just put liens that don't raise exceptions. And setup() is
added as a bottom half of the constructor, which may cause
exceptions. This mechanism makes sure that the object is
certainly created and it enables calling destroy method of
the object if the setup() raises.

With the mechanism, I fixed #1366 by destroying object that
raised an exception.