### PR TITLE
[hap2] Split haplib.py into haplib.py and hap.py

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -302,6 +302,9 @@ rm -rf %{buildroot}
 %{python_sitelib}/hatohol/__init__.py
 %{python_sitelib}/hatohol/__init__.pyc
 %{python_sitelib}/hatohol/__init__.pyo
+%{python_sitelib}/hatohol/hap.py
+%{python_sitelib}/hatohol/hap.pyc
+%{python_sitelib}/hatohol/hap.pyo
 %{python_sitelib}/hatohol/haplib.py
 %{python_sitelib}/hatohol/haplib.pyc
 %{python_sitelib}/hatohol/haplib.pyo

--- a/server/hap2/hatohol/Makefile.am
+++ b/server/hap2/hatohol/Makefile.am
@@ -1,5 +1,6 @@
 noinst_SCRIPTS = \
 	__init__.py \
+	hap.py \
 	haplib.py \
 	transporter.py \
 	standardhap.py \

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# coding: UTF-8
+#
+#  Copyright (C) 2015 Project Hatohol
+#
+#  This file is part of Hatohol.
+#
+#  Hatohol is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License, version 3
+#  as published by the Free Software Foundation.
+#
+#  Hatohol is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with Hatohol. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+"""
+This module contains basic functions and class for HAP (Hatohol Arm Plugins)
+and is supposed to be used both from haplib and transporter.
+transporter and the sub class shall not import haplib. So the functions and
+classes used in them have to be in this module.
+"""
+
+class Signal:
+    """
+    This class is supposed to raise as an exception in order to
+    propagate some events and jump over stack frames.
+    """
+
+    def __init__(self, restart=False):
+        self.restart = restart

--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -27,6 +27,7 @@ import json
 import datetime
 import cPickle
 import base64
+from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
@@ -73,7 +74,7 @@ class Common:
         ms_info = self.__ms_info
         if ms_info is None:
             logging.error("Not found: MonitoringServerInfo.")
-            raise haplib.Signal()
+            raise hap.Signal()
 
         auth_url = ms_info.url + "/tokens"
         ext_info_type = haplib.MonitoringServerInfo.EXTENDED_INFO_JSON
@@ -113,7 +114,7 @@ class Common:
         if len(target_eps) > 0:
             logging.error("Not found Endpoints: Nova: %s, Ceiloemeter: %s" % \
                           (self.__nova_ep, self.__ceilometer_ep))
-            raise haplib.Signal()
+            raise hap.Signal()
 
         logging.info("EP: Nova: %s", self.__nova_ep)
         logging.info("EP: Ceiloemeter: %s", self.__ceilometer_ep)

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -26,6 +26,7 @@ import json
 import re
 import time
 import signal
+from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
@@ -90,7 +91,7 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
             if len(line) == 0:
                 logging.warning("The child process seems to have gone away.")
                 fluentd.kill() # To make sure that the child terminates
-                raise haplib.Signal()
+                raise hap.Signal()
             timestamp, tag, raw_msg = self.__parse_line(line)
             if timestamp is None:
                 continue

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -24,6 +24,7 @@ import MySQLdb
 import time
 import logging
 import datetime
+from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
@@ -91,7 +92,7 @@ class Common:
             self.__cursor = self.__db.cursor()
         except MySQLdb.Error as (errno, msg):
             logging.error('MySQL Error [%d]: %s' % (errno, msg))
-            raise haplib.Signal
+            raise hap.Signal
 
     def __parse_url(self, url):
         # [URL] SERVER_IP:PORT/DATABASE

--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -1,22 +1,27 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # coding: UTF-8
+#
+#  Copyright (C) 2015 Project Hatohol
+#
+#  This file is part of Hatohol.
+#
+#  Hatohol is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License, version 3
+#  as published by the Free Software Foundation.
+#
+#  Hatohol is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with Hatohol. If not, see
+#  <http://www.gnu.org/licenses/>.
+
 """
-  Copyright (C) 2015 Project Hatohol
-
-  This file is part of Hatohol.
-
-  Hatohol is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Lesser General Public License, version 3
-  as published by the Free Software Foundation.
-
-  Hatohol is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  GNU Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with Hatohol. If not, see
-  <http://www.gnu.org/licenses/>.
+This module contains functions and class for creating HAP (Hatohol Arm Plugins)
+and provides framework-like components compared to hap.py that includes more
+basic ones.
 """
 
 import sys
@@ -34,6 +39,7 @@ import imp
 import calendar
 import math
 import copy
+from hatohol import hap
 from hatohol import transporter
 from hatohol.rabbitmqconnector import RabbitMQConnector
 from hatohol.rabbitmqconnector import OverCapacity
@@ -199,20 +205,10 @@ def handle_exception(raises=(SystemExit,)):
     (exctype, value, tb) = sys.exc_info()
     if exctype in raises:
         raise
-    if exctype is not Signal:
+    if exctype is not hap.Signal:
         logging.error("Unexpected error: %s, %s, %s" % \
                       (exctype, value, traceback.format_tb(tb)))
     return exctype, value
-
-
-class Signal:
-    """
-    This class is supposed to raise as an exception in order to
-    propagate some events and jump over stack frames.
-    """
-
-    def __init__(self, restart=False):
-        self.restart = restart
 
 
 class Callback:
@@ -984,7 +980,7 @@ class BasePoller(HapiProcessor, ChildProcess):
         self.__retryInterval = ms_info.retry_interval_sec
         logging.info("Polling inverval: %d/%d",
                      self.__pollingInterval, self.__retryInterval)
-        raise Signal(restart=True)
+        raise hap.Signal(restart=True)
 
     def __call__(self):
         arm_info = ArmInfo()
@@ -1000,7 +996,7 @@ class BasePoller(HapiProcessor, ChildProcess):
             succeeded = True
         except:
             exctype, value = handle_exception()
-            if exctype is Signal:
+            if exctype is hap.Signal:
                 if value.restart:
                     return
             else:

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -25,6 +25,7 @@ import time
 import sys
 import traceback
 import signal
+from hatohol import hap
 from hatohol import haplib
 
 class StandardHap:
@@ -142,7 +143,7 @@ class StandardHap:
     def enable_handling_sigchld(self, enable=True):
         def handler(signum, frame):
             logging.warning("Got SIGCHLD")
-            raise haplib.Signal()
+            raise hap.Signal()
         if enable:
             _handler = handler
         else:

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# coding: UTF-8
+"""
+  Copyright (C) 2015 Project Hatohol
+
+  This file is part of Hatohol.
+
+  Hatohol is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License, version 3
+  as published by the Free Software Foundation.
+
+  Hatohol is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Hatohol. If not, see
+  <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import hap
+
+class Signal(unittest.TestCase):
+    def test_default(self):
+        obj = hap.Signal()
+        self.assertEquals(False, obj.restart)
+
+    def test_restart_is_true(self):
+        obj = hap.Signal(restart=True)
+        self.assertEquals(True, obj.restart)
+
+

--- a/server/hap2/hatohol/test/TestHap2Ceilometer.py
+++ b/server/hap2/hatohol/test/TestHap2Ceilometer.py
@@ -22,6 +22,7 @@ import common as testutils
 from hap2_ceilometer import Common
 import hap2_ceilometer
 from datetime import datetime
+from hatohol import hap
 from hatohol import haplib
 import re
 import transporter
@@ -230,7 +231,7 @@ class TestCommon(unittest.TestCase):
     def test_ensure_connection_without_monitoring_server_info(self):
         options = {"none_monitoring_server_info": True}
         comm = CommonForTest(options)
-        self.assertRaises(haplib.Signal, comm.ensure_connection)
+        self.assertRaises(hap.Signal, comm.ensure_connection)
 
     def test_ensure_connection(self):
         options = {}

--- a/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
+++ b/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
@@ -21,6 +21,7 @@
 
 import unittest
 import common as testutil
+from hatohol import hap
 from hatohol import haplib
 from hap2_nagios_ndoutils import Common
 import hap2_nagios_ndoutils
@@ -86,7 +87,7 @@ class TestCommon(unittest.TestCase):
     def test_ensure_connection_with_failure_of_opening_db(self):
         options = {"db_invalid_param": True}
         comm = CommonForTest(options)
-        self.assertRaises(haplib.Signal, comm.ensure_connection)
+        self.assertRaises(hap.Signal, comm.ensure_connection)
 
     def test_close_connection_without_connection(self):
         comm = Common()

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -31,6 +31,7 @@ import multiprocessing
 import Queue
 import logging
 import datetime
+from hatohol import hap
 
 class Gadget:
     def __init__(self):
@@ -56,16 +57,6 @@ class TestHaplib_handle_exception(unittest.TestCase):
             raise TypeError
         except:
             self.assertRaises(TypeError, haplib.handle_exception, (TypeError,))
-
-
-class TestHaplib_Signal(unittest.TestCase):
-    def test_default(self):
-        obj = haplib.Signal()
-        self.assertEquals(False, obj.restart)
-
-    def test_restart_is_true(self):
-        obj = haplib.Signal(restart=True)
-        self.assertEquals(True, obj.restart)
 
 
 class TestHaplib_Callback(unittest.TestCase):
@@ -905,7 +896,7 @@ class BasePoller(unittest.TestCase):
         try:
             set_ms_info(ms_info)
             raise
-        except haplib.Signal:
+        except hap.Signal:
             pass
 
     def test_call(self):

--- a/server/hap2/setup_common.py
+++ b/server/hap2/setup_common.py
@@ -5,5 +5,5 @@ setup(name='hatohol',
       author='Procect Hatohol',
       author_email='hatohol-users@list.sourceforge.net',
       url='https://github.com/project-hatohol/hatohol',
-      py_modules=['hatohol.haplib', 'hatohol.transporter', 'hatohol.standardhap']
+      py_modules=['hatohol.hap', 'hatohol.haplib', 'hatohol.transporter', 'hatohol.standardhap']
      )


### PR DESCRIPTION
hap.py includes more basic components that are used from all hap
modules. haplib.py provides more framework-like components and
shall not be used from transporter and the sub classes.