### PR TITLE
[npm] Use package json to specify JavaScript libraries version strictly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Makefile.in
 /install-sh
 /libtool
 /ltmain.sh
+/node_modules
 /m4/
 /missing
 /client/static/js/hatohol_version.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,7 @@ install:
   - sudo sh -c "printf '[%s]\n%s=%s\n' mysqld character-set-server utf8  > /etc/mysql/conf.d/utf8.cnf"
   - sudo sh -c "printf '[%s]\n%s=%s\n' client default-character-set utf8  >> /etc/mysql/conf.d/utf8.cnf"
   - mysql -u root < data/test/setup.sql
-  - npm install -g mocha
-  - npm install -g expect.js
-  - npm install -g sinon
-  - npm install -g mocha-phantomjs phantomjs@1.9.7-15
-  - npm install -g casperjs
+  - npm install
   - sudo pip install django==1.5.4
   - sudo pip install mysql-python
   - sudo pip install daemon

--- a/client/test/Makefile.am
+++ b/client/test/Makefile.am
@@ -58,7 +58,7 @@ EXTRA_DIST = \
 	python/hatohol_server_emulator.py
 
 node_modules:
-	ln -sf `npm root -g`
+	ln -sf `npm root`
 
 browser/mocha.js:
 	ln -sf ../node_modules/mocha/mocha.js $@

--- a/client/test/feature/run-test.sh
+++ b/client/test/feature/run-test.sh
@@ -3,4 +3,4 @@ export BASE_DIR="`dirname $0`"
 top_dir="$BASE_DIR/../.."
 top_dir="`cd $top_dir; pwd`"
 
-LANG=ja_JP.utf8 LC_ALL=ja_JP.UTF-8 casperjs test $top_dir/test/feature/*_test.js
+LANG=ja_JP.utf8 LC_ALL=ja_JP.UTF-8 $(npm bin)/casperjs test $top_dir/test/feature/*_test.js

--- a/configure.ac
+++ b/configure.ac
@@ -217,11 +217,11 @@ AC_CHECK_PROG([have_mocha], [mocha], [yes], [no])
 AC_CHECK_PROG([have_npm], [npm], [yes], [no])
 have_expect_js=no
 if test "$have_npm" = "yes"; then
-  expect_js_ver=`npm ls -g | grep expect.js | awk '{ print $2 }' FS=@`
+  expect_js_ver=`npm ls | grep expect.js | awk '{ print $2 }' FS=@`
   if test x"$expect_js_ver" != x; then
     have_expect_js=yes
   fi
-  mocha_ver=`npm ls -g | grep mocha | awk '{ print $2 }' FS=@`
+  mocha_ver=`npm ls | grep mocha | awk '{ print $2 }' FS=@`
 fi
 
 if test "$have_mocha" = "no"; then

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hatohol_webui_test",
+  "name": "hatohol_webui",
   "version": "0.0.0",
   "description": "",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "phantomjs": "1.9.7-15",
     "mocha-phantomjs": "~3.6.0",
     "casperjs": "~1.1.0-beta3"
+  },
+  "dependencies": {
+    "npm-check-updates": "~1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hatohol_webui_test",
+  "version": "0.0.0",
+  "description": "",
+  "devDependencies": {
+    "mocha": "~2.2.5",
+    "expect.js": "~0.3.1",
+    "sinon": "~1.15.4",
+    "phantomjs": "1.9.7-15",
+    "mocha-phantomjs": "~3.6.0",
+    "casperjs": "~1.1.0-beta3"
+  }
+}

--- a/test/run-client-test.sh
+++ b/test/run-client-test.sh
@@ -6,5 +6,5 @@ TOP_DIR="$BASE_DIR/.."
 
 ${TOP_DIR}/client/test/python/run-test.sh || FAILED=1
 ${TOP_DIR}/test/launch-hatohol-for-test.sh || exit 1
-mocha-phantomjs http://localhost:8000/test/index.html || FAILED=1
+$(npm bin)/mocha-phantomjs http://localhost:8000/test/index.html || FAILED=1
 exit $FAILED


### PR DESCRIPTION
To prevent such issue: https://github.com/project-hatohol/hatohol/pull/1477

If we want to use latest dependent JavaScript libraries forcedly, this pull request should be rejected.