### PR TITLE
hap2: Collect child process soon after the termination.

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -636,6 +636,7 @@ class ChildProcess:
         if self.__process is None:
             return
         self.__process.terminate()
+        self.__process.join()
         self.__process = None
         logging.info("terminated: %s", self.__class__.__name__)
 


### PR DESCRIPTION
Without this patch, the children terminated remains as zonbie.