### PR TITLE
[hap2] Abort launching hatohol plugin if the PID file couldn't be created.

### DIFF
--- a/server/hap2/hap2-control-functions.sh.in
+++ b/server/hap2/hap2-control-functions.sh.in
@@ -70,7 +70,7 @@ start_plugin() {
         if test ! -e "$PID_FILE_DIR"; then
             mkdir -p ${PID_FILE_DIR}
         fi
-        echo -n $PID > $PID_FILE
+        echo -n $PID > $PID_FILE || kill $PID; exit 1
         echo
         echo "Succeeded to start $PLUGIN_PATH"
         echo "PID: $PID"


### PR DESCRIPTION
…ated.

Currently the failure of the creation of the PID file is ignored.
However, the execution should be terminated on such situation.

One of the typical situations is execution by a user who cannot
create a file under /var/run.