### PR TITLE
[HostResourceQueryOption] Rename unclear & too long function names

### DIFF
--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -65,23 +65,23 @@ struct HostResourceQueryOption::Impl {
 	ServerIdType    targetServerId;
 	LocalHostIdType targetHostId;
 	HostgroupIdType targetHostgroupId;
-	bool            filterDataOfDefunctServers;
+	bool            excludeDefunctServers;
 
 	Impl(const Synapse &_synapse)
 	: synapse(_synapse),
 	  targetServerId(ALL_SERVERS),
 	  targetHostId(ALL_LOCAL_HOSTS),
 	  targetHostgroupId(ALL_HOST_GROUPS),
-	  filterDataOfDefunctServers(true)
+	  excludeDefunctServers(true)
 	{
 	}
 
 	Impl &operator=(const Impl &rhs)
 	{
-		targetServerId             = rhs.targetServerId;
-		targetHostId               = rhs.targetHostId;
-		targetHostgroupId          = rhs.targetHostgroupId;
-		filterDataOfDefunctServers = rhs.filterDataOfDefunctServers;
+		targetServerId        = rhs.targetServerId;
+		targetHostId          = rhs.targetHostId;
+		targetHostgroupId     = rhs.targetHostgroupId;
+		excludeDefunctServers = rhs.excludeDefunctServers;
 		return *this;
 	}
 };
@@ -124,7 +124,7 @@ string HostResourceQueryOption::getCondition(void) const
 {
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
-	if (getFilterForDataOfDefunctServers()) {
+	if (getExcludeDefunctServers()) {
 		addCondition(
 		  condition,
 		  makeConditionServer(
@@ -284,15 +284,15 @@ void HostResourceQueryOption::setTargetHostgroupId(
 	m_impl->targetHostgroupId = targetHostgroupId;
 }
 
-void HostResourceQueryOption::setFilterForDataOfDefunctServers(
+void HostResourceQueryOption::setExcludeDefunctServers(
   const bool &enable)
 {
-	m_impl->filterDataOfDefunctServers = enable;
+	m_impl->excludeDefunctServers = enable;
 }
 
-const bool &HostResourceQueryOption::getFilterForDataOfDefunctServers(void) const
+const bool &HostResourceQueryOption::getExcludeDefunctServers(void) const
 {
-	return m_impl->filterDataOfDefunctServers;
+	return m_impl->excludeDefunctServers;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -121,24 +121,24 @@ public:
 	virtual void setTargetHostgroupId(HostgroupIdType targetHostgroupId);
 
 	/**
-	 * Enable or disable the filter for the data of defunct servers.
+	 * Enable or disable the filter to exclude defunct servers.
 	 *
 	 * @param enable
 	 * If the parameter is true, the filter is enabled. Otherwise,
 	 * it is disabled.
 	 *
 	 */
-	void setFilterForDataOfDefunctServers(const bool &enable = true);
+	void setExcludeDefunctServers(const bool &enable = true);
 
 	/**
-	 * Get the filter status for the data of defunct servers.
+	 * Get the status of the filter to exclude defunct servers.
 	 *
 	 * @return
 	 * If the filter is enabled, true is returned, Otherwise,
 	 * false is returned.
 	 *
 	 */
-	const bool &getFilterForDataOfDefunctServers(void) const;
+	const bool &getExcludeDefunctServers(void) const;
 
 	std::string getJoinClause(void) const;
 

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -1000,13 +1000,13 @@ void crash(void)
 #endif
 }
 
-void prepareTestDataForFilterForDataOfDefunctServers(void)
+void prepareTestDataExcludeDefunctServers(void)
 {
-	gcut_add_datum("Not filter data of defunct servers",
-		       "filterDataOfDefunctServers", G_TYPE_BOOLEAN, FALSE,
+	gcut_add_datum("Don't exclude defunct servers",
+		       "excludeDefunctServers", G_TYPE_BOOLEAN, FALSE,
 		       NULL);
-	gcut_add_datum("Filter data of defunct servers.",
-		       "filterDataOfDefunctServers", G_TYPE_BOOLEAN, TRUE,
+	gcut_add_datum("Exclude defunct servers",
+		       "excludeDefunctServers", G_TYPE_BOOLEAN, TRUE,
 		       NULL);
 }
 
@@ -1014,10 +1014,10 @@ void fixupForFilteringDefunctServer(
   gconstpointer data, string &expected, HostResourceQueryOption &option,
   const string &tableName)
 {
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
-	if (filterForDataOfDefunctSv)
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
+	option.setExcludeDefunctServers(excludeDefunctServers);
+	if (excludeDefunctServers)
 		insertValidServerCond(expected, option, tableName);
 }
 

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -191,7 +191,7 @@ std::string joinStringVector(const mlpl::StringVector &strVect,
                              bool isPaddingTail = true);
 
 void crash(void);
-void prepareTestDataForFilterForDataOfDefunctServers(void);
+void prepareTestDataExcludeDefunctServers(void);
 void fixupForFilteringDefunctServer(
   gconstpointer data, std::string &expected, HostResourceQueryOption &option,
   const std::string &tableName = "");

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1039,7 +1039,7 @@ void test_getServerHostDefs(gconstpointer data)
 
 void data_getHostInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getHostInfoList(gconstpointer data)
@@ -1050,7 +1050,7 @@ void test_getHostInfoList(gconstpointer data)
 
 void data_getHostInfoListForOneServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getHostInfoListForOneServer(gconstpointer data)
@@ -1062,7 +1062,7 @@ void test_getHostInfoListForOneServer(gconstpointer data)
 
 void data_getHostInfoListWithNoAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getHostInfoListWithNoAuthorizedServer(gconstpointer data)
@@ -1074,7 +1074,7 @@ void test_getHostInfoListWithNoAuthorizedServer(gconstpointer data)
 
 void data_getHostInfoListWithOneAuthorizedServer(gconstpointer data)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getHostInfoListWithOneAuthorizedServer(gconstpointer data)
@@ -1086,7 +1086,7 @@ void test_getHostInfoListWithOneAuthorizedServer(gconstpointer data)
 
 void data_getHostInfoListWithUserWhoCanAccessSomeHostgroups(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getHostInfoListWithUserWhoCanAccessSomeHostgroups(gpointer data)

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -168,7 +168,7 @@ struct AssertGetItemsArg
 			return true;
 		}
 
-		if (filterForDataOfDefunctSv) {
+		if (excludeDefunctServers) {
 			if (!option.isValidServer(info->serverId))
 				return true;
 		}
@@ -577,7 +577,7 @@ void test_getTriggerInfoNotFound(void)
 
 void data_getTriggerInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerInfoList(gconstpointer data)
@@ -587,7 +587,7 @@ void test_getTriggerInfoList(gconstpointer data)
 
 void data_getTriggerInfoListForOneServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerInfoListForOneServer(gconstpointer data)
@@ -598,7 +598,7 @@ void test_getTriggerInfoListForOneServer(gconstpointer data)
 
 void data_getTriggerInfoListForOneServerOneHost(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerInfoListForOneServerOneHost(gconstpointer data)
@@ -610,7 +610,7 @@ void test_getTriggerInfoListForOneServerOneHost(gconstpointer data)
 
 void data_setTriggerInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_setTriggerInfoList(gconstpointer data)
@@ -628,7 +628,7 @@ void test_setTriggerInfoList(gconstpointer data)
 
 void data_addTriggerInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_addTriggerInfoList(gconstpointer data)
@@ -656,7 +656,7 @@ void test_addTriggerInfoList(gconstpointer data)
 
 void data_getTriggerWithOneAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerWithOneAuthorizedServer(gconstpointer data)
@@ -668,7 +668,7 @@ void test_getTriggerWithOneAuthorizedServer(gconstpointer data)
 
 void data_getTriggerWithNoAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerWithNoAuthorizedServer(gconstpointer data)
@@ -680,7 +680,7 @@ void test_getTriggerWithNoAuthorizedServer(gconstpointer data)
 
 void data_getTriggerWithInvalidUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerWithInvalidUserId(gconstpointer data)
@@ -692,7 +692,7 @@ void test_getTriggerWithInvalidUserId(gconstpointer data)
 
 void data_itemInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemInfoList(gconstpointer data)
@@ -702,7 +702,7 @@ void test_itemInfoList(gconstpointer data)
 
 void data_itemInfoListForOneServer(gconstpointer data)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemInfoListForOneServer(gconstpointer data)
@@ -713,7 +713,7 @@ void test_itemInfoListForOneServer(gconstpointer data)
 
 void data_addItemInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_addItemInfoList(gconstpointer data)
@@ -730,7 +730,7 @@ void test_addItemInfoList(gconstpointer data)
 
 void data_getItemsWithOneAuthorizedServer(gconstpointer data)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getItemsWithOneAuthorizedServer(gconstpointer data)
@@ -742,7 +742,7 @@ void test_getItemsWithOneAuthorizedServer(gconstpointer data)
 
 void data_getItemWithNoAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getItemWithNoAuthorizedServer(gconstpointer data)
@@ -754,7 +754,7 @@ void test_getItemWithNoAuthorizedServer(gconstpointer data)
 
 void data_getItemWithInvalidUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getItemWithInvalidUserId(gconstpointer data)
@@ -766,7 +766,7 @@ void test_getItemWithInvalidUserId(gconstpointer data)
 
 void data_getItemWithItemGroupName(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getItemWithItemGroupName(gconstpointer data)
@@ -778,7 +778,7 @@ void test_getItemWithItemGroupName(gconstpointer data)
 
 void data_getNumberOfItemsWithOneAuthorizedServer(gconstpointer data)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getNumberOfItemsWithOneAuthorizedServer(gconstpointer data)
@@ -790,7 +790,7 @@ void test_getNumberOfItemsWithOneAuthorizedServer(gconstpointer data)
 
 void data_getNumberOfItemWithNoAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getNumberOfItemWithNoAuthorizedServer(gconstpointer data)
@@ -802,7 +802,7 @@ void test_getNumberOfItemWithNoAuthorizedServer(gconstpointer data)
 
 void data_getNumberOfItemWithInvalidUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getNumberOfItemWithInvalidUserId(gconstpointer data)
@@ -814,7 +814,7 @@ void test_getNumberOfItemWithInvalidUserId(gconstpointer data)
 
 void data_getNumberOfItemsWithItemGroupName(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getNumberOfItemsWithItemGroupName(gconstpointer data)
@@ -826,7 +826,7 @@ void test_getNumberOfItemsWithItemGroupName(gconstpointer data)
 
 void data_addEventInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_addEventInfoList(gconstpointer data)
@@ -875,7 +875,7 @@ void test_addEventInfoUnifiedId(void)
 
 void data_addDupEventInfoList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_addDupEventInfoList(gconstpointer data)
@@ -895,7 +895,7 @@ void test_addDupEventInfoList(gconstpointer data)
 
 void data_getLastEventId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getMaxEventId(gconstpointer data)
@@ -1114,7 +1114,7 @@ void test_getNumberOfBadHostsWithOneAuthorizedServer(void)
 
 void test_getEventSortAscending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventSortAscending(gconstpointer data)
@@ -1126,7 +1126,7 @@ void test_getEventSortAscending(gconstpointer data)
 
 void data_getEventSortDescending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventSortDescending(gconstpointer data)
@@ -1138,7 +1138,7 @@ void test_getEventSortDescending(gconstpointer data)
 
 void data_getEventWithMaximumNumber(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMaximumNumber(gconstpointer data)
@@ -1153,7 +1153,7 @@ void test_getEventWithMaximumNumber(gconstpointer data)
 
 void data_getEventWithMaximumNumberDescending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMaximumNumberDescending(gconstpointer data)
@@ -1166,7 +1166,7 @@ void test_getEventWithMaximumNumberDescending(gconstpointer data)
 
 void data_getEventWithMaximumNumberAndOffsetAscending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMaximumNumberAndOffsetAscending(gconstpointer data)
@@ -1180,7 +1180,7 @@ void test_getEventWithMaximumNumberAndOffsetAscending(gconstpointer data)
 
 void data_getEventWithMaximumNumberAndOffsetDescending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMaximumNumberAndOffsetDescending(gconstpointer data)
@@ -1194,7 +1194,7 @@ void test_getEventWithMaximumNumberAndOffsetDescending(gconstpointer data)
 
 void data_getEventWithLimitOfUnifiedIdAscending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithLimitOfUnifiedIdAscending(gconstpointer data)
@@ -1207,7 +1207,7 @@ void test_getEventWithLimitOfUnifiedIdAscending(gconstpointer data)
 
 void data_getEventWithSortTimeAscending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithSortTimeAscending(gconstpointer data)
@@ -1220,7 +1220,7 @@ void test_getEventWithSortTimeAscending(gconstpointer data)
 
 void data_getEventWithSortTimeDescending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithSortTimeDescending(gconstpointer data)
@@ -1233,7 +1233,7 @@ void test_getEventWithSortTimeDescending(gconstpointer data)
 
 void data_getEventWithOffsetWithoutLimit(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithOffsetWithoutLimit(gconstpointer data)
@@ -1246,7 +1246,7 @@ void test_getEventWithOffsetWithoutLimit(gconstpointer data)
 
 void data_getEventWithMaxNumAndOffsetAndLimitOfUnifiedIdDescending(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMaxNumAndOffsetAndLimitOfUnifiedIdDescending(
@@ -1262,7 +1262,7 @@ void test_getEventWithMaxNumAndOffsetAndLimitOfUnifiedIdDescending(
 
 void data_getEventWithOneAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithOneAuthorizedServer(gconstpointer data)
@@ -1274,7 +1274,7 @@ void test_getEventWithOneAuthorizedServer(gconstpointer data)
 
 void data_getEventWithNoAuthorizedServer(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithNoAuthorizedServer(gconstpointer data)
@@ -1286,7 +1286,7 @@ void test_getEventWithNoAuthorizedServer(gconstpointer data)
 
 void data_getEventWithInvalidUserId(gconstpointer data)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithInvalidUserId(gconstpointer data)
@@ -1298,7 +1298,7 @@ void test_getEventWithInvalidUserId(gconstpointer data)
 
 void data_getEventWithEventType(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithEventType(gconstpointer data)
@@ -1310,7 +1310,7 @@ void test_getEventWithEventType(gconstpointer data)
 
 void data_getEventWithMinSeverity(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithMinSeverity(gconstpointer data)
@@ -1322,7 +1322,7 @@ void test_getEventWithMinSeverity(gconstpointer data)
 
 void data_getEventWithTriggerStatus(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithTriggerStatus(gconstpointer data)
@@ -1334,7 +1334,7 @@ void test_getEventWithTriggerStatus(gconstpointer data)
 
 void data_getEventWithTimeRange(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithTimeRange(gconstpointer data)
@@ -1347,7 +1347,7 @@ void test_getEventWithTimeRange(gconstpointer data)
 
 void data_getEventsWithIncidentInfo(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventsWithIncidentInfo(gconstpointer data)
@@ -1359,7 +1359,7 @@ void test_getEventsWithIncidentInfo(gconstpointer data)
 
 void data_getEventsWithIncidentInfoByAuthorizedUser(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventsWithIncidentInfoByAuthorizedUser(gconstpointer data)
@@ -1372,7 +1372,7 @@ void test_getEventsWithIncidentInfoByAuthorizedUser(gconstpointer data)
 
 void data_getEventWithTriggerId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventWithTriggerId(gconstpointer data)

--- a/server/test/testDBTablesMonitoring.h
+++ b/server/test/testDBTablesMonitoring.h
@@ -44,7 +44,7 @@ struct AssertGetHostResourceArg {
 	const TResourceType *fixtures;
 	size_t numberOfFixtures;
 	gconstpointer ddtParam;
-	bool filterForDataOfDefunctSv;
+	bool excludeDefunctServers;
 	bool assertContent;
 
 	AssertGetHostResourceArg(void)
@@ -60,7 +60,7 @@ struct AssertGetHostResourceArg {
 	  fixtures(NULL),
 	  numberOfFixtures(0),
 	  ddtParam(NULL),
-	  filterForDataOfDefunctSv(false),
+	  excludeDefunctServers(false),
 	  assertContent(true)
 	{
 	}
@@ -101,7 +101,7 @@ struct AssertGetHostResourceArg {
 
 	virtual bool filterOutExpectedRecord(const TResourceType *info)
 	{
-		if (filterForDataOfDefunctSv) {
+		if (excludeDefunctServers) {
 			if (!option.isValidServer(info->serverId))
 				return true;
 		}
@@ -179,10 +179,10 @@ struct AssertGetHostResourceArg {
 	void setDataDrivenTestParam(gconstpointer _ddtParam)
 	{
 		ddtParam = _ddtParam;
-		filterForDataOfDefunctSv =
+		excludeDefunctServers =
 		  gcut_data_get_boolean(ddtParam,
-		                        "filterDataOfDefunctServers");
-		option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+		                        "excludeDefunctServers");
+		option.setExcludeDefunctServers(excludeDefunctServers);
 	}
 };
 
@@ -382,7 +382,7 @@ struct AssertGetEventsArg
 		for (size_t i = 0; i < numberOfFixtures; i++) {
 			if (!isAuthorized(fixtures[i]))
 				continue;
-			if (filterForDataOfDefunctSv &&
+			if (excludeDefunctServers &&
 			    !option.isValidServer(fixtures[i].serverId)) {
 				continue;
 			}

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -295,7 +295,7 @@ static void _assertEvents(const string &path, const string &callbackName = "")
 {
 	// build expected data
 	AssertGetEventsArg eventsArg(NULL);
-	eventsArg.filterForDataOfDefunctSv = true;
+	eventsArg.excludeDefunctServers = true;
 	eventsArg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	eventsArg.sortType = EventsQueryOption::SORT_TIME;
 	eventsArg.sortDirection = EventsQueryOption::SORT_DESCENDING;
@@ -580,7 +580,7 @@ void test_eventsForOneServerOneHost(void)
 {
 	// build expected data
 	AssertGetEventsArg eventsArg(NULL);
-	eventsArg.filterForDataOfDefunctSv = true;
+	eventsArg.excludeDefunctServers = true;
 	eventsArg.targetServerId = testEventInfo[1].serverId;
 	eventsArg.targetHostId = testEventInfo[1].hostIdInServer;
 	eventsArg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
@@ -600,7 +600,7 @@ void test_eventsForOneServerOneHost(void)
 void test_eventsWithTimeRange(void)
 {
 	AssertGetEventsArg eventsArg(NULL);
-	eventsArg.filterForDataOfDefunctSv = true;
+	eventsArg.excludeDefunctServers = true;
 	eventsArg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	eventsArg.sortType = EventsQueryOption::SORT_TIME;
 	eventsArg.sortDirection = EventsQueryOption::SORT_DESCENDING;

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -258,7 +258,7 @@ void cut_setup(void)
 // ---------------------------------------------------------------------------
 void data_makeSelectConditionUserAdmin(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_makeSelectConditionUserAdmin(gconstpointer data)
@@ -272,7 +272,7 @@ void test_makeSelectConditionUserAdmin(gconstpointer data)
 
 void data_makeSelectConditionAllEvents(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_makeSelectConditionAllEvents(gconstpointer data)
@@ -295,22 +295,22 @@ void test_makeSelectConditionNoneUser(void)
 
 void data_makeSelectCondition(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_makeSelectCondition(gconstpointer data)
 {
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
 	HostResourceQueryOption option(TEST_SYNAPSE);
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+	option.setExcludeDefunctServers(excludeDefunctServers);
 	for (size_t i = 0; i < NumTestUserInfo; i++) {
 		UserIdType userId = i + 1;
 		option.setUserId(userId);
 		string actual = option.getCondition();
 		string expect = makeExpectedConditionForUser(
 		                  userId, testUserInfo[i].flags);
-		if (filterForDataOfDefunctSv)
+		if (excludeDefunctServers)
 			insertValidServerCond(expect, option);
 		cppcut_assert_equal(expect, actual);
 	}
@@ -518,13 +518,13 @@ void test_getPrimaryTableName(void)
 	                    option.getPrimaryTableName());
 }
 
-void test_defaultValueOfFilterForDataOfDefunctServers(void)
+void test_defaultValueOfExcludeDefunctServers(void)
 {
 	HostResourceQueryOption opt(TEST_SYNAPSE);
-	cppcut_assert_equal(true, opt.getFilterForDataOfDefunctServers());
+	cppcut_assert_equal(true, opt.getExcludeDefunctServers());
 }
 
-void data_setGetOfFilterForDataOfDefunctServers(void)
+void data_setAndGetExcludeDefunctServers(void)
 {
 	gcut_add_datum("Disable filtering",
 	               "enable", G_TYPE_BOOLEAN, FALSE, NULL);
@@ -532,12 +532,12 @@ void data_setGetOfFilterForDataOfDefunctServers(void)
 	               "enable", G_TYPE_BOOLEAN, TRUE, NULL);
 }
 
-void test_setGetOfFilterForDataOfDefunctServers(gconstpointer data)
+void test_setAndGetExcludeDefunctServers(gconstpointer data)
 {
 	HostResourceQueryOption opt(TEST_SYNAPSE);
 	bool enable = gcut_data_get_boolean(data, "enable");
-	opt.setFilterForDataOfDefunctServers(enable);
-	cppcut_assert_equal(enable, opt.getFilterForDataOfDefunctServers());
+	opt.setExcludeDefunctServers(enable);
+	cppcut_assert_equal(enable, opt.getExcludeDefunctServers());
 }
 
 void test_makeConditionEmpty(void)
@@ -655,17 +655,17 @@ void test_makeConditionWithTargetServerAndHost(void)
 
 void data_conditionForAdminWithTargetServerAndHost(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_conditionForAdminWithTargetServerAndHost(gconstpointer data)
 {
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
-	if (filterForDataOfDefunctSv)
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
+	if (excludeDefunctServers)
 		cut_omit("To be implemented");
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+	option.setExcludeDefunctServers(excludeDefunctServers);
 	option.setTargetServerId(26);
 	option.setTargetHostId("32");
 	string expect = StringUtils::sprintf("%s=26 AND %s='32'",

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -179,7 +179,7 @@ void cut_setup(void)
 //
 void data_triggersQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionConstructorWithUserId(gconstpointer data)
@@ -189,7 +189,7 @@ void test_triggersQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_triggersQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionFromDataQueryContext(gconstpointer data)
@@ -199,7 +199,7 @@ void test_triggersQueryOptionFromDataQueryContext(gconstpointer data)
 
 void data_triggersQueryOptionCopyConstructor(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionCopyConstructor(gconstpointer data)
@@ -209,7 +209,7 @@ void test_triggersQueryOptionCopyConstructor(gconstpointer data)
 
 void data_triggersQueryOptionWithTargetId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionWithTargetId(gconstpointer data)
@@ -226,7 +226,7 @@ void test_triggersQueryOptionWithTargetId(gconstpointer data)
 
 void data_triggersQueryOptionDefaultMinimumSeverity(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionDefaultMinimumSeverity(gconstpointer data)
@@ -241,7 +241,7 @@ void test_triggersQueryOptionDefaultMinimumSeverity(gconstpointer data)
 
 void data_triggersQueryOptionWithMinimumSeverity(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionWithMinimumSeverity(gconstpointer data)
@@ -257,7 +257,7 @@ void test_triggersQueryOptionWithMinimumSeverity(gconstpointer data)
 
 void data_triggersQueryOptionDefaultStatus(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionDefaultStatus(gconstpointer data)
@@ -272,7 +272,7 @@ void test_triggersQueryOptionDefaultStatus(gconstpointer data)
 
 void data_triggersQueryOptionWithStatus(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_triggersQueryOptionWithStatus(gconstpointer data)
@@ -291,7 +291,7 @@ void test_triggersQueryOptionWithStatus(gconstpointer data)
 //
 void data_eventQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionConstructorWithUserId(gconstpointer data)
@@ -301,7 +301,7 @@ void test_eventQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_eventQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionFromDataQueryContext(gconstpointer data)
@@ -311,7 +311,7 @@ void test_eventQueryOptionFromDataQueryContext(gconstpointer data)
 
 void data_eventQueryOptionCopyConstructor(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionCopyConstructor(gconstpointer data)
@@ -321,7 +321,7 @@ void test_eventQueryOptionCopyConstructor(gconstpointer data)
 
 void data_eventQueryOptionDefaultMinimumSeverity(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithNoSortType(void)
@@ -360,7 +360,7 @@ void test_eventQueryOptionWithSortTypeTime(void)
 
 void data_eventQueryOptionDefaultEventType(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionDefaultEentType(gconstpointer data)
@@ -375,7 +375,7 @@ void test_eventQueryOptionDefaultEentType(gconstpointer data)
 
 void data_eventQueryOptionWithEventType(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithEventType(gconstpointer data)
@@ -401,7 +401,7 @@ void test_eventQueryOptionDefaultMinimumSeverity(gconstpointer data)
 
 void data_eventQueryOptionWithMinimumSeverity(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithMinimumSeverity(gconstpointer data)
@@ -417,7 +417,7 @@ void test_eventQueryOptionWithMinimumSeverity(gconstpointer data)
 
 void data_eventQueryOptionDefaultTriggerStatus(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionDefaultTriggerStatus(gconstpointer data)
@@ -432,7 +432,7 @@ void test_eventQueryOptionDefaultTriggerStatus(gconstpointer data)
 
 void data_eventQueryOptionWithTriggerStatus(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithTriggerStatus(gconstpointer data)
@@ -448,7 +448,7 @@ void test_eventQueryOptionWithTriggerStatus(gconstpointer data)
 
 void data_eventQueryOptionGetServerIdColumnName(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionGetServerIdColumnName(gconstpointer data)
@@ -471,7 +471,7 @@ void test_eventQueryOptionGetServerIdColumnName(gconstpointer data)
 
 void data_eventQueryOptionWithBeginTime(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithBeginTime(gconstpointer data)
@@ -486,7 +486,7 @@ void test_eventQueryOptionWithBeginTime(gconstpointer data)
 
 void data_eventQueryOptionWithEndTime(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithEndTime(gconstpointer data)
@@ -501,7 +501,7 @@ void test_eventQueryOptionWithEndTime(gconstpointer data)
 
 void data_eventQueryOptionWithBeginTimeAndEndTime(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_eventQueryOptionWithBeginTimeAndEndTime(gconstpointer data)
@@ -544,7 +544,7 @@ void test_eventQueryOptionGetEndTime(void)
 //
 void data_itemsQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemsQueryOptionConstructorWithUserId(gconstpointer data)
@@ -554,7 +554,7 @@ void test_itemsQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_itemsQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemsQueryOptionFromDataQueryContext(gconstpointer data)
@@ -564,7 +564,7 @@ void test_itemsQueryOptionFromDataQueryContext(gconstpointer data)
 
 void data_itemsQueryOptionCopyConstructor(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemsQueryOptionCopyConstructor(gconstpointer data)
@@ -574,7 +574,7 @@ void test_itemsQueryOptionCopyConstructor(gconstpointer data)
 
 void data_itemsQueryOptionWithTargetId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemsQueryOptionWithTargetId(gconstpointer data)
@@ -591,7 +591,7 @@ void test_itemsQueryOptionWithTargetId(gconstpointer data)
 
 void data_itemsQueryOptionWithItemGroupName(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_itemsQueryOptionWithItemGroupName(gconstpointer data)
@@ -610,7 +610,7 @@ void test_itemsQueryOptionWithItemGroupName(gconstpointer data)
 //
 void data_hostsQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostsQueryOptionConstructorWithUserId(gconstpointer data)
@@ -620,7 +620,7 @@ void test_hostsQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_hostsQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostsQueryOptionFromDataQueryContext(gconstpointer data)
@@ -643,7 +643,7 @@ void test_hostsQueryOptionSetGetValidty(void)
 
 void data_hostsQueryOptionGetConditionForHostValid(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostsQueryOptionGetConditionForHostValid(gconstpointer data)
@@ -660,7 +660,7 @@ void test_hostsQueryOptionGetConditionForHostValid(gconstpointer data)
 //
 void data_hostgroupsQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostgroupsQueryOptionConstructorWithUserId(gconstpointer data)
@@ -670,7 +670,7 @@ void test_hostgroupsQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_hostgroupsQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostgroupsQueryOptionFromDataQueryContext(gconstpointer data)
@@ -684,7 +684,7 @@ void test_hostgroupsQueryOptionCallGetConditionFromUserWithoutAllServers(void)
 
 	const UserIdType userId = findUserWithout(OPPRVLG_GET_ALL_SERVER);
 	HostgroupsQueryOption option(userId);
-	option.setFilterForDataOfDefunctServers(false);
+	option.setExcludeDefunctServers(false);
 	const string actual = option.getCondition();
 	const string expect = "(server_id=1 AND id_in_server IN ('0','1'))";
 	cppcut_assert_equal(expect, actual);
@@ -695,7 +695,7 @@ void test_hostgroupsQueryOptionCallGetConditionFromUserWithoutAllServers(void)
 //
 void data_hostgroupMembersQueryOptionConstructorWithUserId(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostgroupMembersQueryOptionConstructorWithUserId(gconstpointer data)
@@ -706,7 +706,7 @@ void test_hostgroupMembersQueryOptionConstructorWithUserId(gconstpointer data)
 
 void data_hostgroupMembersQueryOptionFromDataQueryContext(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_hostgroupMembersQueryOptionFromDataQueryContext(gconstpointer data)

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -104,12 +104,12 @@ template<class T>
 static void collectValidResourceInfoString(
   vector<string> &outStringVect,
   const size_t &numTestResourceData, const T *testResourceData,
-  const bool &filterForDataOfDefunctSv, const DataQueryOption &option,
+  const bool &excludeDefunctServers, const DataQueryOption &option,
   string (*dumpResourceFunc)(const T &)) 
 {
 	for (size_t i = 0; i < numTestResourceData; i++) {
 		const T &testResource = testResourceData[i];
-		if (filterForDataOfDefunctSv) {
+		if (excludeDefunctServers) {
 			if (!option.isValidServer(testResource.serverId))
 				continue;
 		}
@@ -154,24 +154,24 @@ void test_singleton(void) {
 
 void data_getTriggerList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getTriggerList(gconstpointer data)
 {
 	loadTestDBTriggers();
 
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
 	vector<string> expectedStrVec;
 	TriggersQueryOption option(USER_ID_SYSTEM);
 	collectValidResourceInfoString<TriggerInfo>(
 	  expectedStrVec, NumTestTriggerInfo, testTriggerInfo,
-	  filterForDataOfDefunctSv, option, dumpTriggerInfo);
+	  excludeDefunctServers, option, dumpTriggerInfo);
 	
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	TriggerInfoList list;
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+	option.setExcludeDefunctServers(excludeDefunctServers);
 	dataStore->getTriggerList(list, option);
 
 	assertLines<TriggerInfo>(expectedStrVec, list, dumpTriggerInfo);
@@ -179,7 +179,7 @@ void test_getTriggerList(gconstpointer data)
 
 void data_getEventList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getEventList(gconstpointer data)
@@ -187,17 +187,17 @@ void test_getEventList(gconstpointer data)
 	loadTestDBTriggers();
 	loadTestDBEvents();
 
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
 	vector<string> expectedStrVec;
 	EventsQueryOption option(USER_ID_SYSTEM);
 	collectValidResourceInfoString<EventInfo>(
 	  expectedStrVec, NumTestEventInfo, testEventInfo,
-	  filterForDataOfDefunctSv, option, dumpEventInfo);
+	  excludeDefunctServers, option, dumpEventInfo);
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	EventInfoList list;
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+	option.setExcludeDefunctServers(excludeDefunctServers);
 	dataStore->getEventList(list, option);
 
 	assertLines<EventInfo>(expectedStrVec, list, dumpEventInfo);
@@ -205,24 +205,24 @@ void test_getEventList(gconstpointer data)
 
 void data_getItemList(void)
 {
-	prepareTestDataForFilterForDataOfDefunctServers();
+	prepareTestDataExcludeDefunctServers();
 }
 
 void test_getItemList(gconstpointer data)
 {
 	loadTestDBItems();
 
-	const bool filterForDataOfDefunctSv =
-	  gcut_data_get_boolean(data, "filterDataOfDefunctServers");
+	const bool excludeDefunctServers =
+	  gcut_data_get_boolean(data, "excludeDefunctServers");
 	ItemsQueryOption option(USER_ID_SYSTEM);
 	vector<string> expectedStrVec;
 	collectValidResourceInfoString<ItemInfo>(
 	  expectedStrVec, NumTestItemInfo, testItemInfo,
-	  filterForDataOfDefunctSv, option, dumpItemInfo);
+	  excludeDefunctServers, option, dumpItemInfo);
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	ItemInfoList list;
-	option.setFilterForDataOfDefunctServers(filterForDataOfDefunctSv);
+	option.setExcludeDefunctServers(excludeDefunctServers);
 	dataStore->getItemList(list, option);
 
 	assertLines<ItemInfo>(expectedStrVec, list, dumpItemInfo);


### PR DESCRIPTION
{get,set}FilterForDataOfDefunctServers ->
{get,set}ExcludeDefunctServers

Because the word "filter" doesn't indicate the meaning "exclude",
it's hard to recognize its behaviour.
In addition, the term "dataOf" is verbose in this context.