### PR TITLE
Suppress warning of host cache #1424 2

### DIFF
--- a/server/src/HostInfoCache.cc
+++ b/server/src/HostInfoCache.cc
@@ -132,6 +132,7 @@ void HostInfoCache::registerAdHoc(const LocalHostIdType &idInServer,
                                   const string &name, Element &elem)
 {
 	ServerHostDef svHostDef;
+	svHostDef.id             = -1;
 	svHostDef.hostId         = INVALID_HOST_ID;
 	svHostDef.serverId       = INVALID_SERVER_ID;
 	svHostDef.hostIdInServer = idInServer;

--- a/server/src/HostInfoCache.cc
+++ b/server/src/HostInfoCache.cc
@@ -61,7 +61,7 @@ HostInfoCache::~HostInfoCache()
 }
 
 void HostInfoCache::update(const ServerHostDef &svHostDef,
-                           const HostIdType &hostId)
+                           const HostIdType &hostId, const bool &adhoc)
 {
 	bool doUpdate = true;
 	m_impl->lock.writeLock();
@@ -78,7 +78,7 @@ void HostInfoCache::update(const ServerHostDef &svHostDef,
 		elem.hostId =
 		  (hostId != INVALID_HOST_ID) ? hostId : svHostDef.hostId;
 		elem.name = svHostDef.name;
-		HATOHOL_ASSERT(elem.hostId != INVALID_HOST_ID,
+		HATOHOL_ASSERT(adhoc || elem.hostId != INVALID_HOST_ID,
 		               "INVALID_HOST_ID: server: %d, host: %s\n",
 		               svHostDef.serverId,
 		               svHostDef.hostIdInServer.c_str());
@@ -126,6 +126,21 @@ bool HostInfoCache::getName(
 	}
 	m_impl->lock.unlock();
 	return found;
+}
+
+void HostInfoCache::registerAdHoc(const LocalHostIdType &idInServer,
+                                  const string &name, Element &elem)
+{
+	ServerHostDef svHostDef;
+	svHostDef.hostId         = INVALID_HOST_ID;
+	svHostDef.serverId       = INVALID_SERVER_ID;
+	svHostDef.hostIdInServer = idInServer;
+	svHostDef.name           = name;
+	svHostDef.status         = HOST_STAT_INAPPLICABLE;
+	update(svHostDef, INVALID_HOST_ID, true);
+
+	elem.hostId = svHostDef.hostId;
+	elem.name   = svHostDef.name;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/HostInfoCache.h
+++ b/server/src/HostInfoCache.h
@@ -37,7 +37,8 @@ public:
 	HostInfoCache(const ServerIdType *serverId = NULL);
 	virtual ~HostInfoCache();
 	void update(const ServerHostDef &svHostDef,
-	            const HostIdType &hostId = INVALID_HOST_ID);
+	            const HostIdType &hostId = INVALID_HOST_ID,
+	            const bool &adhoc = false);
 	void update(const ServerHostDefVect &svHostDefs,
 	            const HostHostIdMap *hostHostIdMapPtr = NULL);
 
@@ -50,6 +51,19 @@ public:
 	 * @return true if the host is found, or false.
 	 */
 	bool getName(const LocalHostIdType &idInServer, Element &elem) const;
+
+	/**
+	 * Register host information temporarily.
+	 *
+	 * The host is typically supposed not to be stored in the DB.
+	 *
+	 * @param idInServer A target host ID in the server.
+	 * @param name       A host name
+	 * @param elem
+	 * The information about the host is stored in this paramter.
+	 */
+	void registerAdHoc(const LocalHostIdType &idInServer,
+	                   const std::string &name, Element &elem);
 
 private:
 	struct Impl;

--- a/server/test/testHostInfoCache.cc
+++ b/server/test/testHostInfoCache.cc
@@ -128,4 +128,20 @@ void test_getNameFromMany(void)
 	}
 }
 
+void test_registerAdHoc(void)
+{
+	HostInfoCache hiCache;
+	HostInfoCache::Element elem;
+	const LocalHostIdType hostIdInServer = "host ideee";
+	const string name = "onamae";
+	hiCache.registerAdHoc(hostIdInServer, name, elem);
+	cppcut_assert_equal(INVALID_HOST_ID, elem.hostId);
+	cppcut_assert_equal(name, elem.name);
+
+	HostInfoCache::Element elem2;
+	cppcut_assert_equal(true, hiCache.getName(hostIdInServer, elem2));
+	cppcut_assert_equal(INVALID_HOST_ID, elem2.hostId);
+	cppcut_assert_equal(name, elem2.name);
+}
+
 } // namespace testHostInfoCache


### PR DESCRIPTION
This pull request suppress warning of HostInfoCache.
The warning is shown when the correspond host is not found in the DB.
However, some HAPs such as hap2_fluentd.py doesn't send host information.
In that case, the warning is shown repeatedly. The patches automatically
unknown hosts register in HostInfoCache ad hoc.