### PR TITLE
travis: use `sudo: required` explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Because current build steps in Travis is heavily depends on sudo.

Upgrading document is here: http://docs.travis-ci.com/user/migrating-from-legacy/
But, sadly, I have no idea to upgrade Travis build step to adopt new Travis infrastructure.