### PR TITLE
Fix 1384 recovery when amqp broker restart2

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -783,11 +783,13 @@ class BaseMainPlugin(HapiProcessor):
                                    self.__implemented_procedures)
 
     def destroy(self):
-        self.__receiver.terminate()
-        self.__receiver = None
+        if self.__receiver is not None:
+            self.__receiver.terminate()
+            self.__receiver = None
 
-        self.__dispatcher.terminate()
-        self.__dispatcher = None
+        if self.__dispatcher is not None:
+            self.__dispatcher.terminate()
+            self.__dispatcher = None
 
     def register_callback(self, code, arg):
         self.__callback.register(code, arg)

--- a/server/hap2/hatohol/rabbitmqconnector.py
+++ b/server/hap2/hatohol/rabbitmqconnector.py
@@ -20,6 +20,7 @@
 
 import logging
 import pika
+import haplib
 from hatohol.transporter import Transporter
 
 class RabbitMQConnector(Transporter):
@@ -87,7 +88,12 @@ class RabbitMQConnector(Transporter):
 
     def close(self):
         if self.__connection is not None:
-            self.__connection.close()
+            try:
+                self.__connection.close()
+            except:
+                # On some condition such as Ubuntu 14.04, the above close()
+                # raises an exception when the rabbitmq-server is stopped.
+                haplib.handle_exception()
             self.__connection = None
 
     def call(self, msg):


### PR DESCRIPTION
This patch fixed the problem in which HAP2 plugins cannot recover
successfully when AMQP broker is restarted (#1384)