### PR TITLE
[client] Fix path of HAPI2 plugins for WebUI

### DIFF
--- a/client/viewer/views.py
+++ b/client/viewer/views.py
@@ -2,12 +2,14 @@
 
 import os
 import glob
+from django.conf import settings
 from django.views.generic import TemplateView
 
 
 class HatoholView(TemplateView):
+    plugin_js_dir = os.path.join(settings.PROJECT_HOME, "static", "js.plugins")
     plugin_js_files = map(os.path.basename,
-                          glob.glob("static/js.plugins/*.js"))
+                          glob.glob(os.path.join(plugin_js_dir, "*.js")))
 
     def get_context_data(self, **kwargs):
         context = super(HatoholView, self).get_context_data(**kwargs)


### PR DESCRIPTION
issue #1373 の問題の修正です。

これで直ると思うのですが、手元の開発環境で何故かApacheで動作させることができておらず、
マシン不調などもあって別途環境を用意するのも時間がかかるので、まだApacheでテストする
ことができていません。

申し訳ありませんが、ひとまずこれでテストしてみて頂けますでしょうか。
もしまだAapacheで問題が解消しないようなら教えて下さい。

前のコードは現在のワーキングディレクトリを考慮せずに相対パスで取ってしまっているので、
どのみちこの修正は入れるべきだと思います。
