### PR TITLE
[configure.ac] Bump version number to 15.07_dev1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.63)
 
-AC_INIT(hatohol, 15.06)
+AC_INIT(hatohol, 15.07_dev1)
 AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADER(config.h)


### PR DESCRIPTION
For building RPM packages for testing.

issue #1451