### PR TITLE
Retry when eintr happens #1519

### DIFF
--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -66,7 +66,7 @@ class Signal:
         self.restart = restart
         self.critical = critical
 
-def MultiprocessingQueue():
+def MultiprocessingQueue(queue_class=multiprocessing.Queue):
     """
     The purpose of this function is to provide get() method with a retry
     when EINTR happens.
@@ -89,7 +89,7 @@ def MultiprocessingQueue():
                 else:
                     timeout = 0
 
-    q = multiprocessing.Queue()
+    q = queue_class()
     original_get = q.get
     q.get = __get
     return q

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -93,3 +93,6 @@ def MultiprocessingQueue(queue_class=multiprocessing.Queue):
     original_get = q.get
     q.get = __get
     return q
+
+def MultiprocessingJoinableQueue():
+    return MultiprocessingQueue(multiprocessing.JoinableQueue)

--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -209,7 +209,7 @@ class Callback:
 class CommandQueue(Callback):
     def __init__(self):
         Callback.__init__(self)
-        self.__q = multiprocessing.Queue()
+        self.__q = hap.MultiprocessingQueue()
 
     def __del__(self):
         self.__q.close()
@@ -365,7 +365,7 @@ Some APIs blocks until the response is arrived.
 """
 class HapiProcessor:
     def __init__(self, process_id, component_code, sender=None):
-        self.__reply_queue = multiprocessing.Queue()
+        self.__reply_queue = hap.MultiprocessingQueue()
         self.__dispatch_queue = None
         self.__process_id = process_id
         self.__component_code = component_code
@@ -674,7 +674,7 @@ class Dispatcher(ChildProcess):
         ChildProcess.__init__(self)
         self.__id_res_q_map = {}
         self.__destination_q_map = {}
-        self.__dispatch_queue = multiprocessing.JoinableQueue()
+        self.__dispatch_queue = hap.MultiprocessingJoinableQueue()
         self.__rpc_queue = rpc_queue
 
     def __del__( self ):
@@ -771,7 +771,7 @@ class BaseMainPlugin(HapiProcessor):
         """
         self.__sender = Sender(transporter_args)
         HapiProcessor.set_sender(self, self.__sender)
-        self.__rpc_queue = multiprocessing.Queue()
+        self.__rpc_queue = hap.MultiprocessingQueue()
 
         # launch dispatcher process
         self.__dispatcher = Dispatcher(self.__rpc_queue)

--- a/server/hap2/hatohol/simple_server.py
+++ b/server/hap2/hatohol/simple_server.py
@@ -43,7 +43,7 @@ class SimpleServer:
     def __init__(self, args, transporter_args):
         self.__args = args
         self.__sender = haplib.Sender(transporter_args)
-        self.__rpc_queue = multiprocessing.JoinableQueue()
+        self.__rpc_queue = hap.MultiprocessingJoinableQueue()
         self.__dispatcher = haplib.Dispatcher(self.__rpc_queue)
         self.__dispatcher.daemonize()
         self.__last_info = {"event": None}

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -21,6 +21,8 @@
 
 import unittest
 import hap
+import Queue
+import signal
 
 class Gadget:
     pass
@@ -63,3 +65,20 @@ class Signal(unittest.TestCase):
         self.assertEquals(True, obj.critical)
 
 
+class MultiprocessingQueue(unittest.TestCase):
+    def test_get_empty_in_nonblocking(self):
+        q = hap.MultiprocessingQueue()
+        self.assertRaises(Queue.Empty, q.get, block=False)
+
+    def test_get_empty_in_blocking(self):
+        q = hap.MultiprocessingQueue()
+        self.assertRaises(Queue.Empty, q.get, timeout=0.1)
+
+    def test_get_item(self):
+        q = hap.MultiprocessingQueue()
+        q.put(4)
+        self.assertEquals(q.get(timeout=1), 4)
+
+    # TODO: we want to add a test of a behavior when IOError due to EINTR
+    #       is raised. However, I don't have an idea of implementation to
+    #       test it.


### PR DESCRIPTION
Some hap2 tests failed with IOError due to EINTR such as
https://travis-ci.org/project-hatohol/hatohol/jobs/75575033.

This patch provides a wrapper object that retries in it.