### PR TITLE
15.06 releng/hapi2 improve launching control script 2

### DIFF
--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -36,8 +36,12 @@
 #endif
 
 #ifndef SOUP_VERSION_2_32
+#define soup_uri_get_scheme(uri) (uri->scheme)
 #define soup_uri_get_host(uri) (uri->host)
 #define soup_uri_get_port(uri) (uri->port)
+#define soup_uri_get_user(uri) (uri->user)
+#define soup_uri_get_password(uri) (uri->password)
+#define soup_uri_get_path(uri) (uri->path)
 #endif
 
 #ifndef SOUP_URI_IS_VALID

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -122,6 +122,11 @@ struct HatoholArmPluginGateHAPI2::Impl
 				 serverId);
 			return;
 		}
+		if (m_pluginInfo.staticQueueAddress.empty()) {
+			m_pluginInfo.staticQueueAddress =
+			  StringUtils::sprintf("hap2.%" FMT_SERVER_ID,
+					       m_serverInfo.id);
+		}
 		m_hapi2.setArmPluginInfo(m_pluginInfo);
 	}
 

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -26,6 +26,7 @@
 #include "ArmFake.h"
 #include "ChildProcessManager.h"
 #include <libsoup/soup.h>
+#include <Reaper.h>
 
 using namespace std;
 using namespace mlpl;
@@ -416,8 +417,13 @@ struct HatoholArmPluginGateHAPI2::Impl
 		  m_pluginInfo.staticQueueAddress.c_str()));
 
 		SoupURI *uri = soup_uri_new(m_pluginInfo.brokerUrl.c_str());
+		if (!uri)
+			return;
+		Reaper<SoupURI> uriReaper(uri, soup_uri_free);
+
 		if (!SOUP_URI_IS_VALID(uri))
 			return;
+
 		const char *scheme = soup_uri_get_scheme(uri);
 		if (!scheme || string(scheme) != "amqp")
 			return;

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -364,10 +364,37 @@ struct HatoholArmPluginGateHAPI2::Impl
 			return false;
 	}
 
+	void setChildProcessEnv(ChildProcessManager::CreateArg &arg)
+	{
+		const char *ldlibpath = getenv("LD_LIBRARY_PATH");
+		if (ldlibpath) {
+			arg.envs.push_back(StringUtils::sprintf(
+			  "LD_LIBRARY_PATH=%s",
+			  ldlibpath));
+		}
+
+		const char *loggerLevel = getenv(Logger::LEVEL_ENV_VAR_NAME);
+		if (loggerLevel) {
+			arg.envs.push_back(StringUtils::sprintf(
+			  "%s=%s",
+			  Logger::LEVEL_ENV_VAR_NAME, loggerLevel));
+		}
+
+		arg.envs.push_back(StringUtils::sprintf(
+		  "HAPI_MONITORING_SERVER_ID=%s",
+		  StringUtils::toString(m_pluginInfo.serverId).c_str()));
+
+		arg.envs.push_back(StringUtils::sprintf(
+		  "HAPI_AMQP_BROKER_URL=%s",
+		  m_pluginInfo.brokerUrl.c_str()));
+
+		arg.envs.push_back(StringUtils::sprintf(
+		  "HAPI_AMQP_QUEUE_NAME=%s",
+		  m_pluginInfo.staticQueueAddress.c_str()));
+	}
+
 	bool runPluginControlScript(const string command)
 	{
-		const char *ENV_NAME_AMQP_BROKER_URL = "HAPI_AMQP_BROKER_URL";
-		const char *ENV_NAME_AMQP_QUEUE_NAME = "HAPI_AMQP_QUEUE_NAME";
 		struct EventCb : public ChildProcessManager::EventCallback {
 
 			HatoholArmPluginGateHAPI2 *gate;
@@ -396,31 +423,8 @@ struct HatoholArmPluginGateHAPI2::Impl
 		arg.args.push_back(m_pluginInfo.path);
 		arg.args.push_back(command);
 		arg.addFlag(G_SPAWN_SEARCH_PATH);
+		setChildProcessEnv(arg);
 
-		// Envrionment variables passsed to the plugin process
-		const char *ldlibpath = getenv("LD_LIBRARY_PATH");
-		if (ldlibpath) {
-			string env = "LD_LIBRARY_PATH=";
-			env += ldlibpath;
-			arg.envs.push_back(env);
-		}
-
-		const char *loggerLevel = getenv(Logger::LEVEL_ENV_VAR_NAME);
-		if (loggerLevel) {
-			string env = StringUtils::sprintf(
-			  "%s=%s",
-			  Logger::LEVEL_ENV_VAR_NAME, loggerLevel);
-			arg.envs.push_back(env);
-		}
-
-		arg.envs.push_back(StringUtils::sprintf(
-		  "%s=%s",
-		  ENV_NAME_AMQP_BROKER_URL,
-		  m_pluginInfo.brokerUrl.c_str()));
-		arg.envs.push_back(StringUtils::sprintf(
-		  "%s=%s",
-		  ENV_NAME_AMQP_QUEUE_NAME,
-		  m_pluginInfo.staticQueueAddress.c_str()));
 		ChildProcessManager::getInstance()->create(arg);
 		if (!eventCb->succeededInCreation) {
 			MLPL_ERR("Failed to %s: %s\n",

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -109,6 +109,15 @@ static void addNumberOfAllowedHostgroups(UnifiedDataStore *dataStore,
 	outputJSON.add("numberOfAllowedHostgroups", numberOfAllowedHostgroups);
 }
 
+static bool isPassiveMode(const ArmPluginInfo &info)
+{
+	const string &path = info.path;
+	if (info.type == MONITORING_SYSTEM_HAPI2)
+		return path.empty();
+	else
+		return path == HatoholArmPluginGate::PassivePluginQuasiPath;
+}
+
 static void addServers(FaceRest::ResourceHandler *job, JSONBuilder &agent,
                        const ServerIdType &targetServerId,
                        const bool &showHostgroupInfo,
@@ -155,8 +164,7 @@ static void addServers(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 			                             agent);
 		}
 		if (pluginIt->id != INVALID_ARM_PLUGIN_INFO_ID) {
-			const bool passiveMode =
-			  (pluginIt->path == HatoholArmPluginGate::PassivePluginQuasiPath);
+			const bool passiveMode = isPassiveMode(*pluginIt);
 			if (passiveMode)
 				agent.addTrue("passiveMode");
 			else
@@ -472,7 +480,7 @@ static HatoholError parseServerParameter(
 	bool passiveMode = false;
 	if (value) {
 		passiveMode = (string(value) == "true");
-		if (passiveMode) {
+		if (passiveMode && svInfo.type != MONITORING_SYSTEM_HAPI2) {
 			armPluginInfo.path =
 			  HatoholArmPluginGate::PassivePluginQuasiPath;
 		}


### PR DESCRIPTION
* Pass more convenient environment variables to the plug-in control script
* Run the plug-in control script synchronously (these script shouldn't block long time)
* Complete relative path of plug-in control script
* Handle "passiveMode" parameter from WebUI correctly
* Allow empty queue name (generate it automatically)