### PR TITLE
Fix 1440

### DIFF
--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -57,5 +57,6 @@ class Signal:
     propagate some events and jump over stack frames.
     """
 
-    def __init__(self, restart=False):
+    def __init__(self, restart=False, critical=False):
         self.restart = restart
+        self.critical = critical

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -48,6 +48,9 @@ def handle_exception(raises=(SystemExit,)):
     if exctype is not Signal:
         logging.error("Unexpected error: %s, %s, %s" % \
                       (exctype, value, traceback.format_tb(tb)))
+    elif value.critical:
+        logging.critical("Got critical signal.")
+        raise
     return exctype, value
 
 

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -25,6 +25,32 @@ transporter and the sub class shall not import haplib. So the functions and
 classes used in them have to be in this module.
 """
 
+import logging
+import sys
+import traceback
+
+def handle_exception(raises=(SystemExit,)):
+    """
+    Logging exception information including back trace and return
+    some information. This method is supposed to be used in 'except:' block.
+    Note that if the exception class is Signal, this method doesn't log it.
+
+    @raises
+    A sequence of exceptionclass names. If the handling exception is one of
+    it, this method just raises it again.
+
+    @return
+    A sequence of exception class and the instance of the handling exception.
+    """
+    (exctype, value, tb) = sys.exc_info()
+    if exctype in raises:
+        raise
+    if exctype is not Signal:
+        logging.error("Unexpected error: %s, %s, %s" % \
+                      (exctype, value, traceback.format_tb(tb)))
+    return exctype, value
+
+
 class Signal:
     """
     This class is supposed to raise as an exception in order to

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -79,7 +79,7 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
             try:
                 self.__fluentd_manager_main_in_try_block()
             except:
-                haplib.handle_exception()
+                hap.handle_exception()
                 self.__arm_info.fail()
                 time.sleep(self.__ms_info.retry_interval_sec)
 
@@ -151,7 +151,7 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
             timestamp, tag = self.__parse_header(header)
         except:
             timestamp, tag, msg = None, None, None
-            haplib.handle_exception()
+            hap.handle_exception()
             self.__arm_info.fail()
         return timestamp, tag, msg
 

--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -24,10 +24,8 @@ and provides framework-like components compared to hap.py that includes more
 basic ones.
 """
 
-import sys
 import time
 import logging
-import traceback
 import multiprocessing
 import Queue
 import json
@@ -188,28 +186,6 @@ TRIGGER_SEVERITY = frozenset(
 
 DEFAULT_MAX_EVENT_CHUNK_SIZE = 100
 MAX_LAST_INFO_SIZE = 32767
-
-def handle_exception(raises=(SystemExit,)):
-    """
-    Logging exception information including back trace and return
-    some information. This method is supposed to be used in 'except:' block.
-    Note that if the exception class is Signal, this method doesn't log it.
-
-    @raises
-    A sequence of exceptionclass names. If the handling exception is one of
-    it, this method just raises it again.
-
-    @return
-    A sequence of exception class and the instance of the handling exception.
-    """
-    (exctype, value, tb) = sys.exc_info()
-    if exctype in raises:
-        raise
-    if exctype is not hap.Signal:
-        logging.error("Unexpected error: %s, %s, %s" % \
-                      (exctype, value, traceback.format_tb(tb)))
-    return exctype, value
-
 
 class Callback:
     def __init__(self):
@@ -995,7 +971,7 @@ class BasePoller(HapiProcessor, ChildProcess):
             self.poll()
             succeeded = True
         except:
-            exctype, value = handle_exception()
+            exctype, value = hap.handle_exception()
             if exctype is hap.Signal:
                 if value.restart:
                     return
@@ -1016,12 +992,12 @@ class BasePoller(HapiProcessor, ChildProcess):
             self.put_arm_info(arm_info)
             self.log_status(arm_info)
         except:
-            handle_exception()
+            hap.handle_exception()
 
         try:
             self.__command_queue.wait(sleep_time)
         except:
-            handle_exception()
+            hap.handle_exception()
 
 
 class Utils:

--- a/server/hap2/hatohol/rabbitmqconnector.py
+++ b/server/hap2/hatohol/rabbitmqconnector.py
@@ -96,11 +96,7 @@ class RabbitMQConnector(Transporter):
             except:
                 # On some condition such as Ubuntu 14.04, the above close()
                 # raises an exception when the rabbitmq-server is stopped.
-                (exctype, value, tb) = sys.exc_info()
-                if exctype is SystemExit:
-                    raise
-                logging.error("Unexpected error: %s, %s, %s" % \
-                              (exctype, value, traceback.format_tb(tb)))
+                hap.handle_exception()
 
             self.__connection = None
 

--- a/server/hap2/hatohol/rabbitmqconnector.py
+++ b/server/hap2/hatohol/rabbitmqconnector.py
@@ -20,6 +20,7 @@
 
 import logging
 import pika
+import hap
 from hatohol.transporter import Transporter
 
 MAX_BODY_SIZE = 50000
@@ -123,6 +124,14 @@ class RabbitMQConnector(Transporter):
         receiver(self._channel, body)
 
     def __publish(self, msg):
+        try:
+            self.__publish_raw(msg)
+        except:
+            # TODO: consider the way to save the message and try to
+            # send it again.
+            raise hap.Signal(critical=True)
+
+    def __publish_raw(self, msg):
         self._channel.basic_publish(exchange="", routing_key=self._queue_name,
                                     body=msg,
                                     properties=pika.BasicProperties(

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -114,7 +114,7 @@ class StandardHap:
                 self.__run()
             except:
                 raises = (KeyboardInterrupt, AssertionError, SystemExit)
-                exctype, value = haplib.handle_exception(raises=raises)
+                exctype, value = hap.handle_exception(raises=raises)
             else:
                 break
 

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -22,6 +22,26 @@
 import unittest
 import hap
 
+class Gadget:
+    pass
+
+class handle_exception(unittest.TestCase):
+    def test_handle_exception(self):
+        obj = Gadget()
+        try:
+            raise obj
+        except:
+            exctype, value = hap.handle_exception()
+        self.assertEquals(Gadget, exctype)
+        self.assertEquals(obj, value)
+
+    def test_handle_exception_on_raises(self):
+        try:
+            raise TypeError
+        except:
+            self.assertRaises(TypeError, hap.handle_exception, (TypeError,))
+
+
 class Signal(unittest.TestCase):
     def test_default(self):
         obj = hap.Signal()

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -41,6 +41,12 @@ class handle_exception(unittest.TestCase):
         except:
             self.assertRaises(TypeError, hap.handle_exception, (TypeError,))
 
+    def test_handle_exception_critical_signal(self):
+        try:
+            raise hap.Signal(critical=True)
+        except:
+            self.assertRaises(hap.Signal, hap.handle_exception)
+
 
 class Signal(unittest.TestCase):
     def test_default(self):

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -46,9 +46,14 @@ class Signal(unittest.TestCase):
     def test_default(self):
         obj = hap.Signal()
         self.assertEquals(False, obj.restart)
+        self.assertEquals(False, obj.critical)
 
     def test_restart_is_true(self):
         obj = hap.Signal(restart=True)
         self.assertEquals(True, obj.restart)
+
+    def test_critical_is_true(self):
+        obj = hap.Signal(critical=True)
+        self.assertEquals(True, obj.critical)
 
 

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -42,23 +42,6 @@ class Gadget:
         self.num_called += 1
 
 
-class TestHaplib_handle_exception(unittest.TestCase):
-    def test_handle_exception(self):
-        obj = Gadget()
-        try:
-            raise obj
-        except:
-            exctype, value = haplib.handle_exception()
-        self.assertEquals(Gadget, exctype)
-        self.assertEquals(obj, value)
-
-    def test_handle_exception_on_raises(self):
-        try:
-            raise TypeError
-        except:
-            self.assertRaises(TypeError, haplib.handle_exception, (TypeError,))
-
-
 class TestHaplib_Callback(unittest.TestCase):
     def test_register_and_call(self):
         cb = haplib.Callback()

--- a/server/hap2/hatohol/test/TestRabbitMQConnector.py
+++ b/server/hap2/hatohol/test/TestRabbitMQConnector.py
@@ -21,6 +21,7 @@ import unittest
 import os
 import common as testutils
 import subprocess
+import hap
 from rabbitmqconnector import RabbitMQConnector
 from rabbitmqconnector import OverCapacity
 import rabbitmqconnector
@@ -123,6 +124,14 @@ class TestRabbitMQConnector(unittest.TestCase):
         self.__publish(TEST_BODY)
         conn.run_receive_loop()
         self.assertEquals(receiver.msg, TEST_BODY)
+
+    def test__publish_with_exception(self):
+        conn = RabbitMQConnector()
+        testutils.set_priv_attr(conn, "__publish_raw", None)
+        target_func = testutils.returnPrivObj(conn, "__publish")
+        with self.assertRaises(hap.Signal) as cm:
+            target_func("msg")
+        self.assertTrue(cm.exception.critical)
 
     def __get_default_transporter_args(self):
         args = {"amqp_broker": self.__broker, "amqp_port": self.__port,

--- a/server/hap2/hatohol/test/common.py
+++ b/server/hap2/hatohol/test/common.py
@@ -4,7 +4,15 @@ def assertNotRaises(func, *args, **kwargs):
     except Exception:
         raise
 
+def get_mangled_name(instance, attr_name, class_name=None):
+    if class_name is None:
+        class_name = instance.__class__.__name__
+    return "instance._" + class_name + attr_name
+
 def returnPrivObj(instance, obj_name, class_name=None):
     if class_name is None:
         class_name = instance.__class__.__name__
     return eval("instance._"+class_name+obj_name)
+
+def set_priv_attr(instance, attr_name, new_attr, class_name=None):
+    exec(get_mangled_name(instance, attr_name, class_name) + " = new_attr")


### PR DESCRIPTION
    Terminate the program if any problem of rabbitmq happen. (#1440)
    
    When the problem happens in the call of pika, a client library for
    RabbitMQ, an exception is raised. Then, it is caught in
    StandardHap.__call__(). However, some situation this kind of
    the problem happens needs to restart of the process in order to
    initialize pika's internal state.
    
    This patch terminates the process by making Signal with a critical
    flag raise.