### PR TITLE
Don't use non-value dictionary.

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -38,7 +38,7 @@ class Common:
 
     def __init__(self):
         self.close_connection()
-        self.__target_items = {
+        self.__target_items = frozenset((
             "cpu",
             "cpu_util",
             "disk.read.requests",
@@ -49,7 +49,7 @@ class Common:
             "disk.write.requests.rate",
             "disk.write.bytes",
             "disk.write.bytes.rate",
-        }
+        ))
 
     def close_connection(self):
         self.__token = None


### PR DESCRIPTION
Lower version of Python such as 2.6 doesn't support
non-value dictionary. Instead this patch uses frozenset,
which is one of the built-in features of Python. 