### PR TITLE
[HAP2] Modify make rules for python scripts

### DIFF
--- a/server/hap2/Makefile.am
+++ b/server/hap2/Makefile.am
@@ -20,9 +20,20 @@ install-data-hook:
 	if test -n "$(DESTDIR)"; then \
 		PYTHON_SETUP_OPTIONS="--root=$(DESTDIR)"; \
 	fi; \
-	python setup_common.py install $$PYTHON_SETUP_OPTIONS && \
-	python setup_zabbixapi.py install $$PYTHON_SETUP_OPTIONS && \
-	python setup_rabbitmqconnector.py install $$PYTHON_SETUP_OPTIONS
+	if test -n "$(prefix)"; then \
+		PYTHON_SETUP_OPTIONS="$$PYTHON_SETUP_OPTIONS --prefix=$(prefix)"; \
+	fi; \
+	python setup_common.py install \
+	  $$PYTHON_SETUP_OPTIONS --record common-files.txt && \
+	python setup_zabbixapi.py install \
+	  $$PYTHON_SETUP_OPTIONS --record zabbixapi-files.txt && \
+	python setup_rabbitmqconnector.py install \
+	  $$PYTHON_SETUP_OPTIONS --record rabbitmqconnector-files.txt
+
+uninstall-hook:
+	cat common-files.txt | xargs rm -f
+	cat zabbixapi-files.txt | xargs rm -f
+	cat rabbitmqconnector-files.txt | xargs rm -f
 
 nobase_hatohol_hap2_SCRIPTS = \
 	hatohol/hap2_zabbix_api.py \
@@ -36,3 +47,8 @@ EXTRA_DIST = \
 	$(hatohol_hap2_DATA) \
 	$(noinst_SCRIPTS) \
 	$(nobase_hatohol_hap2_SCRIPTS)
+
+CLEANFILES = \
+	common-files.txt \
+	zabbixapi-files.txt \
+	rabbitmqconnector-files.txt


### PR DESCRIPTION
* Add --prefix option for install
* Add uninstall rule

I confirmed following things:

* "make hatoholdistcheck" succeeds
* It can build RPM packages correctly