### PR TITLE
[HatoholArmPluginGateHAPI2] Implement time-out feature for calling plugin's methods

### DIFF
--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -409,13 +409,13 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 
 		AutoMutex lock(&m_procedureMapMutex);
 
-		auto timeoutIt = m_procedureCallContextMap.find(id);
-		if (timeoutIt != m_procedureCallContextMap.end()) {
-			ProcedureCallContext *context = timeoutIt->second;
+		auto it = m_procedureCallContextMap.find(id);
+		if (it != m_procedureCallContextMap.end()) {
+			ProcedureCallContext *context = it->second;
 			if (context->m_callback.hasData())
 				context->m_callback->onGotResponse(parser);
 			g_source_remove(context->m_timeoutId);
-			m_procedureCallContextMap.erase(timeoutIt);
+			m_procedureCallContextMap.erase(it);
 			delete context;
 			found = true;
 		}

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -398,7 +398,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		context->m_procedureId = id;
 		context->m_timeoutId =
 		  Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,
-				      _onProcedureCallContext,
+				      onProcedureCallContext,
 				      context);
 		m_procedureCallContextMap[id] = context;
 	}
@@ -421,7 +421,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		return false;
 	}
 
-	static gboolean _onProcedureCallContext(gpointer data)
+	static gboolean onProcedureCallContext(gpointer data)
 	{
 		ProcedureCallContext *context =
 		  static_cast<ProcedureCallContext *>(data);

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -302,7 +302,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	map<string, ProcedureCallContextPtr> m_procedureCallContextMap;
 	AMQPConnectionInfo m_connectionInfo;
 	AMQPConsumer *m_consumer;
-	AMQPHAPI2MessageHandler *m_handler;
+	AMQPHAPI2MessageHandler m_handler;
 
 	Impl(HatoholArmPluginInterfaceHAPI2 &hapi2,
 	     const CommunicationMode mode)
@@ -310,7 +310,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	  m_hapi2(hapi2),
 	  m_established(false),
 	  m_consumer(NULL),
-	  m_handler(NULL)
+	  m_handler(m_hapi2)
 	{
 	}
 
@@ -362,8 +362,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	{
 		setupAMQPConnectionInfo();
 
-		m_handler = new AMQPHAPI2MessageHandler(m_hapi2);
-		m_consumer = new AMQPConsumer(m_connectionInfo, m_handler);
+		m_consumer = new AMQPConsumer(m_connectionInfo, &m_handler);
 	}
 
 	string generateQueueName(const ArmPluginInfo &pluginInfo)
@@ -448,8 +447,6 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 			delete m_consumer;
 			m_consumer = nullptr;
 		}
-		delete m_handler;
-		m_handler = nullptr;
 	}
 
 	void onConnect(void)

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -387,7 +387,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	void queueProcedureCallback(const string id,
 				    ProcedureCallbackPtr callback)
 	{
-		const int PROCEDURE_TIMEOUT_MSEC = 60 * 1000;
+		constexpr int PROCEDURE_TIMEOUT_MSEC = 60 * 1000;
 
 		lock_guard<mutex> lock(m_procedureMapMutex);
 

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -398,9 +398,10 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		ProcedureTimeout *timeout = new ProcedureTimeout();
 		timeout->m_impl = this;
 		timeout->m_procedureId = id;
-		timeout->m_timeoutId = Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,
-							   _onProcedureTimeout,
-							   timeout);
+		timeout->m_timeoutId =
+		  Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,
+				      _onProcedureTimeout,
+				      timeout);
 		m_procedureTimeoutMap[id] = timeout;
 	}
 

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -400,7 +400,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		timeout->m_procedureId = id;
 		timeout->m_timeoutId = Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,
 							   _onProcedureTimeout,
-							   callback);
+							   timeout);
 		m_procedureTimeoutMap[id] = timeout;
 	}
 

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -394,7 +394,6 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		ProcedureCallContext *context = new ProcedureCallContext();
 		context->m_impl = this;
 		context->m_callback = callback;
-		Impl *m_impl;
 		context->m_procedureId = id;
 		context->m_timeoutId =
 		  Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -405,8 +405,6 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 
 	bool runProcedureCallback(const string id, JSONParser &parser)
 	{
-		bool found = false;
-
 		lock_guard<mutex> lock(m_procedureMapMutex);
 
 		auto it = m_procedureCallContextMap.find(id);
@@ -417,10 +415,10 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 			g_source_remove(context->m_timeoutId);
 			m_procedureCallContextMap.erase(it);
 			delete context;
-			found = true;
+			return true;
 		}
 
-		return found;
+		return false;
 	}
 
 	static gboolean _onProcedureCallContext(gpointer data)

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -286,10 +286,10 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 {
 	struct ProcedureCallContext
 	{
-		ProcedureCallbackPtr m_callback;
 		Impl *m_impl;
+		ProcedureCallbackPtr m_callback;
 		string m_procedureId;
-		int m_timeoutId;
+		guint m_timeoutId;
 	};
 	typedef unique_ptr<ProcedureCallContext> ProcedureCallContextPtr;
 
@@ -392,8 +392,9 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		lock_guard<mutex> lock(m_procedureMapMutex);
 
 		ProcedureCallContext *context = new ProcedureCallContext();
-		context->m_callback = callback;
 		context->m_impl = this;
+		context->m_callback = callback;
+		Impl *m_impl;
 		context->m_procedureId = id;
 		context->m_timeoutId =
 		  Utils::setGLibTimer(PROCEDURE_TIMEOUT_MSEC,

--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -23,7 +23,7 @@
 #include "AMQPPublisher.h"
 #include "HatoholArmPluginInterfaceHAPI2.h"
 #include "JSONBuilder.h"
-#include <Mutex.h>
+#include <mutex>
 
 using namespace std;
 using namespace mlpl;
@@ -297,7 +297,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	HatoholArmPluginInterfaceHAPI2 &m_hapi2;
 	bool m_established;
 	ProcedureHandlerMap m_procedureHandlerMap;
-	Mutex m_procedureMapMutex;
+	mutex m_procedureMapMutex;
 	map<string, ProcedureCallContext *> m_procedureCallContextMap;
 	AMQPConnectionInfo m_connectionInfo;
 	AMQPConsumer *m_consumer;
@@ -317,7 +317,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	{
 		stop();
 
-		AutoMutex lock(&m_procedureMapMutex);
+		lock_guard<mutex> lock(m_procedureMapMutex);
 		for (auto &pair: m_procedureCallContextMap) {
 			ProcedureCallContext *context = pair.second;
 			Utils::removeEventSourceIfNeeded(context->m_timeoutId);
@@ -390,7 +390,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	{
 		const int PROCEDURE_TIMEOUT_MSEC = 60 * 1000;
 
-		AutoMutex lock(&m_procedureMapMutex);
+		lock_guard<mutex> lock(m_procedureMapMutex);
 
 		ProcedureCallContext *context = new ProcedureCallContext();
 		context->m_callback = callback;
@@ -407,7 +407,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 	{
 		bool found = false;
 
-		AutoMutex lock(&m_procedureMapMutex);
+		lock_guard<mutex> lock(m_procedureMapMutex);
 
 		auto it = m_procedureCallContextMap.find(id);
 		if (it != m_procedureCallContextMap.end()) {
@@ -428,7 +428,7 @@ struct HatoholArmPluginInterfaceHAPI2::Impl
 		ProcedureCallContext *context =
 		  static_cast<ProcedureCallContext *>(data);
 
-		AutoMutex lock(&context->m_impl->m_procedureMapMutex);
+		lock_guard<mutex> lock(context->m_impl->m_procedureMapMutex);
 
 		if (context->m_callback.hasData())
 			context->m_callback->onTimeout();

--- a/server/common/HatoholArmPluginInterfaceHAPI2.h
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.h
@@ -149,6 +149,7 @@ public:
 	class ProcedureCallback : public UsedCountable {
 	public:
 		virtual void onGotResponse(JSONParser &parser) = 0;
+		virtual void onTimeout(void) {};
 	};
 	typedef UsedCountablePtr<ProcedureCallback> ProcedureCallbackPtr;
 

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -384,7 +384,8 @@ struct HatoholArmPluginGateHAPI2::Impl
 			return result == "SUCCESS";
 		}
 
-		void flush(void) {
+		void flush(void)
+		{
 			if (m_methodName == HAPI2_FETCH_HISTORY) {
 				HistoryInfoVect historyInfoVect;
 				m_impl.runFetchHistoryCallback(m_fetchId,


### PR DESCRIPTION
In the current implementation, HatoholArmPluginGateHAPI2 waits a response from a plugin forever
when it doesn't respond to a request.
This modification let it to give up waiting a response after 60 seconds are passed. 

issue #1458