### PR TITLE
[EventsView] Filter events by EventType instead of TriggerStatus

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -121,7 +121,7 @@ var EventsView = function(userProfile, baseElem) {
       "serverId", "hostgroupId", "hostId",
       "limit", "offset", "limitOfUnifiedId",
       "sortType", "sortOrder",
-      "minimumSeverity", "status", "triggerId",
+      "type", "minimumSeverity", "status", "triggerId",
     ];
     var i, allParams = deparam(), query = {};
     for (i = 0; i < knownKeys.length; i++) {
@@ -141,7 +141,7 @@ var EventsView = function(userProfile, baseElem) {
 
     var query = $.extend({}, self.baseQuery, {
       minimumSeverity:  $("#select-severity").val(),
-      status:           $("#select-status").val(),
+      type:             $("#select-status").val(),
       offset:           self.baseQuery.limit * self.currentPage,
       limitOfUnifiedId: self.limitOfUnifiedId,
     });

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -104,6 +104,7 @@ typedef TriggerIdInfoMap::const_iterator       TriggerIdInfoMapConstIterator;
 typedef std::list<TriggerIdType> TriggerIdList;
 
 enum EventType {
+	EVENT_TYPE_ALL = -1,
 	EVENT_TYPE_GOOD,
 	EVENT_TYPE_BAD,
 	EVENT_TYPE_UNKNOWN,

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -826,6 +826,7 @@ struct EventsQueryOption::Impl {
 	uint64_t limitOfUnifiedId;
 	SortType sortType;
 	SortDirection sortDirection;
+	EventType type;
 	TriggerSeverityType minSeverity;
 	TriggerStatusType triggerStatus;
 	TriggerIdType triggerId;
@@ -834,6 +835,7 @@ struct EventsQueryOption::Impl {
 	: limitOfUnifiedId(NO_LIMIT),
 	  sortType(SORT_UNIFIED_ID),
 	  sortDirection(SORT_DONT_CARE),
+	  type(EVENT_TYPE_ALL),
 	  minSeverity(TRIGGER_SEVERITY_UNKNOWN),
 	  triggerStatus(TRIGGER_STATUS_ALL),
 	  triggerId(ALL_TRIGGERS)
@@ -878,6 +880,15 @@ string EventsQueryOption::getCondition(void) const
 			"%s<=%" PRIu64,
 			getColumnName(IDX_EVENTS_UNIFIED_ID).c_str(),
 			m_impl->limitOfUnifiedId);
+	}
+
+	if (m_impl->type != EVENT_TYPE_ALL) {
+		if (!condition.empty())
+			condition += " AND ";
+		condition += StringUtils::sprintf(
+			"%s=%d",
+			getColumnName(IDX_EVENTS_EVENT_TYPE).c_str(),
+			m_impl->type);
 	}
 
 	if (m_impl->minSeverity != TRIGGER_SEVERITY_UNKNOWN) {
@@ -981,6 +992,16 @@ void EventsQueryOption::setMinimumSeverity(const TriggerSeverityType &severity)
 TriggerSeverityType EventsQueryOption::getMinimumSeverity(void) const
 {
 	return m_impl->minSeverity;
+}
+
+void EventsQueryOption::setType(const EventType &type)
+{
+	m_impl->type = type;
+}
+
+EventType EventsQueryOption::getType(void) const
+{
+	return m_impl->type;
 }
 
 void EventsQueryOption::setTriggerStatus(const TriggerStatusType &status)

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -52,6 +52,8 @@ public:
 	SortType getSortType(void) const;
 	SortDirection getSortDirection(void) const;
 
+	void setType(const EventType &type);
+	EventType getType(void) const;
 	void setMinimumSeverity(const TriggerSeverityType &severity);
 	TriggerSeverityType getMinimumSeverity(void) const;
 	void setTriggerStatus(const TriggerStatusType &status);

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -214,6 +214,14 @@ HatoholError RestResourceHost::parseEventParameter(EventsQueryOption &option,
 	if (err != HTERR_OK && err != HTERR_NOT_FOUND_PARAMETER)
 		return err;
 
+	// event type
+	EventType type = EVENT_TYPE_ALL;
+	err = getParam<EventType>(query, "type",
+				  "%d", type);
+	if (err != HTERR_OK && err != HTERR_NOT_FOUND_PARAMETER)
+		return err;
+	option.setType(type);
+
 	// minimum severity
 	TriggerSeverityType severity = TRIGGER_SEVERITY_UNKNOWN;
 	err = getParam<TriggerSeverityType>(query, "minimumSeverity",

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1296,6 +1296,18 @@ void test_getEventWithInvalidUserId(gconstpointer data)
 	assertGetEventsWithFilter(arg);
 }
 
+void data_getEventWithEventType(void)
+{
+	prepareTestDataForFilterForDataOfDefunctServers();
+}
+
+void test_getEventWithEventType(gconstpointer data)
+{
+	AssertGetEventsArg arg(data);
+	arg.type = EVENT_TYPE_BAD;
+	assertGetEventsWithFilter(arg);
+}
+
 void data_getEventWithMinSeverity(void)
 {
 	prepareTestDataForFilterForDataOfDefunctServers();

--- a/server/test/testDBTablesMonitoring.h
+++ b/server/test/testDBTablesMonitoring.h
@@ -187,6 +187,7 @@ struct AssertGetEventsArg
 {
 	uint64_t limitOfUnifiedId;
 	EventsQueryOption::SortType sortType;
+	EventType type;
 	TriggerSeverityType minSeverity;
 	TriggerStatusType triggerStatus;
 	TriggerIdType triggerId;
@@ -199,6 +200,7 @@ struct AssertGetEventsArg
 		    const EventInfo *eventInfo = testEventInfo,
 		    size_t numEventInfo = NumTestEventInfo)
 	: limitOfUnifiedId(0), sortType(EventsQueryOption::SORT_UNIFIED_ID),
+	  type(EVENT_TYPE_ALL),
 	  minSeverity(TRIGGER_SEVERITY_UNKNOWN),
 	  triggerStatus(TRIGGER_STATUS_ALL),
 	  triggerId(ALL_TRIGGERS),
@@ -230,6 +232,7 @@ struct AssertGetEventsArg
 		if (limitOfUnifiedId)
 			option.setLimitOfUnifiedId(limitOfUnifiedId);
 		option.setSortType(sortType, sortDirection);
+		option.setType(type);
 		option.setMinimumSeverity(minSeverity);
 		option.setTriggerStatus(triggerStatus);
 		option.setTriggerId(triggerId);
@@ -242,6 +245,9 @@ struct AssertGetEventsArg
 			return true;
 		}
 		if (limitOfUnifiedId && idMap[info] > limitOfUnifiedId)
+			return true;
+
+		if (type != EVENT_TYPE_ALL && info->type != type)
 			return true;
 
 		// TODO: Use TriggerInfo instead of EventInfo because actual

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -358,6 +358,37 @@ void test_eventQueryOptionWithSortTypeTime(void)
 	cppcut_assert_equal(expected, option.getOrderBy());
 }
 
+void data_eventQueryOptionDefaultEventType(void)
+{
+	prepareTestDataForFilterForDataOfDefunctServers();
+}
+
+void test_eventQueryOptionDefaultEentType(gconstpointer data)
+{
+	EventsQueryOption option(USER_ID_SYSTEM);
+	string expected =  "";
+	fixupForFilteringDefunctServer(data, expected, option);
+	cppcut_assert_equal(EVENT_TYPE_ALL,
+			    option.getType());
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
+void data_eventQueryOptionWithEventType(void)
+{
+	prepareTestDataForFilterForDataOfDefunctServers();
+}
+
+void test_eventQueryOptionWithEventType(gconstpointer data)
+{
+	EventsQueryOption option(USER_ID_SYSTEM);
+	option.setType(EVENT_TYPE_BAD);
+	string expected = "event_value=1";
+	fixupForFilteringDefunctServer(data, expected, option);
+	cppcut_assert_equal(EVENT_TYPE_BAD,
+			    option.getType());
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
 void test_eventQueryOptionDefaultMinimumSeverity(gconstpointer data)
 {
 	EventsQueryOption option(USER_ID_SYSTEM);


### PR DESCRIPTION
EventType should be used to filter events instead of TriggerStatus because the "Status" column
of EventsView uses EventType, not TriggerStatus.

Issue #1491