### PR TITLE
[hap2] Set content-type to "application/json"

### DIFF
--- a/server/hap2/hatohol/rabbitmqconnector.py
+++ b/server/hap2/hatohol/rabbitmqconnector.py
@@ -112,7 +112,9 @@ class RabbitMQConnector(Transporter):
 
     def __publish(self, msg):
         self._channel.basic_publish(exchange="", routing_key=self._queue_name,
-                                    body=msg)
+                                    body=msg,
+                                    properties=pika.BasicProperties(
+                                        content_type="application/json"))
 
     @classmethod
     def define_arguments(cls, parser):


### PR DESCRIPTION
`pika.channel.basic_publish` can be set `content-type` with `properties=pika.BasicProperties()`.
In hap2, `content-type` should be set `application/json`.