### PR TITLE
[hap2] Fix a broken test: TestZabbixApi.TestZabbixApi.test_get_items()

### DIFF
--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -48,7 +48,7 @@ class TestZabbixApi(unittest.TestCase):
         result = self.api.get_items()
         exact = [{"itemId": u"1","hostId": u"1", "brief": u"test_name",
                   "unit": u"B", "itemGroupName": [u"test_name"],
-                  "lastValueTime": "19700101000000.111111111", "lastValue": u"100"}]
+                  "lastValueTime": "19700101000003.111111111", "lastValue": u"100"}]
 
         self.assertEquals(exact, result)
 

--- a/server/hap2/hatohol/test/test_urllib2.py
+++ b/server/hap2/hatohol/test/test_urllib2.py
@@ -27,7 +27,7 @@ RESULTS = {
     "item.get": [{"itemid": "1", "hostid": "1",
         "name": "test_name","units": "B","value_type":"3",
         "applications": [{"applicationid": "test_id", "name": "test_name"}],
-        "lastclock": "0", "lastns":"111111111", "lastvalue": "100"}],
+        "lastclock": "3", "lastns":"111111111", "lastvalue": "100"}],
     "history.get": [{"itemid": "1", "clock": "0", "value": "1", "ns": "111111111"},
                     {"itemid": "1", "clock": "1", "value": "2", "ns": "222222222"}],
     "host.get": [{"hostid": "1", "name":"test_host", "groups":[{"groupid":"1"}]}],


### PR DESCRIPTION
Current items with lastclock=0 are dropped. So we have to choose one
other than 0.