### PR TITLE
[hap2] Fix the typo in the option usage.

### DIFF
--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -43,7 +43,7 @@ class StandardHap:
         parser.add_argument("-p", "--disable-poller", action="store_true")
 
         help_msg = """
-            Minimum status logger.interval in seconds.
+            Minimum status logging interval in seconds.
             The actual interval depends on the implementation and is
             typically larger than this parameter.
             """


### PR DESCRIPTION
This has been contaminated in the patch that replaces logging with logger.