### PR TITLE
[client][servers_view] Add popover of server info.

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -146,3 +146,8 @@ h2.hatohol-graph {
 .legend table td {
   padding: 2px;
 }
+
+/* Override bootstrap's default value */
+.popover {
+    max-width: 550px;
+}

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -348,12 +348,10 @@ var ServersView = function(userProfile) {
           for (var j = 0; j < paramObj.length; j++) {
             var param = paramObj[j];
             var value;
-            if (!param.label || !param.id || param.hidden)
+            if (!param.label || !param.id || param.hidden || param.inputStyle == "password")
               continue;
             s += gettext(param.label) + ": ";
-            if (param.inputStyle == "password") {
-              s += "******";
-            } else if (param.inputStyle == "checkBox") {
+            if (param.inputStyle == "checkBox") {
               value = server[param.id];
               if (value == true) {
                 s += gettext("True");

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -20,7 +20,9 @@
 var ServersView = function(userProfile) {
   var self = this;
   var serverIds = new Array();
-
+  var paramArray = new Array();
+  var currServersMap = {};
+ 
   // call the constructor of the super class
   HatoholMonitoringView.apply(this, [userProfile]);
 
@@ -216,6 +218,17 @@ var ServersView = function(userProfile) {
       } else {
         s += "<td></td>";
       }
+      s += "<td id='server-info-" + serverId + "'" +
+           "  data-title='" + gettext("Server ID") + ": " + escapeHTML(serverId) + "'" +
+           "  data-html=true" +
+           "  data-trigger='hover'" +
+           "  data-container='body'" +
+           "  data-placement='left'" +
+           "  serverType='" + getServerTypeId(o) + "'" +
+           "  serverId='" + escapeHTML(serverId) + "'" +
+           ">";
+      s += "<i class='glyphicon glyphicon-info-sign'></i>";
+      s += "</td>";
       s += "<td class='edit-server-column' style='display:none;'>";
       s += "<input id='edit-server" + escapeHTML(o["id"]) + "'";
       s += "  type='button' class='btn btn-default'";
@@ -235,6 +248,7 @@ var ServersView = function(userProfile) {
     self.setupCheckboxForDelete($("#update-tirgger-server-button"));
     $(".delete-selector").show();
     setupEditButtons(reply);
+    setupServerInfo(reply);
     self.displayUpdateTime();
     self.startConnection("server-conn-stat", updateServerConnStat);
   }
@@ -275,6 +289,92 @@ var ServersView = function(userProfile) {
       $("#" + idConnStat).html(html);
       options = {content: connStatParser.getInfoHTML()};
       $("#" + idConnStat).popover(options);
+    }
+  }
+
+  function setupServerInfo(reply) {
+    var servers = reply["servers"];
+    for (var i = 0; i < servers.length; ++i) {
+      currServersMap[servers[i]["id"]] = servers[i];
+    }
+    getServerTypesAsync();
+  }
+
+  function getServerTypesAsync() {
+    new HatoholConnector({
+      url: "/server-type",
+      replyCallback: replyCallback,
+    });
+  }
+
+  function replyCallback(reply, parser) {
+    if (!(reply.serverType instanceof Array)) {
+      return;
+    }
+    paramArray = [];
+    for (var i = 0; i < reply.serverType.length; i++) {
+      var serverTypeInfo = reply.serverType[i];
+      var name = serverTypeInfo.name;
+      if (!name) {
+        continue;
+      }
+      var type = serverTypeInfo.type;
+      if (type == hatohol.MONITORING_SYSTEM_HAPI2)
+        type = serverTypeInfo.uuid;
+      if (type == undefined) {
+        continue;
+      }
+      var parameters = serverTypeInfo.parameters;
+      if (parameters == undefined) {
+        continue;
+      }
+      paramArray[type] = parameters;
+    }
+    makeServerInfo();
+  }
+
+  function makeServerInfo() {
+    for (var i = 0; i < serverIds.length; i++) {
+      var id = "#server-info-" + serverIds[i];
+      $(id).popover({
+        content: function() {
+          var serverId = this.getAttribute("serverId");
+          var server = currServersMap[serverId];
+          var serverType = this.getAttribute("serverType");
+          var params = paramArray[serverType];
+          var paramObj = JSON.parse(params);
+          var s = "";
+          s += gettext('Monitoring server type') + ": " + makeMonitoringSystemTypeLabel(server) + "</br>";
+          for (var j = 0; j < paramObj.length; j++) {
+            var param = paramObj[j];
+            var value;
+            if (!param.label || !param.id || param.hidden)
+              continue;
+            s += gettext(param.label) + ": ";
+            if (param.inputStyle == "password") {
+              s += "******";
+            } else if (param.inputStyle == "checkBox") {
+              value = server[param.id];
+              if (value == true) {
+                s += gettext("True");
+              } else {
+                s += gettext("False");
+              }
+            } else {
+              value = server[param.id];
+              if (value) {
+                s += value;
+              } else {
+                if (param.hint) {
+                  s += param.hint;
+                }
+              }
+            }
+            s += "<br>";
+          }
+          return s;
+        }
+      });
     }
   }
 };

--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -218,7 +218,7 @@ var ServersView = function(userProfile) {
       } else {
         s += "<td></td>";
       }
-      s += "<td id='server-info-" + serverId + "'" +
+      s += "<td id='server-info-" + escapeHTML(serverId) + "'" +
            "  data-title='" + gettext("Server ID") + ": " + escapeHTML(serverId) + "'" +
            "  data-html=true" +
            "  data-trigger='hover'" +

--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -69,7 +69,7 @@
         <th>{% trans "IP Address" %}</th>
         <th>{% trans "Nickname" %}</th>
         <th>{% trans "Maps" %}</th>
-	<th class="server-info-column" style="display:none;"></th>
+        <th class="server-info-column" style="display:none;"></th>
         <th class="edit-server-column" style="display:none;"></th>
       </tr>
     </thead>

--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -69,6 +69,7 @@
         <th>{% trans "IP Address" %}</th>
         <th>{% trans "Nickname" %}</th>
         <th>{% trans "Maps" %}</th>
+	<th class="server-info-column" style="display:none;"></th>
         <th class="edit-server-column" style="display:none;"></th>
       </tr>
     </thead>


### PR DESCRIPTION
監視サーバ編集画面を開かなくても、監視サーバの設定を表示できるようにしました。
* マップの右に[info]アイコンを置き、その付近をホバーした時に表示します
* [info]アイコンの位置がウィンドウの右端に近いため、ポップオーバーは左側に出しました
* URLがはみ出るためポップオーバーの最大幅をbootstrapのデフォルトより広げました
* タイトルは通信状態のポップオーバーと同一としました
* パスワード欄も"******"として表示しました
* チェックボックスの状態は "True" / "False" で表示します
* 値が設定されていない要素の場合、ヒントがあればそれを表示するようにしました（設定後の値なので"(empty: Default)"のみのはずです）