### PR TITLE
[hap2] find and load transporter modules dynamically (#1461)

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -314,12 +314,18 @@ rm -rf %{buildroot}
 %{python_sitelib}/hatohol/transporter.py
 %{python_sitelib}/hatohol/transporter.pyc
 %{python_sitelib}/hatohol/transporter.pyo
+%{python_sitelib}/hatohol/transporters/__init__.py
+%{python_sitelib}/hatohol/transporters/__init__.pyc
+%{python_sitelib}/hatohol/transporters/__init__.pyo
 %{_libexecdir}/hatohol/hap2/hap2-control-functions.sh
 
 %files hap2-rabbitmq-connector
 %{python_sitelib}/hatohol/rabbitmqconnector.py
 %{python_sitelib}/hatohol/rabbitmqconnector.pyc
 %{python_sitelib}/hatohol/rabbitmqconnector.pyo
+%{python_sitelib}/hatohol/transporters/rabbitmqhapiconnector.py
+%{python_sitelib}/hatohol/transporters/rabbitmqhapiconnector.pyc
+%{python_sitelib}/hatohol/transporters/rabbitmqhapiconnector.pyo
 
 %files hap2-zabbix
 %{python_sitelib}/hatohol/zabbixapi.py

--- a/server/hap2/hatohol/Makefile.am
+++ b/server/hap2/hatohol/Makefile.am
@@ -5,6 +5,8 @@ noinst_SCRIPTS = \
 	transporter.py \
 	standardhap.py \
 	rabbitmqconnector.py \
-	zabbixapi.py
+	zabbixapi.py \
+	transporters/__init__.py \
+	transporters/rabbitmqhapiconnector.py
 
 EXTRA_DIST = $(noinst_SCRIPTS)

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -25,8 +25,6 @@ import testutils
 import transporter
 import os
 import json
-from collections import namedtuple
-import argparse
 import multiprocessing
 import Queue
 import logging
@@ -231,20 +229,6 @@ class Sender(unittest.TestCase):
 
 
 class Utils(unittest.TestCase):
-    def test_define_transporter_arguments(self):
-        test_parser = argparse.ArgumentParser()
-        testutils.assertNotRaises(haplib.Utils.define_transporter_arguments,
-                               test_parser)
-
-    def test_load_transporter(self):
-        test_transport_arguments = namedtuple("transport_argument",
-                                              "transporter_module transporter")
-        test_transport_arguments.transporter_module = "hatohol.haplib"
-        test_transport_arguments.transporter = "RabbitMQHapiConnector"
-
-        testutils.assertNotRaises(haplib.Utils.load_transporter,
-                               test_transport_arguments)
-
     def test_parse_received_message_invalid_json(self):
         test_message = "invalid_message"
         result = haplib.Utils.parse_received_message(test_message, None)

--- a/server/hap2/hatohol/test/TestStandardHap.py
+++ b/server/hap2/hatohol/test/TestStandardHap.py
@@ -21,7 +21,7 @@ import unittest
 import sys
 from standardhap import StandardHap
 import haplib
-import transporter
+from hatohol import transporter
 import multiprocessing
 import json
 
@@ -71,6 +71,9 @@ class EzTransporter(transporter.Transporter):
         self.__queue.put(reply)
 
 
+transporter.Manager.register(EzTransporter)
+
+
 class TestStandardHap(unittest.TestCase):
     class StandardHapTestee(StandardHap):
         def __init__(self):
@@ -91,9 +94,7 @@ class TestStandardHap(unittest.TestCase):
 
     def test_normal_run(self):
         hap = self.StandardHapTestee()
-        sys.argv = [sys.argv[0],
-                    "--transporter", "EzTransporter",
-                    "--transporter-module", "test.TestStandardHap"]
+        sys.argv = [sys.argv[0], "--transporter", "EzTransporter"]
         hap()
         hap.enable_handling_sigchld(False)
         exact_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))

--- a/server/hap2/hatohol/test/TestTransporter.py
+++ b/server/hap2/hatohol/test/TestTransporter.py
@@ -17,9 +17,13 @@
   License along with Hatohol. If not, see
   <http://www.gnu.org/licenses/>.
 """
+import os
+import argparse
 import unittest
-from transporter import Transporter
-import transporter
+import testutils
+from collections import namedtuple
+from hatohol import transporter
+from hatohol.transporter import Transporter
 
 class TestTransporter(unittest.TestCase):
     def test_factory(self):
@@ -57,3 +61,29 @@ class TestTransporter(unittest.TestCase):
 
     def __default_transporter_args(self):
         return {"class": Transporter}
+
+class Manager(unittest.TestCase):
+    def test_define_arguments(self):
+        test_parser = argparse.ArgumentParser()
+        manager = transporter.Manager(None)
+        testutils.assertNotRaises(manager.define_arguments, test_parser)
+
+    def test_register_and_find(self):
+        class testTrans:
+            @classmethod
+            def define_arguments(cls, parser):
+                pass
+
+        manager = transporter.Manager(None)
+        self.assertIsNone(manager.find("testTrans"))
+        transporter.Manager.register(testTrans)
+        self.assertEquals(manager.find("testTrans"), testTrans)
+
+    def test_import_module_for_nonexisting_module(self):
+        path = os.path.dirname(__file__)
+        self.assertIsNone(transporter.Manager.import_module("notfound", path))
+
+    def test_import_module(self):
+        path = os.path.dirname(__file__)
+        mod = transporter.Manager.import_module("stub", path)
+        self.assertEquals(mod.a, 1)

--- a/server/hap2/hatohol/test/stub.py
+++ b/server/hap2/hatohol/test/stub.py
@@ -1,0 +1,4 @@
+"""
+This module is used from TestTransporter
+"""
+a = 1

--- a/server/hap2/hatohol/transporters/__init__.py
+++ b/server/hap2/hatohol/transporters/__init__.py
@@ -1,0 +1,27 @@
+import os
+from hatohol import transporter
+
+"""
+Load all pyton files in this directory except for files which begin
+with hyphen.
+"""
+
+def is_valid_module_name(filename):
+    if filename[-3:] != ".py":
+        return False
+    if filename[0:1] == "_":
+        return False
+    return True
+
+def extract_module_name(filename):
+    if not is_valid_module_name(filename):
+        return None
+    return filename[:-3]
+
+file_dir = os.path.dirname(__file__)
+files = os.listdir(file_dir)
+for filename in files:
+    module_name = extract_module_name(filename)
+    if module_name is None:
+        continue
+    transporter.Manager.import_module(module_name, file_dir)

--- a/server/hap2/hatohol/transporters/rabbitmqhapiconnector.py
+++ b/server/hap2/hatohol/transporters/rabbitmqhapiconnector.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# coding: UTF-8
+#
+#  Copyright (C) 2015 Project Hatohol
+#
+#  This file is part of Hatohol.
+#
+#  Hatohol is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License, version 3
+#  as published by the Free Software Foundation.
+#
+#  Hatohol is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with Hatohol. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+from hatohol.rabbitmqconnector import RabbitMQConnector
+from hatohol import transporter
+
+class RabbitMQHapiConnector(RabbitMQConnector):
+    def setup(self, transporter_args):
+        send_queue_suffix = transporter_args.get("amqp_send_queue_suffix", "-S")
+        recv_queue_suffix = transporter_args.get("amqp_recv_queue_suffix", "-T")
+        suffix_map = {transporter.DIR_SEND: send_queue_suffix,
+                      transporter.DIR_RECV: recv_queue_suffix}
+        suffix = suffix_map.get(transporter_args["direction"], "")
+
+        if "amqp_hapi_queue" not in transporter_args:
+            transporter_args["amqp_hapi_queue"] = transporter_args["amqp_queue"]
+        transporter_args["amqp_queue"] = \
+            transporter_args["amqp_hapi_queue"] + suffix
+        RabbitMQConnector.setup(self, transporter_args)
+
+transporter.Manager.register(RabbitMQHapiConnector)

--- a/server/hap2/setup_rabbitmqconnector.py
+++ b/server/hap2/setup_rabbitmqconnector.py
@@ -6,5 +6,5 @@ setup(name='hatohol',
       author='Procect Hatohol',
       author_email='hatohol-users@list.sourceforge.net',
       url='https://github.com/project-hatohol/hatohol',
-      py_modules=['hatohol.rabbitmqconnector']
+      py_modules=['hatohol.rabbitmqconnector', 'hatohol.transporters.rabbitmqhapiconnector']
      )


### PR DESCRIPTION
In HAPI2.0 framework, a transporter module is replaceable.
To improve the flexibility, this patch tries to find transporter
modules: hatohol/transporters under each $PYTHONPATH.