### PR TITLE
Support trasporter modules in deep path (#1374)

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -923,7 +923,8 @@ class Utils:
     def define_transporter_arguments(parser):
         parser.add_argument("--transporter", type=str,
                             default="RabbitMQHapiConnector")
-        parser.add_argument("--transporter-module", type=str, default="haplib")
+        parser.add_argument("--transporter-module", type=str,
+                            default="hatohol.haplib")
 
         # TODO: Don't specifiy a sub class of transporter directly.
         #       We'd like to implement the mechanism that automatically
@@ -933,8 +934,11 @@ class Utils:
 
     @staticmethod
     def load_transporter(args):
-        (file, pathname, descr) = imp.find_module(args.transporter_module)
-        mod = imp.load_module("", file, pathname, descr)
+        path = None
+        for mod_name in args.transporter_module.split("."):
+            (file, pathname, descr) = imp.find_module(mod_name, path)
+            mod = imp.load_module("", file, pathname, descr)
+            path = mod.__path__
         transporter_class = eval("mod.%s" % args.transporter)
         return transporter_class
 

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -228,7 +228,7 @@ class Utils(unittest.TestCase):
     def test_load_transporter(self):
         test_transport_arguments = namedtuple("transport_argument",
                                               "transporter_module transporter")
-        test_transport_arguments.transporter_module = "haplib"
+        test_transport_arguments.transporter_module = "hatohol.haplib"
         test_transport_arguments.transporter = "RabbitMQHapiConnector"
 
         common.assertNotRaises(haplib.Utils.load_transporter,

--- a/server/hap2/hatohol/test/TestStandardHap.py
+++ b/server/hap2/hatohol/test/TestStandardHap.py
@@ -93,7 +93,7 @@ class TestStandardHap(unittest.TestCase):
         hap = self.StandardHapTestee()
         sys.argv = [sys.argv[0],
                     "--transporter", "EzTransporter",
-                    "--transporter-module", "TestStandardHap"]
+                    "--transporter-module", "test.TestStandardHap"]
         hap()
         exact_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))
         result_ms = hap.get_received_ms_info()


### PR DESCRIPTION
This patch suppors a module name with multiple dots.