### PR TITLE
[hatohol.spec] Add "--with-qpid" to configure script

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -178,7 +178,7 @@ Header files for the Hatohol library.
 %setup -q -n %{name}-%{version}
 
 %build
-%configure
+%configure --with-qpid
 make
 
 %install


### PR DESCRIPTION
It's disabled by default, but the RPM package still includes
hatohol-arm-plugin-zabbix which depends on qpid.