### PR TITLE
[travis] Fix install error of mocha-phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - npm install -g mocha
   - npm install -g expect.js
   - npm install -g sinon
-  - npm install -g mocha-phantomjs phantomjs
+  - npm install -g mocha-phantomjs phantomjs@1.9.7-15
   - npm install -g casperjs
   - sudo pip install django==1.5.4
   - sudo pip install mysql-python


### PR DESCRIPTION
It requires an old versio of phantomjs (1.9.1 - 1.9.7-15).

The error log:
5495 error peerinvalid The package phantomjs does not satisfy its siblings' peerDependencies requirements!
5495 error peerinvalid Peer mocha-phantomjs@3.6.0 wants phantomjs@1.9.1 - 1.9.7-15