### PR TITLE
Ceilometer hostname fixup

### DIFF
--- a/client/static/js.plugins/hap2-ceilometer.js
+++ b/client/static/js.plugins/hap2-ceilometer.js
@@ -4,4 +4,9 @@
 
   self.type = uuid;
   self.label = "Ceilometer (HAPI2)";
+  self.getHostName = function(server, hostId) {
+    if (hostId == "N/A")
+        return "N/A"
+    return null
+  }
 }(hatohol));

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -175,7 +175,9 @@ function getHostName(server, hostId) {
   if (server) {
     plugin = getPlugin(server)
     if (plugin && plugin.getHostName)
-        return plugin.getHostName(server, hostId)
+        hostName = plugin.getHostName(server, hostId)
+        if (hostName != null)
+            return hostName
   }
 
   if (!server || !server["hosts"] || !(hostId in server["hosts"]))

--- a/client/test/browser/index.html
+++ b/client/test/browser/index.html
@@ -58,6 +58,7 @@
 <script src="../../static/js.plugins/hap1-ceilometer.js"></script>
 <script src="../../static/js.plugins/hapi-json.js"></script>
 <script src="../../static/js.plugins/hap2-fluentd.js"></script>
+<script src="../../static/js.plugins/hap2-ceilometer.js"></script>
 <script src="test_hatohol_session_manager.js"></script>
 <script src="test_hatohol_connector.js"></script>
 <script src="test_hatohol_reply_parser.js"></script>
@@ -82,6 +83,7 @@
 <script src="test_graphs_view.js"></script>
 <script src="test_triggers_view.js"></script>
 <script src="test_hap2_fluentd.js"></script>
+<script src="test_hap2_ceilometer.js"></script>
 <script>
   $(function(){
     if (window.mochaPhantomJS)

--- a/client/test/browser/test_hap2_ceilometer.js
+++ b/client/test/browser/test_hap2_ceilometer.js
@@ -1,0 +1,14 @@
+describe('hap2_ceilometer', function() {
+  function getPlugin() {
+    return hatohol["hap_aa25a332-d1f7-11e4-80b4-d43d7e3146fb"]
+  }
+
+  it('getHostName: N/A', function() {
+    expect(getPlugin().getHostName("", "N/A")).to.be("N/A")
+  });
+
+  it('getHostName: normal strings', function() {
+    expect(getPlugin().getHostName("", "normal")).to.be(null)
+  });
+});
+

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -417,6 +417,20 @@ describe('getHostName', function() {
     var id = "My ID"
     expect(getHostName(server, id)).to.be("my id");
   });
+
+  it('plugin dependent returns null', function() {
+    var server = {
+      "name": "server",
+      "uuid": "19f28992-c1c1-4eea-87a3-222dc76ad103",
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+    }
+    hatohol["hap_" + server.uuid] = {
+      "getHostName": function(server, hostId) { return null },
+    }
+    var id = "512"
+    var expected = gettext("Unknown") + " (ID: " + id + ")";
+    expect(getHostName(server, id)).to.be(expected);
+  });
 });
 
 describe('getNickName', function() {


### PR DESCRIPTION
When the host ID of the ceilometer's alarm is "N/A", it's shown as Unknown ID.
These patches fixes it.