### PR TITLE
[Ansible] Add CentOS7 playbook

### DIFF
--- a/setup-with-ansible/Vagrantfile
+++ b/setup-with-ansible/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       :id => "centos-6-x86_64",
       :box_url => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box",
     },
+    {
+      :id => "centos-7-x86_64",
+      :box_url => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box",
+    },
   ]
 
   id_prefix = "hatohol"

--- a/setup-with-ansible/centos7.yml
+++ b/setup-with-ansible/centos7.yml
@@ -1,0 +1,120 @@
+---
+  - name: upgrade all packages
+    yum: name=* state=latest
+
+  - name: install git
+    yum: name=git
+
+  - name: install g++
+    yum: name=gcc-c++
+
+  - name: install autoconf and automake
+    yum: name={{ item }}
+    with_items:
+      - autoconf
+      - automake
+
+  - name: install libtool
+    yum: name=libtool
+
+  - name: install gettext-devel
+    yum: name=gettext-devel
+
+  - name: install glib2-devel
+    yum: name=glib2-devel
+
+  - name: install libsoup-devel
+    yum: name=libsoup-devel
+
+  - name: register hatohol repo
+    get_url: url=http://project-hatohol.github.io/repo/hatohol-el7.repo dest=/etc/yum.repos.d/
+
+  - name: install json-glib-devel
+    yum: name=json-glib-devel
+
+  - name: install sqlite-devel
+    yum: name=sqlite-devel
+
+  - name: install libuuid-devel
+    yum: name=libuuid-devel
+
+  - name: install mariadb-devel
+    yum: name=mariadb-devel
+
+#  - name: install ndoutils-nagios3-mysql
+#    yum: name=ndoutils-nagios3-mysql
+
+  - name: register the repository for librabbitmq
+    yum: name=http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+
+  - name: install librabbitmq-devel
+    yum: name=librabbitmq-devel
+
+  - name: install QPid dev packages
+    yum: name={{ item }}
+    with_items:
+      - qpid-cpp-client-devel
+
+#  - name: install qpidd
+#    yum: name=qpidd
+
+  - name: install curl
+    yum: name=curl
+
+  # no cutter repository for CentOS7
+  # - name: register the repository for cutter
+  #   yum: name=http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm
+
+  # - name: install cutter
+  #   yum: name=cutter
+
+  - name: install python-pip
+    yum: name=python-pip
+
+  - name: install python-devel
+    yum: name=python-devel
+
+  - name: install python-argparse
+    yum: name=python-argparse
+
+  - name: install mysql-python
+    yum: name=MySQL-python
+
+#  - name: install npm
+#    yum: name=npm
+
+#  - name: install nodejs-legacy
+#    yum: name=nodejs-legacy
+
+#  - name: install mocha
+#    npm: name=mocha global=yes
+
+#  - name: install expect.js
+#    npm: name=expect.js global=yes
+
+#  - name: install sinon
+#    npm: name=sinon global=yes
+
+#  - name: install mocha-phantomjs
+#    npm: name=mocha-phantomjs global=yes
+
+#  - name: install phantomjs
+#    npm: name=phantomjs global=yes
+
+  - name: install django
+    yum: name=Django
+
+  - name: install python-daemon
+    yum: name=python-daemon
+
+  - name: install python-pika
+    pip: name=pika
+
+  - name: install httpd
+    yum: name=httpd
+
+  - name: install mod_wsgi
+    yum: name=mod_wsgi
+
+  - name: install rpm-build
+    yum: name=rpm-build

--- a/setup-with-ansible/setup-hatohol-dev.yaml
+++ b/setup-with-ansible/setup-hatohol-dev.yaml
@@ -4,4 +4,6 @@
     - include: ubuntu.yml
       when: ansible_distribution == "Ubuntu"
     - include: centos.yml
-      when: ansible_distribution == "CentOS"
+      when: ansible_distribution == "CentOS" and ansible_distribution_version.split('.')[0]|int == 6
+    - include: centos7.yml
+      when: ansible_distribution == "CentOS" and ansible_distribution_version.split('.')[0]|int == 7


### PR DESCRIPTION
This playbook works as follows:

## Requirements

* Vagrant 1.6.5 or later.

Because vagrant 1.6.4 or earlier, following error occurred:

```log
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

ARPCHECK=no /sbin/ifup eth1 2> /dev/null

Stdout from the command:



Stderr from the command:
```

## Launch CentOS 7 box

```bash
$ CPU_NUM=4 MEMORY=4096 vagrant up hatohol-centos-7-x86_64
```

## Building Hatohol rpm

```bash
% vagrant ssh hatohol-centos-7-x86_64
$ git clone https://github.com/project-hatohol/hatohol.git
$ cd hatohol
$ ./autogen.sh
$ ./configure
$ make -j4
$ make dist -j4
$ MAKEFLAGS="-j 4" rpmbuild -tb hatohol-*.tar.bz2
```