### PR TITLE
[client] Remove getServerName()

### DIFF
--- a/client/static/js/hatohol_graph.js
+++ b/client/static/js/hatohol_graph.js
@@ -243,7 +243,7 @@ HatoholGraph.prototype._updateTitleAndLegendLabels = function() {
     if (!item || !servers)
       return gettext("Unknown host");
     var server = servers[item.serverId];
-    var serverName = getServerName(server, item["serverId"]);
+    var serverName = getNickName(server, item["serverId"]);
     var hostName   = getHostName(server, item["hostId"]);
     return serverName + ": " + hostName;
   }

--- a/client/static/js/incident_settings_view.js
+++ b/client/static/js/incident_settings_view.js
@@ -130,11 +130,11 @@ var IncidentSettingsView = function(userProfile) {
   //
   // parser of received json data
   //
-  function getServerNameFromAction(actionsPkt, actionDef) {
+  function getNickNameFromAction(actionsPkt, actionDef) {
     var serverId = actionDef["serverId"];
     if (!serverId)
       return "ANY";
-    return getServerName(actionsPkt["servers"][serverId], serverId);
+    return getNickName(actionsPkt["servers"][serverId], serverId);
   }
 
   function getHostgroupNameFromAction(actionsPkt, actionDef) {
@@ -161,7 +161,7 @@ var IncidentSettingsView = function(userProfile) {
         "actionId='" + escapeHTML(actionDef.actionId) + "'></td>";
       s += "<td>" + escapeHTML(actionDef.actionId) + "</td>";
 
-      var serverName = getServerNameFromAction(actionsPkt, actionDef);
+      var serverName = getNickNameFromAction(actionsPkt, actionDef);
       s += "<td>" + escapeHTML(serverName) + "</td>";
 
       var hostgroupName = getHostgroupNameFromAction(actionsPkt, actionDef);

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -149,12 +149,6 @@ function getServerName(server, serverId) {
   return server["name"];
 }
 
-function getNickName(server, serverId) {
-  if (!server || !server["nickname"])
-    return gettext("Unknown") + " (ID: " + serverId + ")";
-  return server["nickname"];
-}
-
 function getHostgroupName(server, hostgroupId) {
   var getNamelessHostgroupName = function(hostgroupId) {
     return gettext("Unknown") + " (ID: " + hostgroupId + ")";

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -358,26 +358,6 @@ describe('makeMonitoringSystemTypeLabel', function() {
   });
 });
 
-describe('getServerName', function() {
-  it('with valid name', function() {
-    var server = { "name": "server" };
-    var serverId = 2;
-    expect(getServerName(server, serverId)).to.be("server");
-  });
-
-  it('with no server', function() {
-    var serverId = 2;
-    var expected = gettext("Unknown") + " (ID: " + serverId + ")";
-    expect(getServerName(undefined, serverId)).to.be(expected);
-  });
-
-  it('with no name', function() {
-    var serverId = 2;
-    var expected = gettext("Unknown") + " (ID: " + serverId + ")";
-    expect(getServerName({}, serverId)).to.be(expected);
-  });
-});
-
 describe('getHostName', function() {
   it('with valid name', function() {
     var server = {


### PR DESCRIPTION
It won't be used anymore.
Use getNickName() instead.

issue #1499