### PR TITLE
[rpm][15.06] Fix packaging failure in CentOS 6

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -1,5 +1,12 @@
 %define is_el6 %(if [ x"%rhel" = x"6" ]; then echo 1; else echo 0; fi)
 %define is_el7 %(if [ x"%rhel" = x"7" ]; then echo 1; else echo 0; fi)
+%define __os_install_post    \
+    %{_rpmconfigdir}/brp-compress \
+    %{!?__debug_package:%{_rpmconfigdir}/brp-strip %{__strip}} \
+    %{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
+    %{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
+    %{_rpmconfigdir}/brp-python-bytecompile \
+%{nil}
 
 Summary: Hatohol
 Name: hatohol

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -195,8 +195,8 @@ install -D -m 644 %{buildroot}/%{_datadir}/hatohol/hatohol.conf %{buildroot}/%{_
 
 rm -f %{buildroot}/%{_libdir}/*.la
 rm -f %{buildroot}/%{_libdir}/*.a
-rm -f %{buildroot}%{python_sitelib}/hatohol-0.0.0-py2.7.egg-info
-rm -f %{buildroot}%{python_sitelib}/hatohol-0.1-py2.7.egg-info
+rm -f %{buildroot}%{python_sitelib}/hatohol-0.0.0-py2.*.egg-info
+rm -f %{buildroot}%{python_sitelib}/hatohol-0.1-py2.*.egg-info
 
 %pre server
 getent group hatohol > /dev/null || groupadd -r hatohol


### PR DESCRIPTION
* Specify `__os_install_post ` value strictly
* Loosen rm *.egg-info target