### PR TITLE
[hap2] Retry Queue.get() when it interrputs by EINTR.

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -209,7 +209,7 @@ class Callback:
 class CommandQueue(Callback):
     def __init__(self):
         Callback.__init__(self)
-        self.__q = multiprocessing.Queue()
+        self.__q = hap.MultiprocessingQueue()
 
     def __del__(self):
         self.__q.close()
@@ -365,7 +365,7 @@ Some APIs blocks until the response is arrived.
 """
 class HapiProcessor:
     def __init__(self, process_id, component_code, sender=None):
-        self.__reply_queue = multiprocessing.Queue()
+        self.__reply_queue = hap.MultiprocessingQueue()
         self.__dispatch_queue = None
         self.__process_id = process_id
         self.__component_code = component_code
@@ -674,7 +674,7 @@ class Dispatcher(ChildProcess):
         ChildProcess.__init__(self)
         self.__id_res_q_map = {}
         self.__destination_q_map = {}
-        self.__dispatch_queue = multiprocessing.JoinableQueue()
+        self.__dispatch_queue = hap.MultiprocessingJoinableQueue()
         self.__rpc_queue = rpc_queue
 
     def __del__( self ):
@@ -771,7 +771,7 @@ class BaseMainPlugin(HapiProcessor):
         """
         self.__sender = Sender(transporter_args)
         HapiProcessor.set_sender(self, self.__sender)
-        self.__rpc_queue = multiprocessing.Queue()
+        self.__rpc_queue = hap.MultiprocessingQueue()
 
         # launch dispatcher process
         self.__dispatcher = Dispatcher(self.__rpc_queue)

--- a/server/hap2/hatohol/simple_server.py
+++ b/server/hap2/hatohol/simple_server.py
@@ -43,7 +43,7 @@ class SimpleServer:
     def __init__(self, args, transporter_args):
         self.__args = args
         self.__sender = haplib.Sender(transporter_args)
-        self.__rpc_queue = multiprocessing.JoinableQueue()
+        self.__rpc_queue = hap.MultiprocessingJoinableQueue()
         self.__dispatcher = haplib.Dispatcher(self.__rpc_queue)
         self.__dispatcher.daemonize()
         self.__last_info = {"event": None}

--- a/server/hap2/hatohol/test/TestHap.py
+++ b/server/hap2/hatohol/test/TestHap.py
@@ -21,6 +21,10 @@
 
 import unittest
 import hap
+import Queue
+import signal
+import errno
+import time
 
 class Gadget:
     pass
@@ -63,3 +67,46 @@ class Signal(unittest.TestCase):
         self.assertEquals(True, obj.critical)
 
 
+class MultiprocessingQueue(unittest.TestCase):
+    def test_get_empty_in_nonblocking(self):
+        q = hap.MultiprocessingQueue()
+        self.assertRaises(Queue.Empty, q.get, block=False)
+
+    def test_get_empty_in_blocking(self):
+        q = hap.MultiprocessingQueue()
+        self.assertRaises(Queue.Empty, q.get, timeout=0.1)
+
+    def test_get_item(self):
+        q = hap.MultiprocessingQueue()
+        q.put(4)
+        self.assertEquals(q.get(timeout=1), 4)
+
+    def test_handle_ioerr_not_eintr(self):
+        try:
+            raise IOError(errno.ENOENT, "")
+        except IOError as e:
+            self.assertRaises(IOError, hap._handle_ioerr, e, None, None)
+
+    def test_handle_ioerr_errrno_is_not_EINTR(self):
+        try:
+            raise IOError(errno.ENOENT, "")
+        except IOError as e:
+            self.assertRaises(IOError, hap._handle_ioerr, e, None, None)
+
+    def test_handle_ioerr_timeout_is_None(self):
+        e = IOError(errno.EINTR, "")
+        self.assertIsNone(hap._handle_ioerr(e, None, None))
+
+    def test_handle_ioerr_curr_time_over_expired_time(self):
+        e = IOError(errno.EINTR, "")
+        timeout = 5 # any positive integer is OK
+        expired_time = time.time() - 1
+        self.assertEquals(hap._handle_ioerr(e, timeout, expired_time), 0)
+
+    def test_handle_ioerr_curr_not_expired(self):
+        e = IOError(errno.EINTR, "")
+        timeout = 5 # any positive integer is OK
+        expired_time = time.time() + 10
+        returned_timeout = hap._handle_ioerr(e, timeout, expired_time)
+        self.assertGreater(returned_timeout, 0)
+        self.assertLess(hap._handle_ioerr(e, timeout, expired_time), 10)


### PR DESCRIPTION
multiprocessing.Queue.get() might raise IOError due to EINTR.
The added functions provides the wrapper function get() that
retries when EINTR is raised in it.