### PR TITLE
[HostResourceQueryOption] Filter by plural {servers,hostgroups,hosts}

### DIFF
--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -200,6 +200,10 @@ typedef std::set<HostIdType>      HostIdSet;
 typedef HostIdSet::iterator       HostIdSetIterator;
 typedef HostIdSet::const_iterator HostIdSetConstIterator;
 
+typedef std::set<LocalHostIdType>      LocalHostIdSet;
+typedef LocalHostIdSet::iterator       LocalHostIdSetIterator;
+typedef LocalHostIdSet::const_iterator LocalHostIdSetConstIterator;
+
 typedef std::set<IncidentTrackerIdType>      IncidentTrackerIdSet;
 typedef IncidentTrackerIdSet::iterator       IncidentTrackerIdSetIterator;
 typedef IncidentTrackerIdSet::const_iterator IncidentTrackerIdSetConstIterator;
@@ -213,7 +217,7 @@ typedef std::map<ServerIdType, HostgroupIdSet> ServerHostGrpSetMap;
 typedef ServerHostGrpSetMap::iterator       ServerHostGrpSetMapIterator;
 typedef ServerHostGrpSetMap::const_iterator ServerHostGrpSetMapConstIterator;
 
-typedef std::map<ServerIdType, HostIdSet> ServerHostSetMap;
+typedef std::map<ServerIdType, LocalHostIdSet> ServerHostSetMap;
 typedef ServerHostSetMap::iterator       ServerHostSetMapIterator;
 typedef ServerHostSetMap::const_iterator ServerHostSetMapConstIterator;
 

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -213,6 +213,10 @@ typedef std::map<ServerIdType, HostgroupIdSet> ServerHostGrpSetMap;
 typedef ServerHostGrpSetMap::iterator       ServerHostGrpSetMapIterator;
 typedef ServerHostGrpSetMap::const_iterator ServerHostGrpSetMapConstIterator;
 
+typedef std::map<ServerIdType, HostIdSet> ServerHostSetMap;
+typedef ServerHostSetMap::iterator       ServerHostSetMapIterator;
+typedef ServerHostSetMap::const_iterator ServerHostSetMapConstIterator;
+
 typedef std::vector<ItemCategoryIdType>      ItemCategoryIdVector;
 typedef ItemCategoryIdVector::iterator       ItemCategoryIdVecotrIterator;
 typedef ItemCategoryIdVector::const_iterator ItemCategoryIdVecotrConstIterator;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -66,6 +66,7 @@ struct HostResourceQueryOption::Impl {
 	LocalHostIdType targetHostId;
 	HostgroupIdType targetHostgroupId;
 	bool            excludeDefunctServers;
+	list<ServerIdType> excludeServerIdList;
 
 	Impl(const Synapse &_synapse)
 	: synapse(_synapse),
@@ -281,6 +282,18 @@ void HostResourceQueryOption::setExcludeDefunctServers(
 const bool &HostResourceQueryOption::getExcludeDefunctServers(void) const
 {
 	return m_impl->excludeDefunctServers;
+}
+
+void HostResourceQueryOption::setExcludeServerIdList(
+  const std::list<ServerIdType> &serverIdList)
+{
+	m_impl->excludeServerIdList = serverIdList;
+}
+
+const std::list<ServerIdType> &
+HostResourceQueryOption::getExcludeServerIdList(void)
+{
+	return m_impl->excludeServerIdList;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -138,14 +138,14 @@ string HostResourceQueryOption::getCondition(void) const
 	if (!has(OPPRVLG_GET_ALL_SERVER)) {
 		string allowedHostsCondition =
 		  makeConditionAllowedHosts(getAllowedServersAndHostgroups());
+
 		if (DBHatohol::isAlwaysFalseCondition(allowedHostsCondition))
 			return DBHatohol::getAlwaysFalseCondition();
+
 		addCondition(condition, allowedHostsCondition);
 	}
-	addCondition(condition, makeConditionTargetIds(),
-		     ADD_TYPE_AND, true);
-	addCondition(condition, makeConditionServersFilter(),
-		     ADD_TYPE_AND, true);
+	addCondition(condition, makeConditionTargetIds());
+	addCondition(condition, makeConditionServersFilter());
 
 	return condition;
 }
@@ -346,7 +346,9 @@ string HostResourceQueryOption::makeConditionTargetIds(void) const
 		    rhs(m_impl->targetHostgroupId)));
 	}
 
-	return condition;
+	if (condition.empty())
+		return condition;
+	return StringUtils::sprintf("(%s)", condition.c_str());
 }
 
 string HostResourceQueryOption::makeConditionHostgroup(
@@ -574,5 +576,7 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 		}
 	}
 
-	return condition;
+	if (condition.empty())
+		return condition;
+	return StringUtils::sprintf("(%s)", condition.c_str());
 }

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -132,15 +132,15 @@ string HostResourceQueryOption::getCondition(void) const
 	string condition;
 
 	if (getExcludeDefunctServers()) {
-		addCondition(
-		  condition,
+		string validServersCondition(
 		  makeConditionServer(
 		    getDataQueryContext().getValidServerIdSet(),
 		    getServerIdColumnName()));
+		addCondition(condition, validServersCondition);
 	}
 
 	if (!has(OPPRVLG_GET_ALL_SERVER)) {
-		string allowedHostsCondition = makeConditionAllowedHosts();
+		string allowedHostsCondition(makeConditionAllowedHosts());
 
 		if (DBHatohol::isAlwaysFalseCondition(allowedHostsCondition))
 			return allowedHostsCondition;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -139,6 +139,7 @@ string HostResourceQueryOption::getCondition(void) const
 {
 	string condition;
 
+	// Select only alive servers
 	if (getExcludeDefunctServers()) {
 		string validServersCondition(
 		  makeConditionServer(getValidServerIdSet(),
@@ -146,6 +147,7 @@ string HostResourceQueryOption::getCondition(void) const
 		addCondition(condition, validServersCondition);
 	}
 
+	// Select only allowed servers and hostgroups
 	if (!has(OPPRVLG_GET_ALL_SERVER)) {
 		string allowedHostsCondition(makeConditionAllowedHosts());
 
@@ -154,6 +156,8 @@ string HostResourceQueryOption::getCondition(void) const
 
 		addCondition(condition, allowedHostsCondition);
 	}
+
+	// Select servers, hostgroups and hosts sepcified by the caller
 	addCondition(condition, makeConditionTargetIds());
 	addCondition(condition, makeConditionFilter());
 

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -603,6 +603,9 @@ HostResourceQueryOption::getAllowedServersAndHostgroups(void) const
 
 string HostResourceQueryOption::makeConditionServersFilter(void) const
 {
+	if (m_impl->filterServerIdSet.empty())
+		return string();
+
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
 	if (m_impl->excludeServerIdSet) {
@@ -635,6 +638,9 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 
 string HostResourceQueryOption::makeConditionHostgroupsFilter(void) const
 {
+	if (m_impl->filterServerHostgroupSetMap.empty())
+		return string();
+
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
 	string serverIdColumnName = getServerIdColumnName();
@@ -678,6 +684,9 @@ string HostResourceQueryOption::makeConditionHostgroupsFilter(void) const
 
 string HostResourceQueryOption::makeConditionHostsFilter(void) const
 {
+	if (m_impl->filterServerHostSetMap.empty())
+		return string();
+
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
 	string serverIdColumnName = getServerIdColumnName();

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -66,8 +66,8 @@ struct HostResourceQueryOption::Impl {
 	LocalHostIdType targetHostId;
 	HostgroupIdType targetHostgroupId;
 	bool            excludeDefunctServers;
-	list<ServerIdType> filterServerIdList;
-	bool excludeServerIdList;
+	ServerIdSet filterServerIdSet;
+	bool excludeServerIdSet;
 	ServerHostGrpSetMap filterServerHostgroupSetMap;
 	bool excludeServerHostgroupSetMap;
 	ServerHostSetMap filterServerHostSetMap;
@@ -83,7 +83,7 @@ struct HostResourceQueryOption::Impl {
 	  targetHostId(ALL_LOCAL_HOSTS),
 	  targetHostgroupId(ALL_HOST_GROUPS),
 	  excludeDefunctServers(true),
-	  excludeServerIdList(false),
+	  excludeServerIdSet(false),
 	  excludeServerHostgroupSetMap(false),
 	  excludeServerHostSetMap(false),
 	  validServerIdSet(NULL),
@@ -266,18 +266,18 @@ const bool &HostResourceQueryOption::getExcludeDefunctServers(void) const
 	return m_impl->excludeDefunctServers;
 }
 
-void HostResourceQueryOption::setFilterServerIdList(
-  const std::list<ServerIdType> &serverIdList, const bool exclude)
+void HostResourceQueryOption::setFilterServerIds(
+  const ServerIdSet &serverIds, const bool exclude)
 {
-	m_impl->filterServerIdList = serverIdList;
-	m_impl->excludeServerIdList = exclude;
+	m_impl->filterServerIdSet = serverIds;
+	m_impl->excludeServerIdSet = exclude;
 }
 
-void HostResourceQueryOption::getFilterServerIdList(
-  std::list<ServerIdType> &serverIdList, bool &exclude)
+void HostResourceQueryOption::getFilterServerIds(
+  ServerIdSet &serverIds, bool &exclude)
 {
-	serverIdList = m_impl->filterServerIdList;
-	exclude = m_impl->excludeServerIdList;
+	serverIds = m_impl->filterServerIdSet;
+	exclude = m_impl->excludeServerIdSet;
 }
 
 void HostResourceQueryOption::setFilterHostgroupIds(
@@ -605,8 +605,8 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 {
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
-	if (m_impl->excludeServerIdList) {
-		for (auto &serverId: m_impl->filterServerIdList) {
+	if (m_impl->excludeServerIdSet) {
+		for (auto &serverId: m_impl->filterServerIdSet) {
 			if (!isAllowedServer(serverId))
 				continue;
 			addCondition(condition,
@@ -616,7 +616,7 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 				       serverId));
 		}
 	} else {
-		for (auto &serverId: m_impl->filterServerIdList) {
+		for (auto &serverId: m_impl->filterServerIdSet) {
 			addCondition(condition,
 				     StringUtils::sprintf(
 				       "%s=%" FMT_SERVER_ID,

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -209,7 +209,9 @@ bool HostResourceQueryOption::isHostgroupUsed(void) const
 		return false;
 	if (isHostgroupEnumerationInCondition())
 		return true;
-	return m_impl->targetHostgroupId != ALL_HOST_GROUPS;
+	return
+	  m_impl->targetHostgroupId != ALL_HOST_GROUPS ||
+	  !m_impl->filterServerHostgroupSetMap.empty();
 }
 
 string HostResourceQueryOption::getColumnName(const size_t &idx) const

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -273,6 +273,27 @@ void HostResourceQueryOption::getFilterServerIdList(
 	exclude =m_impl->excludeServerIdList;
 }
 
+void HostResourceQueryOption::setFilterHostgroupIdList(
+  const std::list<GenericIdType> &hostgroupIdList, const bool exculde)
+{
+}
+
+void HostResourceQueryOption::getFilterHostgroupIdList(
+  std::list<GenericIdType> &hostgroupIdList, bool &exclude)
+{
+}
+
+void HostResourceQueryOption::setFilterHostIdList(
+  const std::list<GenericIdType> &hostIdList, const bool exculde)
+{
+}
+
+void HostResourceQueryOption::getFilterHostIdList(
+  std::list<GenericIdType> &hostIdList, bool &exclude)
+{
+}
+
+
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -70,6 +70,7 @@ struct HostResourceQueryOption::Impl {
 	bool excludeServerIdList;
 
 	// TODO: Remove it, because it used only for tests
+	const ServerIdSet *validServerIdSet;
 	const ServerHostGrpSetMap *allowedServersAndHostgroups;
 
 	Impl(const Synapse &_synapse)
@@ -79,6 +80,7 @@ struct HostResourceQueryOption::Impl {
 	  targetHostgroupId(ALL_HOST_GROUPS),
 	  excludeDefunctServers(true),
 	  excludeServerIdList(false),
+	  validServerIdSet(NULL),
 	  allowedServersAndHostgroups(NULL)
 	{
 	}
@@ -133,9 +135,8 @@ string HostResourceQueryOption::getCondition(void) const
 
 	if (getExcludeDefunctServers()) {
 		string validServersCondition(
-		  makeConditionServer(
-		    getDataQueryContext().getValidServerIdSet(),
-		    getServerIdColumnName()));
+		  makeConditionServer(getValidServerIdSet(),
+				      getServerIdColumnName()));
 		addCondition(condition, validServersCondition);
 	}
 
@@ -571,6 +572,13 @@ string HostResourceQueryOption::getJoinClauseWithGlobalHostId(void) const
 	    synapse.hostgroupMapGlobalHostIdColumnIdx).c_str());
 }
 
+const ServerIdSet &HostResourceQueryOption::getValidServerIdSet(void) const
+{
+	if (m_impl->validServerIdSet)
+		return *m_impl->validServerIdSet;
+	return getDataQueryContext().getValidServerIdSet();
+}
+
 const ServerHostGrpSetMap &
 HostResourceQueryOption::getAllowedServersAndHostgroups(void) const
 {
@@ -610,6 +618,11 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 }
 
 // For test use only
+void HostResourceQueryOption::setValidServerIdSet(const ServerIdSet *set)
+{
+	m_impl->validServerIdSet = set;
+}
+
 void HostResourceQueryOption::setAllowedServersAndHostgroups (
   const ServerHostGrpSetMap *map)
 {

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -73,7 +73,7 @@ struct HostResourceQueryOption::Impl {
 	list<GenericIdType> filterHostIdList;
 	bool excludeHostIdList;
 
-	// TODO: Remove it, because it used only for tests
+	// For unit tests
 	const ServerIdSet *validServerIdSet;
 	const ServerHostGrpSetMap *allowedServersAndHostgroups;
 

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -434,11 +434,15 @@ string HostResourceQueryOption::makeConditionForNormalUser(
 	for (; it != allowedServersAndHostgroups.end(); ++it) {
 		const ServerIdType &serverId = it->first;
 
-		if (targetServerId != ALL_SERVERS && targetServerId != serverId)
+		if (targetServerId != ALL_SERVERS && targetServerId != serverId) {
+			// It isn't the target server.
 			continue;
+		}
 
-		if (serverId == ALL_SERVERS)
+		if (serverId == ALL_SERVERS) {
+			// All servers are allowed
 			return "";
+		}
 
 		string conditionServer = makeConditionServer(
 					   serverId, it->second,

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -299,6 +299,19 @@ bool HostResourceQueryOption::isAllowedServer(
 		allowedServersAndHostgroups.end();
 }
 
+bool HostResourceQueryOption::isAllowedHostgroup(
+  const ServerIdType &targetServerId,
+  const HostgroupIdType &targetHostgroupId) const
+{
+	const ServerHostGrpSetMap &allowedServersAndHostgroups =
+	  getAllowedServersAndHostgroups();
+	auto serverIt(allowedServersAndHostgroups.find(targetServerId));
+	if (serverIt != allowedServersAndHostgroups.end())
+		return false;
+	const HostgroupIdSet &hostgroupSet = serverIt->second;
+	return hostgroupSet.find(targetHostgroupId) != hostgroupSet.end();
+}
+
 string HostResourceQueryOption::makeConditionForPrivilegedUser(void) const
 {
 	string condition;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -290,6 +290,15 @@ string HostResourceQueryOption::getHostIdColumnName(void) const
 	                           m_impl->synapse.hostIdColumnIdx);
 }
 
+bool HostResourceQueryOption::isAllowedServer(
+  const ServerIdType &targetServerId) const
+{
+	const ServerHostGrpSetMap &allowedServersAndHostgroups =
+	  getAllowedServersAndHostgroups();
+	return allowedServersAndHostgroups.find(targetServerId) !=
+		allowedServersAndHostgroups.end();
+}
+
 string HostResourceQueryOption::makeConditionForPrivilegedUser(void) const
 {
 	string condition;
@@ -395,14 +404,6 @@ string HostResourceQueryOption::makeConditionServer(
 	}
 }
 
-static inline bool isAllowedServer(
-  const ServerHostGrpSetMap &allowedServersAndHostgroups,
-  const ServerIdType &targetServerId)
-{
-	return allowedServersAndHostgroups.find(targetServerId)
-		!= allowedServersAndHostgroups.end();
-}
-
 string HostResourceQueryOption::makeConditionForNormalUser(
   const ServerHostGrpSetMap &allowedServersAndHostgroups) const
 {
@@ -430,9 +431,7 @@ string HostResourceQueryOption::makeConditionForNormalUser(
 		return DBHatohol::getAlwaysFalseCondition();
 	}
 
-	if (targetServerId != ALL_SERVERS &&
-	    !isAllowedServer(allowedServersAndHostgroups, targetServerId))
-	{
+	if (targetServerId != ALL_SERVERS && !isAllowedServer(targetServerId)) {
 		return DBHatohol::getAlwaysFalseCondition();
 	}
 

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -140,8 +140,7 @@ string HostResourceQueryOption::getCondition(void) const
 	}
 
 	if (!has(OPPRVLG_GET_ALL_SERVER)) {
-		string allowedHostsCondition =
-		  makeConditionAllowedHosts();
+		string allowedHostsCondition = makeConditionAllowedHosts();
 
 		if (DBHatohol::isAlwaysFalseCondition(allowedHostsCondition))
 			return DBHatohol::getAlwaysFalseCondition();

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -148,36 +148,6 @@ string HostResourceQueryOption::getCondition(void) const
 	}
 }
 
-string HostResourceQueryOption::makeConditionForPrivilegedUser(void) const
-{
-	string condition;
-	DBTermCStringProvider rhs(*getDBTermCodec());
-
-	if (m_impl->targetServerId != ALL_SERVERS) {
-		addCondition(condition,
-		  StringUtils::sprintf(
-		    "%s=%s",
-		    getServerIdColumnName().c_str(),
-		    rhs(m_impl->targetServerId)));
-	}
-	if (m_impl->targetHostId != ALL_LOCAL_HOSTS) {
-		addCondition(condition,
-		  StringUtils::sprintf(
-		    "%s=%s",
-		    getHostIdColumnName().c_str(),
-		    rhs(m_impl->targetHostId)));
-	}
-	if (m_impl->targetHostgroupId != ALL_HOST_GROUPS) {
-		addCondition(condition,
-		  StringUtils::sprintf(
-		    "%s=%s",
-		    getHostgroupIdColumnName().c_str(),
-		    rhs(m_impl->targetHostgroupId)));
-	}
-
-	return condition;
-}
-
 string HostResourceQueryOption::getFromClause(void) const
 {
 	if (isHostgroupUsed())
@@ -314,6 +284,36 @@ string HostResourceQueryOption::getHostIdColumnName(void) const
 {
 	return getColumnNameCommon(m_impl->synapse.hostTableProfile,
 	                           m_impl->synapse.hostIdColumnIdx);
+}
+
+string HostResourceQueryOption::makeConditionForPrivilegedUser(void) const
+{
+	string condition;
+	DBTermCStringProvider rhs(*getDBTermCodec());
+
+	if (m_impl->targetServerId != ALL_SERVERS) {
+		addCondition(condition,
+		  StringUtils::sprintf(
+		    "%s=%s",
+		    getServerIdColumnName().c_str(),
+		    rhs(m_impl->targetServerId)));
+	}
+	if (m_impl->targetHostId != ALL_LOCAL_HOSTS) {
+		addCondition(condition,
+		  StringUtils::sprintf(
+		    "%s=%s",
+		    getHostIdColumnName().c_str(),
+		    rhs(m_impl->targetHostId)));
+	}
+	if (m_impl->targetHostgroupId != ALL_HOST_GROUPS) {
+		addCondition(condition,
+		  StringUtils::sprintf(
+		    "%s=%s",
+		    getHostgroupIdColumnName().c_str(),
+		    rhs(m_impl->targetHostgroupId)));
+	}
+
+	return condition;
 }
 
 string HostResourceQueryOption::makeConditionHostgroup(

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -68,6 +68,10 @@ struct HostResourceQueryOption::Impl {
 	bool            excludeDefunctServers;
 	list<ServerIdType> filterServerIdList;
 	bool excludeServerIdList;
+	list<GenericIdType> filterHostgroupIdList;
+	bool excludeHostgroupIdList;
+	list<GenericIdType> filterHostIdList;
+	bool excludeHostIdList;
 
 	// TODO: Remove it, because it used only for tests
 	const ServerIdSet *validServerIdSet;
@@ -80,6 +84,8 @@ struct HostResourceQueryOption::Impl {
 	  targetHostgroupId(ALL_HOST_GROUPS),
 	  excludeDefunctServers(true),
 	  excludeServerIdList(false),
+	  excludeHostgroupIdList(false),
+	  excludeHostIdList(false),
 	  validServerIdSet(NULL),
 	  allowedServersAndHostgroups(NULL)
 	{
@@ -271,27 +277,35 @@ void HostResourceQueryOption::getFilterServerIdList(
   std::list<ServerIdType> &serverIdList, bool &exclude)
 {
 	serverIdList = m_impl->filterServerIdList;
-	exclude =m_impl->excludeServerIdList;
+	exclude = m_impl->excludeServerIdList;
 }
 
 void HostResourceQueryOption::setFilterHostgroupIdList(
-  const std::list<GenericIdType> &hostgroupIdList, const bool exculde)
+  const std::list<GenericIdType> &hostgroupIdList, const bool exclude)
 {
+	m_impl->filterHostgroupIdList = hostgroupIdList;
+	m_impl->excludeHostgroupIdList = exclude;
 }
 
 void HostResourceQueryOption::getFilterHostgroupIdList(
   std::list<GenericIdType> &hostgroupIdList, bool &exclude)
 {
+	hostgroupIdList = m_impl->filterHostgroupIdList;
+	exclude = m_impl->excludeHostgroupIdList;
 }
 
 void HostResourceQueryOption::setFilterHostIdList(
-  const std::list<GenericIdType> &hostIdList, const bool exculde)
+  const std::list<GenericIdType> &hostIdList, const bool exclude)
 {
+	m_impl->filterHostIdList = hostIdList;
+	m_impl->excludeHostIdList = exclude;
 }
 
 void HostResourceQueryOption::getFilterHostIdList(
   std::list<GenericIdType> &hostIdList, bool &exclude)
 {
+	hostIdList = m_impl->filterHostIdList;
+	exclude = m_impl->excludeHostIdList;
 }
 
 

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -529,3 +529,17 @@ HostResourceQueryOption::getAllowedServersAndHostgroups(void) const
 {
 	return getDataQueryContext().getServerHostGrpSetMap();
 }
+
+string HostResourceQueryOption::makeConditionExcludeServers() const
+{
+	DBTermCStringProvider rhs(*getDBTermCodec());
+	string condition;
+	for (auto &serverId: m_impl->excludeServerIdList) {
+		addCondition(condition,
+			     StringUtils::sprintf(
+			       "%s<>%" FMT_SERVER_ID,
+			       getServerIdColumnName().c_str(),
+			       serverId));
+	}
+	return condition;
+}

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -525,83 +525,6 @@ string HostResourceQueryOption::makeConditionAllowedHosts(void) const
 	return StringUtils::sprintf("(%s)", condition.c_str());
 }
 
-string HostResourceQueryOption::getFromClauseForOneTable(void) const
-{
-	return getPrimaryTableName();
-}
-
-string HostResourceQueryOption::getFromClauseWithHostgroup(void) const
-{
-	const Synapse &synapse = m_impl->synapse;
-
-	return StringUtils::sprintf(
-	  "%s %s",
-	  synapse.tableProfile.name,
-	  getJoinClause().c_str());
-}
-
-string HostResourceQueryOption::getColumnNameCommon(
-  const DBAgent::TableProfile &tableProfile, const size_t &idx) const
-{
-	HATOHOL_ASSERT(idx < tableProfile.numColumns,
-	               "idx: %zd, numColumns: %zd, table: %s",
-	               idx, tableProfile.numColumns, tableProfile.name);
-	string name;
-	if (getTableNameAlways() || isHostgroupUsed()) {
-		name = tableProfile.getFullColumnName(idx);
-	} else {
-		const ColumnDef *columnDefs = tableProfile.columnDefs;
-		name = columnDefs[idx].columnName;
-	}
-	return name;
-}
-
-bool HostResourceQueryOption::isHostgroupEnumerationInCondition(void) const
-{
-	if (has(OPPRVLG_GET_ALL_SERVER))
-		return false;
-	const ServerHostGrpSetMap &allowedServersAndHostgroups =
-	  getAllowedServersAndHostgroups();
-	ServerHostGrpSetMapConstIterator it
-	  = allowedServersAndHostgroups.begin();
-	for (; it != allowedServersAndHostgroups.end(); ++it) {
-		const ServerIdType &serverId = it->first;
-		if (serverId == ALL_SERVERS)
-			continue;
-		const HostgroupIdSet &hostgrpIdSet = it->second;
-		if (hostgrpIdSet.find(ALL_HOST_GROUPS) == hostgrpIdSet.end())
-			return true;
-	}
-	return false;
-}
-
-string HostResourceQueryOption::getJoinClauseWithGlobalHostId(void) const
-{
-	const Synapse &synapse = m_impl->synapse;
-	return StringUtils::sprintf(
-	  "INNER JOIN %s ON %s=%s",
-	  synapse.hostgroupMapTableProfile.name,
-	  synapse.tableProfile.getFullColumnName(
-	    synapse.globalHostIdColumnIdx).c_str(),
-	  synapse.hostgroupMapTableProfile.getFullColumnName(
-	    synapse.hostgroupMapGlobalHostIdColumnIdx).c_str());
-}
-
-const ServerIdSet &HostResourceQueryOption::getValidServerIdSet(void) const
-{
-	if (m_impl->validServerIdSet)
-		return *m_impl->validServerIdSet;
-	return getDataQueryContext().getValidServerIdSet();
-}
-
-const ServerHostGrpSetMap &
-HostResourceQueryOption::getAllowedServersAndHostgroups(void) const
-{
-	if (m_impl->allowedServersAndHostgroups)
-		return *m_impl->allowedServersAndHostgroups;
-	return getDataQueryContext().getServerHostGrpSetMap();
-}
-
 string HostResourceQueryOption::makeConditionServersFilter(void) const
 {
 	if (m_impl->filterServerIdSet.empty())
@@ -766,6 +689,83 @@ string HostResourceQueryOption::makeConditionFilter(void) const
 		return StringUtils::sprintf("(%s)", condition.c_str());
 	else
 		return condition;
+}
+
+string HostResourceQueryOption::getFromClauseForOneTable(void) const
+{
+	return getPrimaryTableName();
+}
+
+string HostResourceQueryOption::getFromClauseWithHostgroup(void) const
+{
+	const Synapse &synapse = m_impl->synapse;
+
+	return StringUtils::sprintf(
+	  "%s %s",
+	  synapse.tableProfile.name,
+	  getJoinClause().c_str());
+}
+
+string HostResourceQueryOption::getColumnNameCommon(
+  const DBAgent::TableProfile &tableProfile, const size_t &idx) const
+{
+	HATOHOL_ASSERT(idx < tableProfile.numColumns,
+	               "idx: %zd, numColumns: %zd, table: %s",
+	               idx, tableProfile.numColumns, tableProfile.name);
+	string name;
+	if (getTableNameAlways() || isHostgroupUsed()) {
+		name = tableProfile.getFullColumnName(idx);
+	} else {
+		const ColumnDef *columnDefs = tableProfile.columnDefs;
+		name = columnDefs[idx].columnName;
+	}
+	return name;
+}
+
+bool HostResourceQueryOption::isHostgroupEnumerationInCondition(void) const
+{
+	if (has(OPPRVLG_GET_ALL_SERVER))
+		return false;
+	const ServerHostGrpSetMap &allowedServersAndHostgroups =
+	  getAllowedServersAndHostgroups();
+	ServerHostGrpSetMapConstIterator it
+	  = allowedServersAndHostgroups.begin();
+	for (; it != allowedServersAndHostgroups.end(); ++it) {
+		const ServerIdType &serverId = it->first;
+		if (serverId == ALL_SERVERS)
+			continue;
+		const HostgroupIdSet &hostgrpIdSet = it->second;
+		if (hostgrpIdSet.find(ALL_HOST_GROUPS) == hostgrpIdSet.end())
+			return true;
+	}
+	return false;
+}
+
+string HostResourceQueryOption::getJoinClauseWithGlobalHostId(void) const
+{
+	const Synapse &synapse = m_impl->synapse;
+	return StringUtils::sprintf(
+	  "INNER JOIN %s ON %s=%s",
+	  synapse.hostgroupMapTableProfile.name,
+	  synapse.tableProfile.getFullColumnName(
+	    synapse.globalHostIdColumnIdx).c_str(),
+	  synapse.hostgroupMapTableProfile.getFullColumnName(
+	    synapse.hostgroupMapGlobalHostIdColumnIdx).c_str());
+}
+
+const ServerIdSet &HostResourceQueryOption::getValidServerIdSet(void) const
+{
+	if (m_impl->validServerIdSet)
+		return *m_impl->validServerIdSet;
+	return getDataQueryContext().getValidServerIdSet();
+}
+
+const ServerHostGrpSetMap &
+HostResourceQueryOption::getAllowedServersAndHostgroups(void) const
+{
+	if (m_impl->allowedServersAndHostgroups)
+		return *m_impl->allowedServersAndHostgroups;
+	return getDataQueryContext().getServerHostGrpSetMap();
 }
 
 // For test use only

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -68,10 +68,10 @@ struct HostResourceQueryOption::Impl {
 	bool            excludeDefunctServers;
 	list<ServerIdType> filterServerIdList;
 	bool excludeServerIdList;
-	list<GenericIdType> filterHostgroupIdList;
-	bool excludeHostgroupIdList;
-	list<GenericIdType> filterHostIdList;
-	bool excludeHostIdList;
+	ServerHostGrpSetMap filterServerHostgroupSetMap;
+	bool excludeServerHostgroupSetMap;
+	ServerHostSetMap filterServerHostSetMap;
+	bool excludeServerHostSetMap;
 
 	// For unit tests
 	const ServerIdSet *validServerIdSet;
@@ -84,8 +84,8 @@ struct HostResourceQueryOption::Impl {
 	  targetHostgroupId(ALL_HOST_GROUPS),
 	  excludeDefunctServers(true),
 	  excludeServerIdList(false),
-	  excludeHostgroupIdList(false),
-	  excludeHostIdList(false),
+	  excludeServerHostgroupSetMap(false),
+	  excludeServerHostSetMap(false),
 	  validServerIdSet(NULL),
 	  allowedServersAndHostgroups(NULL)
 	{
@@ -280,32 +280,32 @@ void HostResourceQueryOption::getFilterServerIdList(
 	exclude = m_impl->excludeServerIdList;
 }
 
-void HostResourceQueryOption::setFilterHostgroupIdList(
-  const std::list<GenericIdType> &hostgroupIdList, const bool exclude)
+void HostResourceQueryOption::setFilterHostgroupIds(
+  const ServerHostGrpSetMap &hostgroupIds, const bool exclude)
 {
-	m_impl->filterHostgroupIdList = hostgroupIdList;
-	m_impl->excludeHostgroupIdList = exclude;
+	m_impl->filterServerHostgroupSetMap = hostgroupIds;
+	m_impl->excludeServerHostgroupSetMap = exclude;
 }
 
-void HostResourceQueryOption::getFilterHostgroupIdList(
-  std::list<GenericIdType> &hostgroupIdList, bool &exclude)
+void HostResourceQueryOption::getFilterHostgroupIds(
+  ServerHostGrpSetMap &hostgroupIds, bool &exclude)
 {
-	hostgroupIdList = m_impl->filterHostgroupIdList;
-	exclude = m_impl->excludeHostgroupIdList;
+	hostgroupIds = m_impl->filterServerHostgroupSetMap;
+	exclude = m_impl->excludeServerHostgroupSetMap;
 }
 
-void HostResourceQueryOption::setFilterHostIdList(
-  const std::list<GenericIdType> &hostIdList, const bool exclude)
+void HostResourceQueryOption::setFilterHostIds(
+  const ServerHostSetMap &hostIds, const bool exclude)
 {
-	m_impl->filterHostIdList = hostIdList;
-	m_impl->excludeHostIdList = exclude;
+	m_impl->filterServerHostSetMap = hostIds;
+	m_impl->excludeServerHostSetMap = exclude;
 }
 
-void HostResourceQueryOption::getFilterHostIdList(
-  std::list<GenericIdType> &hostIdList, bool &exclude)
+void HostResourceQueryOption::getFilterHostIds(
+  ServerHostSetMap &hostIds, bool &exclude)
 {
-	hostIdList = m_impl->filterHostIdList;
-	exclude = m_impl->excludeHostIdList;
+	hostIds = m_impl->filterServerHostSetMap;
+	exclude = m_impl->excludeServerHostSetMap;
 }
 
 

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -143,7 +143,7 @@ string HostResourceQueryOption::getCondition(void) const
 		string allowedHostsCondition = makeConditionAllowedHosts();
 
 		if (DBHatohol::isAlwaysFalseCondition(allowedHostsCondition))
-			return DBHatohol::getAlwaysFalseCondition();
+			return allowedHostsCondition;
 
 		addCondition(condition, allowedHostsCondition);
 	}

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -448,12 +448,8 @@ string HostResourceQueryOption::makeConditionServer(
 	return condition;
 }
 
-string HostResourceQueryOption::makeConditionAllowedHosts(
-  const ServerHostGrpSetMap *allowedServersAndHostgroupsPtr) const
+string HostResourceQueryOption::makeConditionAllowedHosts(void) const
 {
-	if (allowedServersAndHostgroupsPtr)
-		m_impl->allowedServersAndHostgroups =
-			allowedServersAndHostgroupsPtr;
 	const ServerHostGrpSetMap &allowedServersAndHostgroups =
 	  getAllowedServersAndHostgroups();
 
@@ -611,4 +607,11 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 	if (condition.empty())
 		return condition;
 	return StringUtils::sprintf("(%s)", condition.c_str());
+}
+
+// For test use only
+void HostResourceQueryOption::setAllowedServersAndHostgroups (
+  const ServerHostGrpSetMap *map)
+{
+	m_impl->allowedServersAndHostgroups = map;
 }

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -617,6 +617,8 @@ string HostResourceQueryOption::makeConditionServersFilter(void) const
 		}
 	} else {
 		for (auto &serverId: m_impl->filterServerIdSet) {
+			if (!isAllowedServer(serverId))
+				continue;
 			addCondition(condition,
 				     StringUtils::sprintf(
 				       "%s=%" FMT_SERVER_ID,

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -638,7 +638,7 @@ string HostResourceQueryOption::makeConditionHostgroupsFilter(void) const
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
 	string serverIdColumnName = getServerIdColumnName();
-	string hostgroupIdColumnName = getServerIdColumnName();
+	string hostgroupIdColumnName = getHostgroupIdColumnName();
 
 	if (m_impl->excludeServerHostgroupSetMap) {
 		for (auto &pair: m_impl->filterServerHostgroupSetMap) {
@@ -647,7 +647,7 @@ string HostResourceQueryOption::makeConditionHostgroupsFilter(void) const
 			for (auto &hostgroupId: pair.second) {
 				addCondition(condition,
 					     StringUtils::sprintf(
-					       "NOT (%s<>%s AND %s<>%s)",
+					       "NOT (%s=%s AND %s=%s)",
 					       serverIdColumnName.c_str(),
 					       rhs(pair.first),
 					       hostgroupIdColumnName.c_str(),
@@ -681,7 +681,7 @@ string HostResourceQueryOption::makeConditionHostsFilter(void) const
 	DBTermCStringProvider rhs(*getDBTermCodec());
 	string condition;
 	string serverIdColumnName = getServerIdColumnName();
-	string hostIdColumnName = getServerIdColumnName();
+	string hostIdColumnName = getHostIdColumnName();
 
 	if (m_impl->excludeServerHostSetMap) {
 		for (auto &pair: m_impl->filterServerHostSetMap) {
@@ -690,7 +690,7 @@ string HostResourceQueryOption::makeConditionHostsFilter(void) const
 			for (auto &hostId: pair.second) {
 				addCondition(condition,
 					     StringUtils::sprintf(
-					       "NOT (%s<>%s AND %s<>%s)",
+					       "NOT (%s=%s AND %s=%s)",
 					       serverIdColumnName.c_str(),
 					       rhs(pair.first),
 					       hostIdColumnName.c_str(),
@@ -722,7 +722,7 @@ string HostResourceQueryOption::makeConditionHostsFilter(void) const
 string HostResourceQueryOption::makeConditionFilter(void) const
 {
 	string condition, nextCondition;
-	bool numFilters = 0;
+	size_t numFilters = 0;
 
 	AddConditionType addType = m_impl->excludeServerIdSet ?
 		ADD_TYPE_AND : ADD_TYPE_OR;

--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -297,10 +297,13 @@ string HostResourceQueryOption::getHostIdColumnName(void) const
 bool HostResourceQueryOption::isAllowedServer(
   const ServerIdType &targetServerId) const
 {
+	if (has(OPPRVLG_GET_ALL_SERVER))
+		return true;
 	const ServerHostGrpSetMap &allowedServersAndHostgroups =
 	  getAllowedServersAndHostgroups();
-	return allowedServersAndHostgroups.find(targetServerId) !=
-		allowedServersAndHostgroups.end();
+	auto endIt = allowedServersAndHostgroups.end();
+	return (allowedServersAndHostgroups.find(ALL_SERVERS) != endIt) ||
+	       (allowedServersAndHostgroups.find(targetServerId) != endIt);
 }
 
 bool HostResourceQueryOption::isAllowedHostgroup(
@@ -309,8 +312,12 @@ bool HostResourceQueryOption::isAllowedHostgroup(
 {
 	const ServerHostGrpSetMap &allowedServersAndHostgroups =
 	  getAllowedServersAndHostgroups();
+	auto endServerIt(allowedServersAndHostgroups.end());
+	if (allowedServersAndHostgroups.find(ALL_SERVERS) != endServerIt)
+		return true;
 	auto serverIt(allowedServersAndHostgroups.find(targetServerId));
-	if (serverIt != allowedServersAndHostgroups.end())
+	if (!has(OPPRVLG_GET_ALL_SERVER) &&
+	    serverIt != allowedServersAndHostgroups.end())
 		return false;
 	const HostgroupIdSet &hostgroupSet = serverIt->second;
 	return hostgroupSet.find(targetHostgroupId) != hostgroupSet.end();

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -153,6 +153,7 @@ protected:
 	std::string getServerIdColumnName(void) const;
 	std::string getHostgroupIdColumnName(void) const;
 	std::string getHostIdColumnName(void) const;
+	bool isAllowedServer(const ServerIdType &targetServerId) const;
 
 	std::string makeConditionForPrivilegedUser(void) const;
 	std::string makeConditionForNormalUser(

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -120,6 +120,16 @@ public:
 	virtual HostgroupIdType getTargetHostgroupId(void) const;
 	virtual void setTargetHostgroupId(HostgroupIdType targetHostgroupId);
 
+	/**
+	 * Set a list of IDs of monitoring servers to select or exclude.
+	 *
+	 * @param serverIdList
+	 * A list of IDs of monitoring servers to select or exclude.
+	 *
+	 * @param exclude
+	 * If the parameter is false, only the specified monitoring servers are
+	 * selected. Otherwise they are excluded.
+	 */
 	virtual void setFilterServerIdList(
 	  const std::list<ServerIdType> &serverIdList,
 	  const bool exculde = false);

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -159,7 +159,7 @@ protected:
 
 	std::string makeConditionTargetIds(void) const;
 	std::string makeConditionAllowedHosts(
-	  const ServerHostGrpSetMap &allowedServersAndHostgroups) const;
+	  const ServerHostGrpSetMap *allowedServersAndHostgroups = NULL) const;
 	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,
 	  const std::string &serverIdColumnName) const;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -123,18 +123,18 @@ public:
 	/**
 	 * Set a list of IDs of monitoring servers to select or exclude.
 	 *
-	 * @param serverIdList
+	 * @param serverIds
 	 * A list of IDs of monitoring servers to select or exclude.
 	 *
 	 * @param exclude
 	 * If the parameter is false, only the specified monitoring servers are
 	 * selected. Otherwise they are excluded.
 	 */
-	virtual void setFilterServerIdList(
-	  const std::list<ServerIdType> &serverIdList,
+	virtual void setFilterServerIds(
+	  const ServerIdSet &serverIds,
 	  const bool exclude = false);
-	virtual void getFilterServerIdList(
-	  std::list<ServerIdType> &serverIdList,
+	virtual void getFilterServerIds(
+	  ServerIdSet &serverIds,
 	  bool &exclude);
 
 	/**

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -138,6 +138,40 @@ public:
 	  bool &exclude);
 
 	/**
+	 * Set a list of IDs of hostgroups to select or exclude.
+	 *
+	 * @param hostgroupIdList
+	 * A list of IDs of hostgroups to select or exclude.
+	 *
+	 * @param exclude
+	 * If the parameter is false, only the specified hostgroups are
+	 * selected. Otherwise they are excluded.
+	 */
+	virtual void setFilterHostgroupIdList(
+	  const std::list<GenericIdType> &hostgroupIdList,
+	  const bool exculde = false);
+	virtual void getFilterHostgroupIdList(
+	  std::list<GenericIdType> &hostgroupIdList,
+	  bool &exclude);
+
+	/**
+	 * Set a list of IDs of hosts to select or exclude.
+	 *
+	 * @param hostIdList
+	 * A list of IDs of hosts to select or exclude.
+	 *
+	 * @param exclude
+	 * If the parameter is false, only the specified hosts are
+	 * selected. Otherwise they are excluded.
+	 */
+	virtual void setFilterHostIdList(
+	  const std::list<GenericIdType> &hostIdList,
+	  const bool exculde = false);
+	virtual void getFilterHostIdList(
+	  std::list<GenericIdType> &hostIdList,
+	  bool &exclude);
+
+	/**
 	 * Enable or disable the filter to exclude defunct servers.
 	 *
 	 * @param enable

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -132,7 +132,7 @@ public:
 	 */
 	virtual void setFilterServerIdList(
 	  const std::list<ServerIdType> &serverIdList,
-	  const bool exculde = false);
+	  const bool exclude = false);
 	virtual void getFilterServerIdList(
 	  std::list<ServerIdType> &serverIdList,
 	  bool &exclude);
@@ -149,7 +149,7 @@ public:
 	 */
 	virtual void setFilterHostgroupIdList(
 	  const std::list<GenericIdType> &hostgroupIdList,
-	  const bool exculde = false);
+	  const bool exclude = false);
 	virtual void getFilterHostgroupIdList(
 	  std::list<GenericIdType> &hostgroupIdList,
 	  bool &exclude);
@@ -166,7 +166,7 @@ public:
 	 */
 	virtual void setFilterHostIdList(
 	  const std::list<GenericIdType> &hostIdList,
-	  const bool exculde = false);
+	  const bool exclude = false);
 	virtual void getFilterHostIdList(
 	  std::list<GenericIdType> &hostIdList,
 	  bool &exclude);

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -140,35 +140,35 @@ public:
 	/**
 	 * Set a list of IDs of hostgroups to select or exclude.
 	 *
-	 * @param hostgroupIdList
+	 * @param hostgroupIds
 	 * A list of IDs of hostgroups to select or exclude.
 	 *
 	 * @param exclude
 	 * If the parameter is false, only the specified hostgroups are
 	 * selected. Otherwise they are excluded.
 	 */
-	virtual void setFilterHostgroupIdList(
-	  const std::list<GenericIdType> &hostgroupIdList,
+	virtual void setFilterHostgroupIds(
+	  const ServerHostGrpSetMap &hostgroupIds,
 	  const bool exclude = false);
-	virtual void getFilterHostgroupIdList(
-	  std::list<GenericIdType> &hostgroupIdList,
+	virtual void getFilterHostgroupIds(
+	  ServerHostGrpSetMap &hostgroupIds,
 	  bool &exclude);
 
 	/**
 	 * Set a list of IDs of hosts to select or exclude.
 	 *
-	 * @param hostIdList
+	 * @param hostIds
 	 * A list of IDs of hosts to select or exclude.
 	 *
 	 * @param exclude
 	 * If the parameter is false, only the specified hosts are
 	 * selected. Otherwise they are excluded.
 	 */
-	virtual void setFilterHostIdList(
-	  const std::list<GenericIdType> &hostIdList,
+	virtual void setFilterHostIds(
+	  const ServerHostSetMap &hostIds,
 	  const bool exclude = false);
-	virtual void getFilterHostIdList(
-	  std::list<GenericIdType> &hostIdList,
+	virtual void getFilterHostIds(
+	  ServerHostSetMap &hostIds,
 	  bool &exclude);
 
 	/**

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -177,6 +177,8 @@ protected:
 
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
+	std::string makeConditionExcludeServers() const;
+
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -202,8 +202,7 @@ protected:
 				const HostgroupIdType &targetHostgroupId) const;
 
 	std::string makeConditionTargetIds(void) const;
-	std::string makeConditionAllowedHosts(
-	  const ServerHostGrpSetMap *allowedServersAndHostgroups = NULL) const;
+	std::string makeConditionAllowedHosts(void) const;
 	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,
 	  const std::string &serverIdColumnName) const;
@@ -228,6 +227,9 @@ protected:
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
 	std::string makeConditionServersFilter(void) const;
+
+	// For test use only
+	void setAllowedServersAndHostgroups(const ServerHostGrpSetMap *map);
 
 private:
 	struct Impl;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -224,11 +224,13 @@ protected:
 	bool isHostgroupEnumerationInCondition(void) const;
 	std::string getJoinClauseWithGlobalHostId(void) const;
 
+	const ServerIdSet &getValidServerIdSet(void) const;
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
 	std::string makeConditionServersFilter(void) const;
 
 	// For test use only
+	void setValidServerIdSet(const ServerIdSet *set);
 	void setAllowedServersAndHostgroups(const ServerHostGrpSetMap *map);
 
 private:

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -157,8 +157,8 @@ protected:
 	bool isAllowedHostgroup(const ServerIdType &targetServerId,
 				const HostgroupIdType &targetHostgroupId) const;
 
-	std::string makeConditionForPrivilegedUser(void) const;
-	std::string makeConditionForNormalUser(
+	std::string makeConditionTargetIds(void) const;
+	std::string makeConditionAllowedHosts(
 	  const ServerHostGrpSetMap &allowedServersAndHostgroups) const;
 	std::string makeConditionServer(
 	  const ServerIdSet &serverIdSet,

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -216,6 +216,11 @@ protected:
 	  const HostgroupIdSet &hostgroupIdSet,
 	  const std::string &hostgroupIdColumnName) const;
 
+	std::string makeConditionServersFilter(void) const;
+	std::string makeConditionHostgroupsFilter(void) const;
+	std::string makeConditionHostsFilter(void) const;
+	std::string makeConditionFilter(void) const;
+
 	virtual std::string getFromClauseForOneTable(void) const;
 	virtual std::string getFromClauseWithHostgroup(void) const;
 
@@ -226,11 +231,6 @@ protected:
 
 	const ServerIdSet &getValidServerIdSet(void) const;
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
-
-	std::string makeConditionServersFilter(void) const;
-	std::string makeConditionHostgroupsFilter(void) const;
-	std::string makeConditionHostsFilter(void) const;
-	std::string makeConditionFilter(void) const;
 
 	// For test use only
 	void setValidServerIdSet(const ServerIdSet *set);

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -228,6 +228,9 @@ protected:
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
 	std::string makeConditionServersFilter(void) const;
+	std::string makeConditionHostgroupsFilter(void) const;
+	std::string makeConditionHostsFilter(void) const;
+	std::string makeConditionFilter(void) const;
 
 	// For test use only
 	void setValidServerIdSet(const ServerIdSet *set);

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -183,7 +183,7 @@ protected:
 
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
-	std::string makeConditionServersFilterForPrivilegedUser(void) const;
+	std::string makeConditionServersFilter(void) const;
 
 private:
 	struct Impl;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -120,9 +120,12 @@ public:
 	virtual HostgroupIdType getTargetHostgroupId(void) const;
 	virtual void setTargetHostgroupId(HostgroupIdType targetHostgroupId);
 
-	virtual void setExcludeServerIdList(
-	  const std::list<ServerIdType> &serverIdList);
-	virtual const std::list<ServerIdType> &getExcludeServerIdList(void);
+	virtual void setFilterServerIdList(
+	  const std::list<ServerIdType> &serverIdList,
+	  const bool exculde = false);
+	virtual void getFilterServerIdList(
+	  std::list<ServerIdType> &serverIdList,
+	  bool &exclude);
 
 	/**
 	 * Enable or disable the filter to exclude defunct servers.
@@ -177,7 +180,7 @@ protected:
 
 	const ServerHostGrpSetMap &getAllowedServersAndHostgroups(void) const;
 
-	std::string makeConditionExcludeServers() const;
+	std::string makeConditionServersFilterForPrivilegedUser(void) const;
 
 private:
 	struct Impl;

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -120,6 +120,10 @@ public:
 	virtual HostgroupIdType getTargetHostgroupId(void) const;
 	virtual void setTargetHostgroupId(HostgroupIdType targetHostgroupId);
 
+	virtual void setExcludeServerIdList(
+	  const std::list<ServerIdType> &serverIdList);
+	virtual const std::list<ServerIdType> &getExcludeServerIdList(void);
+
 	/**
 	 * Enable or disable the filter to exclude defunct servers.
 	 *

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -154,6 +154,8 @@ protected:
 	std::string getHostgroupIdColumnName(void) const;
 	std::string getHostIdColumnName(void) const;
 	bool isAllowedServer(const ServerIdType &targetServerId) const;
+	bool isAllowedHostgroup(const ServerIdType &targetServerId,
+				const HostgroupIdType &targetHostgroupId) const;
 
 	std::string makeConditionForPrivilegedUser(void) const;
 	std::string makeConditionForNormalUser(

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -423,7 +423,7 @@ const EventInfo testEventInfo[] = {
 	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
-	4,                        // globalHostId,
+	35,                       // globalHostId,
 	"10001",                  // hostIdInServer,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,
@@ -437,7 +437,7 @@ const EventInfo testEventInfo[] = {
 	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
-	6,                        // globalHostId,
+	41,                       // globalHostId,
 	"10002",                  // hostIdInServer,
 	"hostZ2",                 // hostName,
 	"TEST Trigger 3",         // brief,
@@ -451,7 +451,7 @@ const EventInfo testEventInfo[] = {
 	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
-	1,                        // globalHostId,
+	10,                       // globalHostId,
 	"235012",                 // hostIdInServer,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1a",        // brief,
@@ -465,7 +465,7 @@ const EventInfo testEventInfo[] = {
 	"1",                      // triggerId
 	TRIGGER_STATUS_OK,        // status
 	TRIGGER_SEVERITY_INFO,    // severity
-	1,                        // globalHostId,
+	10,                       // globalHostId,
 	"235012",                 // hostIdInServer,
 	"hostX1",                 // hostName,
 	"TEST Trigger 1",         // brief,
@@ -479,7 +479,7 @@ const EventInfo testEventInfo[] = {
 	"3",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_INFO,    // severity
-	2,                        // globalHostId,
+	11,                       // globalHostId,
 	"235013",                 // hostIdInServer,
 	"hostX2",                 // hostName,
 	"TEST Trigger 1b",        // brief,
@@ -492,7 +492,7 @@ const EventInfo testEventInfo[] = {
 	"2",                      // triggerId
 	TRIGGER_STATUS_PROBLEM,   // status
 	TRIGGER_SEVERITY_WARNING, // severity
-	4,                        // globalHostId,
+	35,                       // globalHostId,
 	"10001",                  // hostIdInServer,
 	"hostZ1",                 // hostName,
 	"TEST Trigger 2",         // brief,

--- a/server/test/TestHostResourceQueryOption.cc
+++ b/server/test/TestHostResourceQueryOption.cc
@@ -49,3 +49,9 @@ void TestHostResourceQueryOption::callSetAllowedServersAndHostgroups(
 {
 	setAllowedServersAndHostgroups(map);
 }
+
+void TestHostResourceQueryOption::callSetValidServerIdSet(
+  const ServerIdSet *set)
+{
+	setValidServerIdSet(set);
+}

--- a/server/test/TestHostResourceQueryOption.cc
+++ b/server/test/TestHostResourceQueryOption.cc
@@ -39,8 +39,13 @@ string TestHostResourceQueryOption::callMakeConditionServer(
 	return makeConditionServer(serverIdSet, serverIdColumnName);
 }
 
-string TestHostResourceQueryOption::callMakeConditionAllowedHosts(
-  const ServerHostGrpSetMap &srvHostGrpSetMap) const
+string TestHostResourceQueryOption::callMakeConditionAllowedHosts(void) const
 {
-	return makeConditionAllowedHosts(&srvHostGrpSetMap);
+	return makeConditionAllowedHosts();
+}
+
+void TestHostResourceQueryOption::callSetAllowedServersAndHostgroups(
+  const ServerHostGrpSetMap *map)
+{
+	setAllowedServersAndHostgroups(map);
 }

--- a/server/test/TestHostResourceQueryOption.cc
+++ b/server/test/TestHostResourceQueryOption.cc
@@ -42,5 +42,5 @@ string TestHostResourceQueryOption::callMakeConditionServer(
 string TestHostResourceQueryOption::callMakeConditionAllowedHosts(
   const ServerHostGrpSetMap &srvHostGrpSetMap) const
 {
-	return makeConditionAllowedHosts(srvHostGrpSetMap);
+	return makeConditionAllowedHosts(&srvHostGrpSetMap);
 }

--- a/server/test/TestHostResourceQueryOption.cc
+++ b/server/test/TestHostResourceQueryOption.cc
@@ -39,8 +39,8 @@ string TestHostResourceQueryOption::callMakeConditionServer(
 	return makeConditionServer(serverIdSet, serverIdColumnName);
 }
 
-string TestHostResourceQueryOption::callMakeCondition(
+string TestHostResourceQueryOption::callMakeConditionAllowedHosts(
   const ServerHostGrpSetMap &srvHostGrpSetMap) const
 {
-	return makeConditionForNormalUser(srvHostGrpSetMap);
+	return makeConditionAllowedHosts(srvHostGrpSetMap);
 }

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -34,8 +34,9 @@ public:
 	  const ServerIdSet &serverIdSet,
 	  const std::string &serverIdColumnName) const;
 
-	std::string callMakeConditionAllowedHosts(
-	  const ServerHostGrpSetMap &srvHostGrpSetMap) const;
+	std::string callMakeConditionAllowedHosts(void) const;
+	void callSetAllowedServersAndHostgroups(
+	  const ServerHostGrpSetMap *map);
 };
 
 #endif // TestHostResourceQueryOption_h

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -37,6 +37,7 @@ public:
 	std::string callMakeConditionAllowedHosts(void) const;
 	void callSetAllowedServersAndHostgroups(
 	  const ServerHostGrpSetMap *map);
+	void callSetValidServerIdSet(const ServerIdSet *set);
 };
 
 #endif // TestHostResourceQueryOption_h

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -34,7 +34,7 @@ public:
 	  const ServerIdSet &serverIdSet,
 	  const std::string &serverIdColumnName) const;
 
-	std::string callMakeCondition(
+	std::string callMakeConditionAllowedHosts(
 	  const ServerHostGrpSetMap &srvHostGrpSetMap) const;
 };
 

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1506,8 +1506,8 @@ void test_getEventsSelectByHosts(void)
 	for (auto &event: events)
 		actual += makeEventOutput(event);
 	string expected(
-	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
-	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
 }
 
@@ -1533,8 +1533,8 @@ void test_getEventsExcludeByHosts(void)
 	for (auto &event: events)
 		actual += makeEventOutput(event);
 	string expected(
-	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
-	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
 }
 
@@ -1563,11 +1563,11 @@ void test_getEventsSelectByServersAndHosts(void)
 	for (auto &event: events)
 		actual += makeEventOutput(event);
 	string expected(
-	  "3|1|1362957200|0|0|2|1|2|4|10001|hostZ1|TEST Trigger 2|"
+	  "3|1|1362957200|0|0|2|1|2|35|10001|hostZ1|TEST Trigger 2|"
 	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n"
-	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
-	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n"
-	  "3|3|1390000000|123456789|1|2|1|2|4|10001|hostZ1|TEST Trigger 2|"
+	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n"
+	  "3|3|1390000000|123456789|1|2|1|2|35|10001|hostZ1|TEST Trigger 2|"
 	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n");
 	cppcut_assert_equal(expected, actual);
 }
@@ -1598,7 +1598,7 @@ void test_getEventsExcludeByServersAndSelectByHosts(void)
 	for (auto &event: events)
 		actual += makeEventOutput(event);
 	string expected(
-	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
 }
 
@@ -1627,7 +1627,7 @@ void test_getEventsSelectByServersAndExcludeByHosts(void)
 	for (auto &event: events)
 		actual += makeEventOutput(event);
 	string expected(
-	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
 }
 

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1631,4 +1631,65 @@ void test_getEventsSelectByServersAndExcludeByHosts(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getEventsSelectByHostgroup(void)
+{
+	loadTestDBServerHostDef();
+	loadTestDBHostgroup();
+	loadTestDBHostgroupMember();
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	HostgroupIdSet hostgroupIdSet;
+	hostgroupIdSet.insert("1");
+	ServerHostSetMap map;
+	map[1] = hostgroupIdSet;
+	const bool exclude = true;
+	option.setFilterHostgroupIds(map, !exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "1|1|1363123456|0|0|2|1|1|10|235012|hostX1|TEST Trigger 1a|"
+	    "{\"expandedDescription\":\"Test Trigger on hostX1\"}\n"
+	  "1|2|1378900022|0|0|1|0|1|10|235012|hostX1|TEST Trigger 1|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getEventsExcludeByHostgroup(void)
+{
+	loadTestDBServerHostDef();
+	loadTestDBHostgroup();
+	loadTestDBHostgroupMember();
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet3;
+	hostgroupIdSet1.insert("2");
+	hostgroupIdSet3.insert("1");
+	hostgroupIdSet3.insert("2");
+	ServerHostSetMap map;
+	map[1] = hostgroupIdSet1;
+	map[3] = hostgroupIdSet3;
+	const bool exclude = true;
+	option.setFilterHostgroupIds(map, exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "1|1|1363123456|0|0|2|1|1|10|235012|hostX1|TEST Trigger 1a|"
+	    "{\"expandedDescription\":\"Test Trigger on hostX1\"}\n"
+	  "1|2|1378900022|0|0|1|0|1|10|235012|hostX1|TEST Trigger 1|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
 } // namespace testDBTablesMonitoring

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1484,4 +1484,58 @@ void test_getLastUpdateTimeOfIncidentsWithNoRecord(void)
 	  expected, dbMonitoring.getLastUpdateTimeOfIncidents(trackerId));
 }
 
+void test_getEventsSelectHosts(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	LocalHostIdSet hostIdSet1, hostIdSet3;
+	hostIdSet1.insert("235013");
+	hostIdSet3.insert("10002");
+	ServerHostSetMap map;
+	map[1] = hostIdSet1;
+	map[3] = hostIdSet3;
+	const bool exclude = true;
+	option.setFilterHostIds(map, !exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getEventsExcludeHosts(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	LocalHostIdSet hostIdSet1, hostIdSet3;
+	hostIdSet1.insert("235012");
+	hostIdSet3.insert("10001");
+	ServerHostSetMap map;
+	map[1] = hostIdSet1;
+	map[3] = hostIdSet3;
+	const bool exclude = true;
+	option.setFilterHostIds(map, exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
 } // namespace testDBTablesMonitoring

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1484,7 +1484,7 @@ void test_getLastUpdateTimeOfIncidentsWithNoRecord(void)
 	  expected, dbMonitoring.getLastUpdateTimeOfIncidents(trackerId));
 }
 
-void test_getEventsSelectHosts(void)
+void test_getEventsSelectByHosts(void)
 {
 	loadTestDBEvents();
 
@@ -1511,7 +1511,7 @@ void test_getEventsSelectHosts(void)
 	cppcut_assert_equal(expected, actual);
 }
 
-void test_getEventsExcludeHosts(void)
+void test_getEventsExcludeByHosts(void)
 {
 	loadTestDBEvents();
 
@@ -1534,6 +1534,99 @@ void test_getEventsExcludeHosts(void)
 		actual += makeEventOutput(event);
 	string expected(
 	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getEventsSelectByServersAndHosts(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	LocalHostIdSet hostIdSet1;
+
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+
+	hostIdSet1.insert("235013");
+	ServerHostSetMap hostsMap;
+	hostsMap[1] = hostIdSet1;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, !exclude);
+	option.setFilterHostIds(hostsMap, !exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "3|1|1362957200|0|0|2|1|2|4|10001|hostZ1|TEST Trigger 2|"
+	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n"
+	  "3|2|1362958000|0|0|3|1|1|6|10002|hostZ2|TEST Trigger 3|\n"
+	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n"
+	  "3|3|1390000000|123456789|1|2|1|2|4|10001|hostZ1|TEST Trigger 2|"
+	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n");
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getEventsExcludeByServersAndSelectByHosts(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	LocalHostIdSet hostIdSet1;
+
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(1);
+	serverIdSet.insert(3);
+
+	hostIdSet1.insert("235013");
+	ServerHostSetMap hostsMap;
+	hostsMap[1] = hostIdSet1;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, exclude);
+	option.setFilterHostIds(hostsMap, !exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
+	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getEventsSelectByServersAndExcludeByHosts(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	LocalHostIdSet hostIdSet1;
+
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(1);
+
+	hostIdSet1.insert("235012");
+	ServerHostSetMap hostsMap;
+	hostsMap[1] = hostIdSet1;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, !exclude);
+	option.setFilterHostIds(hostsMap, exclude);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual;
+	for (auto &event: events)
+		actual += makeEventOutput(event);
+	string expected(
 	  "1|3|1389123457|0|0|3|1|1|2|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
 }

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -417,6 +417,20 @@ void test_getDBTermCodec(void)
 	                    typeid(*option.getDBTermCodec()));
 }
 
+void test_selectPluralServers(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	list<ServerIdType> serverIdList;
+	serverIdList.push_back(3);
+	serverIdList.push_back(4);
+	serverIdList.push_back(211);
+	const bool exclude = true;
+	option.setFilterServerIdList(serverIdList, !exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND (server_id=3 OR server_id=4 OR server_id=211)");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
 void test_excludeServers(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -471,12 +471,16 @@ void test_selectPluralHostgroups(void)
 	map[6] = hostgroupIdSet2;
 	const bool exclude = true;
 	option.setFilterHostgroupIds(map, !exclude);
-	string expect("server_id IN (1,2,3,4,211,222,301)"
+	string expect("test_table_name.server_id IN (1,2,3,4,211,222,301)"
 		      " AND "
-		      "((server_id=5 AND host_group_id='101') OR"
-		      " (server_id=5 AND host_group_id='102') OR"
-		      " (server_id=6 AND host_group_id='103') OR"
-		      " (server_id=6 AND host_group_id='104'))");
+		      "((test_table_name.server_id=5 AND"
+		      " test_hgrp_table_name.host_group_id='101') OR"
+		      " (test_table_name.server_id=5 AND"
+		      " test_hgrp_table_name.host_group_id='102') OR"
+		      " (test_table_name.server_id=6 AND"
+		      " test_hgrp_table_name.host_group_id='103') OR"
+		      " (test_table_name.server_id=6 AND"
+		      " test_hgrp_table_name.host_group_id='104'))");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
@@ -493,12 +497,16 @@ void test_excludePluralHostgroups(void)
 	map[6] = hostgroupIdSet2;
 	const bool exclude = true;
 	option.setFilterHostgroupIds(map, exclude);
-	string expect("server_id IN (1,2,3,4,211,222,301)"
+	string expect("test_table_name.server_id IN (1,2,3,4,211,222,301)"
 		      " AND "
-		      "(NOT (server_id=5 AND host_group_id='101') AND"
-		      " NOT (server_id=5 AND host_group_id='102') AND"
-		      " NOT (server_id=6 AND host_group_id='103') AND"
-		      " NOT (server_id=6 AND host_group_id='104'))");
+		      "(NOT (test_table_name.server_id=5 AND"
+		      " test_hgrp_table_name.host_group_id='101') AND"
+		      " NOT (test_table_name.server_id=5 AND"
+		      " test_hgrp_table_name.host_group_id='102') AND"
+		      " NOT (test_table_name.server_id=6 AND"
+		      " test_hgrp_table_name.host_group_id='103') AND"
+		      " NOT (test_table_name.server_id=6 AND"
+		      " test_hgrp_table_name.host_group_id='104'))");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
@@ -577,19 +585,29 @@ void test_selectPluralServerAndGroupsAndHosts(void)
 	option.setFilterHostgroupIds(groupsMap, !exclude);
 	option.setFilterHostIds(hostsMap, !exclude);
 
-	string expect("server_id IN (1,2,3,4,211,222,301)"
+	string expect("test_table_name.server_id IN (1,2,3,4,211,222,301)"
 		      " AND ("
-		      "(server_id=1 OR server_id=2 OR server_id=211)"
+		      "(test_table_name.server_id=1 OR"
+		      " test_table_name.server_id=2 OR"
+		      " test_table_name.server_id=211)"
 		      " OR "
-		      "((server_id=3 AND host_group_id='101') OR"
-		      " (server_id=3 AND host_group_id='102') OR"
-		      " (server_id=4 AND host_group_id='103') OR"
-		      " (server_id=4 AND host_group_id='104'))"
+		      "((test_table_name.server_id=3 AND"
+		      " test_hgrp_table_name.host_group_id='101') OR"
+		      " (test_table_name.server_id=3 AND"
+		      " test_hgrp_table_name.host_group_id='102') OR"
+		      " (test_table_name.server_id=4 AND"
+		      " test_hgrp_table_name.host_group_id='103') OR"
+		      " (test_table_name.server_id=4 AND"
+		      " test_hgrp_table_name.host_group_id='104'))"
 		      " OR "
-		      "((server_id=5 AND host_id='1001') OR"
-		      " (server_id=5 AND host_id='1002') OR"
-		      " (server_id=6 AND host_id='1003') OR"
-		      " (server_id=6 AND host_id='1004'))"
+		      "((test_table_name.server_id=5 AND"
+		      " test_table_name.host_id='1001') OR"
+		      " (test_table_name.server_id=5 AND"
+		      " test_table_name.host_id='1002') OR"
+		      " (test_table_name.server_id=6 AND"
+		      " test_table_name.host_id='1003') OR"
+		      " (test_table_name.server_id=6 AND"
+		      " test_table_name.host_id='1004'))"
 		      ")");
 	cppcut_assert_equal(expect, option.getCondition());
 }

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -251,7 +251,7 @@ void test_makeSelectConditionUserAdmin(gconstpointer data)
 	string expect = "";
 	fixupForFilteringDefunctServer(data, expect, option);
 	string actual = option.getCondition();
-	cppcut_assert_equal(actual, expect);
+	cppcut_assert_equal(expect, actual);
 }
 
 void data_makeSelectConditionAllEvents(void)
@@ -266,7 +266,7 @@ void test_makeSelectConditionAllEvents(gconstpointer data)
 	string expect = "";
 	fixupForFilteringDefunctServer(data, expect, option);
 	string actual = option.getCondition();
-	cppcut_assert_equal(actual, expect);
+	cppcut_assert_equal(expect, actual);
 }
 
 void test_makeSelectConditionNoneUser(void)
@@ -274,7 +274,7 @@ void test_makeSelectConditionNoneUser(void)
 	HostResourceQueryOption option(TEST_SYNAPSE);
 	string actual = option.getCondition();
 	string expect = DBHatohol::getAlwaysFalseCondition();
-	cppcut_assert_equal(actual, expect);
+	cppcut_assert_equal(expect, actual);
 }
 
 void data_makeSelectCondition(void)

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -417,7 +417,7 @@ void test_getDBTermCodec(void)
 	                    typeid(*option.getDBTermCodec()));
 }
 
-void test_selectPluralServersWithPrivilege(void)
+void test_selectPluralServers(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
 	ServerIdSet serverIdSet;
@@ -431,7 +431,7 @@ void test_selectPluralServersWithPrivilege(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_excludeServersWithPrivilege(void)
+void test_excludeServers(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
 	ServerIdSet serverIdSet;
@@ -458,13 +458,9 @@ void test_excludeServersWithoutPrivilege(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_selectPluralHostgroupsWithPrivilege(void)
+void test_selectPluralHostgroups(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	ServerIdSet serverIdSet;
-	serverIdSet.insert(3);
-	serverIdSet.insert(4);
-	serverIdSet.insert(211);
 	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet2;
 	hostgroupIdSet1.insert("101");
 	hostgroupIdSet1.insert("102");
@@ -474,27 +470,19 @@ void test_selectPluralHostgroupsWithPrivilege(void)
 	map[5] = hostgroupIdSet1;
 	map[6] = hostgroupIdSet2;
 	const bool exclude = true;
-	option.setFilterServerIds(serverIdSet, !exclude);
 	option.setFilterHostgroupIds(map, !exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
-		      " AND ("
-		      "(server_id=3 OR server_id=4 OR server_id=211)"
-		      " OR "
+		      " AND "
 		      "((server_id=5 AND host_group_id='101') OR"
 		      " (server_id=5 AND host_group_id='102') OR"
 		      " (server_id=6 AND host_group_id='103') OR"
-		      " (server_id=6 AND host_group_id='104'))"
-		      ")");
+		      " (server_id=6 AND host_group_id='104'))");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_excludePluralHostgroupsWithPrivilege(void)
+void test_excludePluralHostgroups(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	ServerIdSet serverIdSet;
-	serverIdSet.insert(3);
-	serverIdSet.insert(4);
-	serverIdSet.insert(211);
 	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet2;
 	hostgroupIdSet1.insert("101");
 	hostgroupIdSet1.insert("102");
@@ -504,27 +492,19 @@ void test_excludePluralHostgroupsWithPrivilege(void)
 	map[5] = hostgroupIdSet1;
 	map[6] = hostgroupIdSet2;
 	const bool exclude = true;
-	option.setFilterServerIds(serverIdSet, exclude);
 	option.setFilterHostgroupIds(map, exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
-		      " AND ("
-		      "(server_id<>3 AND server_id<>4 AND server_id<>211)"
 		      " AND "
 		      "(NOT (server_id=5 AND host_group_id='101') AND"
 		      " NOT (server_id=5 AND host_group_id='102') AND"
 		      " NOT (server_id=6 AND host_group_id='103') AND"
-		      " NOT (server_id=6 AND host_group_id='104'))"
-		      ")");
+		      " NOT (server_id=6 AND host_group_id='104'))");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_selectPluralHostsWithPrivilege(void)
+void test_selectPluralHosts(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	ServerIdSet serverIdSet;
-	serverIdSet.insert(3);
-	serverIdSet.insert(4);
-	serverIdSet.insert(211);
 	LocalHostIdSet hostIdSet1, hostIdSet2;
 	hostIdSet1.insert("101");
 	hostIdSet1.insert("102");
@@ -534,46 +514,82 @@ void test_selectPluralHostsWithPrivilege(void)
 	map[5] = hostIdSet1;
 	map[6] = hostIdSet2;
 	const bool exclude = true;
-	option.setFilterServerIds(serverIdSet, !exclude);
 	option.setFilterHostIds(map, !exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
-		      " AND ("
-		      "(server_id=3 OR server_id=4 OR server_id=211)"
-		      " OR "
+		      " AND "
 		      "((server_id=5 AND host_id='101') OR"
 		      " (server_id=5 AND host_id='102') OR"
 		      " (server_id=6 AND host_id='103') OR"
-		      " (server_id=6 AND host_id='104'))"
-		      ")");
+		      " (server_id=6 AND host_id='104'))");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_excludePluralHostsWithPrivilege(void)
+void test_excludePluralHosts(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	ServerIdSet serverIdSet;
-	serverIdSet.insert(3);
-	serverIdSet.insert(4);
-	serverIdSet.insert(211);
 	LocalHostIdSet hostIdSet1, hostIdSet2;
 	hostIdSet1.insert("101");
 	hostIdSet1.insert("102");
 	hostIdSet2.insert("103");
 	hostIdSet2.insert("104");
-	ServerHostSetMap map;
-	map[5] = hostIdSet1;
-	map[6] = hostIdSet2;
+	ServerHostSetMap hostsMap;
+	hostsMap[5] = hostIdSet1;
+	hostsMap[6] = hostIdSet2;
 	const bool exclude = true;
-	option.setFilterServerIds(serverIdSet, exclude);
-	option.setFilterHostIds(map, exclude);
+	option.setFilterHostIds(hostsMap, !exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND "
+		      "((server_id=5 AND host_id='101') OR"
+		      " (server_id=5 AND host_id='102') OR"
+		      " (server_id=6 AND host_id='103') OR"
+		      " (server_id=6 AND host_id='104'))");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
+void test_selectPluralServerAndGroupsAndHosts(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(1);
+	serverIdSet.insert(2);
+	serverIdSet.insert(211);
+
+	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet2;
+	hostgroupIdSet1.insert("101");
+	hostgroupIdSet1.insert("102");
+	hostgroupIdSet2.insert("103");
+	hostgroupIdSet2.insert("104");
+	ServerHostGrpSetMap groupsMap;
+	groupsMap[3] = hostgroupIdSet1;
+	groupsMap[4] = hostgroupIdSet2;
+
+	LocalHostIdSet hostIdSet1, hostIdSet2;
+	hostIdSet1.insert("1001");
+	hostIdSet1.insert("1002");
+	hostIdSet2.insert("1003");
+	hostIdSet2.insert("1004");
+
+	ServerHostSetMap hostsMap;
+	hostsMap[5] = hostIdSet1;
+	hostsMap[6] = hostIdSet2;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, !exclude);
+	option.setFilterHostgroupIds(groupsMap, !exclude);
+	option.setFilterHostIds(hostsMap, !exclude);
+
 	string expect("server_id IN (1,2,3,4,211,222,301)"
 		      " AND ("
-		      "(server_id<>3 AND server_id<>4 AND server_id<>211)"
-		      " AND "
-		      "(NOT (server_id=5 AND host_id='101') AND"
-		      " NOT (server_id=5 AND host_id='102') AND"
-		      " NOT (server_id=6 AND host_id='103') AND"
-		      " NOT (server_id=6 AND host_id='104'))"
+		      "(server_id=1 OR server_id=2 OR server_id=211)"
+		      " OR "
+		      "((server_id=3 AND host_group_id='101') OR"
+		      " (server_id=3 AND host_group_id='102') OR"
+		      " (server_id=4 AND host_group_id='103') OR"
+		      " (server_id=4 AND host_group_id='104'))"
+		      " OR "
+		      "((server_id=5 AND host_id='1001') OR"
+		      " (server_id=5 AND host_id='1002') OR"
+		      " (server_id=6 AND host_id='1003') OR"
+		      " (server_id=6 AND host_id='1004'))"
 		      ")");
 	cppcut_assert_equal(expect, option.getCondition());
 }

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -424,9 +424,10 @@ void test_excludeServers(void)
 	serverIdList.push_back(3);
 	serverIdList.push_back(4);
 	serverIdList.push_back(211);
-	option.setExcludeServerIdList(serverIdList);
+	const bool exclude = true;
+	option.setFilterServerIdList(serverIdList, exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
-		      " AND server_id<>3 AND server_id<>4 AND server_id<>211");
+		      " AND (server_id<>3 AND server_id<>4 AND server_id<>211)");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
@@ -437,7 +438,8 @@ void test_excludeServersWithoutPriviledge(void)
 	serverIdList.push_back(3);
 	serverIdList.push_back(4);
 	serverIdList.push_back(211);
-	option.setExcludeServerIdList(serverIdList);
+	const bool exclude = true;
+	option.setFilterServerIdList(serverIdList, exclude);
 	string expect("0");
 	cppcut_assert_equal(expect, option.getCondition());
 }

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -843,15 +843,27 @@ void test_conditionForAdminWithTargetServerAndHost(gconstpointer data)
 {
 	const bool excludeDefunctServers =
 	  gcut_data_get_boolean(data, "excludeDefunctServers");
-	if (excludeDefunctServers)
-		cut_omit("To be implemented");
-	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	string expect;
+	TestHostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet validServerIdSet;
+	if (excludeDefunctServers) {
+		validServerIdSet.insert(1);
+		validServerIdSet.insert(26);
+		option.callSetValidServerIdSet(&validServerIdSet);
+		expect = StringUtils::sprintf("%s IN (1,26)"
+					      " AND "
+					      "(%s=26 AND %s='32')",
+					      serverIdColumnName.c_str(),
+					      serverIdColumnName.c_str(),
+					      hostIdColumnName.c_str());
+	} else {
+		expect = StringUtils::sprintf("(%s=26 AND %s='32')",
+					      serverIdColumnName.c_str(),
+					      hostIdColumnName.c_str());
+	}
 	option.setExcludeDefunctServers(excludeDefunctServers);
 	option.setTargetServerId(26);
 	option.setTargetHostId("32");
-	string expect = StringUtils::sprintf("(%s=26 AND %s='32')",
-					     serverIdColumnName.c_str(),
-					     hostIdColumnName.c_str());
 	cppcut_assert_equal(expect, option.getCondition());
 }
 

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -420,12 +420,12 @@ void test_getDBTermCodec(void)
 void test_selectPluralServersWithPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	list<ServerIdType> serverIdList;
-	serverIdList.push_back(3);
-	serverIdList.push_back(4);
-	serverIdList.push_back(211);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
 	const bool exclude = true;
-	option.setFilterServerIdList(serverIdList, !exclude);
+	option.setFilterServerIds(serverIdSet, !exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
 		      " AND (server_id=3 OR server_id=4 OR server_id=211)");
 	cppcut_assert_equal(expect, option.getCondition());
@@ -434,12 +434,12 @@ void test_selectPluralServersWithPrivilege(void)
 void test_excludeServersWithPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
-	list<ServerIdType> serverIdList;
-	serverIdList.push_back(3);
-	serverIdList.push_back(4);
-	serverIdList.push_back(211);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
 	const bool exclude = true;
-	option.setFilterServerIdList(serverIdList, exclude);
+	option.setFilterServerIds(serverIdSet, exclude);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
 		      " AND (server_id<>3 AND server_id<>4 AND server_id<>211)");
 	cppcut_assert_equal(expect, option.getCondition());
@@ -448,12 +448,12 @@ void test_excludeServersWithPrivilege(void)
 void test_excludeServersWithoutPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE);
-	list<ServerIdType> serverIdList;
-	serverIdList.push_back(3);
-	serverIdList.push_back(4);
-	serverIdList.push_back(211);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
 	const bool exclude = true;
-	option.setFilterServerIdList(serverIdList, exclude);
+	option.setFilterServerIds(serverIdSet, exclude);
 	string expect("0");
 	cppcut_assert_equal(expect, option.getCondition());
 }

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -458,6 +458,126 @@ void test_excludeServersWithoutPrivilege(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
+void test_selectPluralHostgroupsWithPrivilege(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
+	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet2;
+	hostgroupIdSet1.insert("101");
+	hostgroupIdSet1.insert("102");
+	hostgroupIdSet2.insert("103");
+	hostgroupIdSet2.insert("104");
+	ServerHostGrpSetMap map;
+	map[5] = hostgroupIdSet1;
+	map[6] = hostgroupIdSet2;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, !exclude);
+	option.setFilterHostgroupIds(map, !exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND ("
+		      "(server_id=3 OR server_id=4 OR server_id=211)"
+		      " OR "
+		      "((server_id=5 AND host_group_id='101') OR"
+		      " (server_id=5 AND host_group_id='102') OR"
+		      " (server_id=6 AND host_group_id='103') OR"
+		      " (server_id=6 AND host_group_id='104'))"
+		      ")");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
+void test_excludePluralHostgroupsWithPrivilege(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
+	HostgroupIdSet hostgroupIdSet1, hostgroupIdSet2;
+	hostgroupIdSet1.insert("101");
+	hostgroupIdSet1.insert("102");
+	hostgroupIdSet2.insert("103");
+	hostgroupIdSet2.insert("104");
+	ServerHostGrpSetMap map;
+	map[5] = hostgroupIdSet1;
+	map[6] = hostgroupIdSet2;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, exclude);
+	option.setFilterHostgroupIds(map, exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND ("
+		      "(server_id<>3 AND server_id<>4 AND server_id<>211)"
+		      " AND "
+		      "(NOT (server_id=5 AND host_group_id='101') AND"
+		      " NOT (server_id=5 AND host_group_id='102') AND"
+		      " NOT (server_id=6 AND host_group_id='103') AND"
+		      " NOT (server_id=6 AND host_group_id='104'))"
+		      ")");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
+void test_selectPluralHostsWithPrivilege(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
+	LocalHostIdSet hostIdSet1, hostIdSet2;
+	hostIdSet1.insert("101");
+	hostIdSet1.insert("102");
+	hostIdSet2.insert("103");
+	hostIdSet2.insert("104");
+	ServerHostSetMap map;
+	map[5] = hostIdSet1;
+	map[6] = hostIdSet2;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, !exclude);
+	option.setFilterHostIds(map, !exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND ("
+		      "(server_id=3 OR server_id=4 OR server_id=211)"
+		      " OR "
+		      "((server_id=5 AND host_id='101') OR"
+		      " (server_id=5 AND host_id='102') OR"
+		      " (server_id=6 AND host_id='103') OR"
+		      " (server_id=6 AND host_id='104'))"
+		      ")");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
+void test_excludePluralHostsWithPrivilege(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	ServerIdSet serverIdSet;
+	serverIdSet.insert(3);
+	serverIdSet.insert(4);
+	serverIdSet.insert(211);
+	LocalHostIdSet hostIdSet1, hostIdSet2;
+	hostIdSet1.insert("101");
+	hostIdSet1.insert("102");
+	hostIdSet2.insert("103");
+	hostIdSet2.insert("104");
+	ServerHostSetMap map;
+	map[5] = hostIdSet1;
+	map[6] = hostIdSet2;
+	const bool exclude = true;
+	option.setFilterServerIds(serverIdSet, exclude);
+	option.setFilterHostIds(map, exclude);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND ("
+		      "(server_id<>3 AND server_id<>4 AND server_id<>211)"
+		      " AND "
+		      "(NOT (server_id=5 AND host_id='101') AND"
+		      " NOT (server_id=5 AND host_id='102') AND"
+		      " NOT (server_id=6 AND host_id='103') AND"
+		      " NOT (server_id=6 AND host_id='104'))"
+		      ")");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
 } // namespace testHostResourceQueryOption
 
 namespace testHostResourceQueryOptionWithoutDBSetup {

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -417,7 +417,7 @@ void test_getDBTermCodec(void)
 	                    typeid(*option.getDBTermCodec()));
 }
 
-void test_selectPluralServers(void)
+void test_selectPluralServersWithPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
 	list<ServerIdType> serverIdList;
@@ -431,7 +431,7 @@ void test_selectPluralServers(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_excludeServers(void)
+void test_excludeServersWithPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
 	list<ServerIdType> serverIdList;
@@ -445,7 +445,7 @@ void test_excludeServers(void)
 	cppcut_assert_equal(expect, option.getCondition());
 }
 
-void test_excludeServersWithoutPriviledge(void)
+void test_excludeServersWithoutPrivilege(void)
 {
 	HostResourceQueryOption option(TEST_SYNAPSE);
 	list<ServerIdType> serverIdList;

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -294,7 +294,7 @@ void test_makeSelectCondition(gconstpointer data)
 		string actual = option.getCondition();
 		string expect = makeExpectedConditionForUser(
 		                  userId, testUserInfo[i].flags);
-		if (excludeDefunctServers)
+		if (expect != "0" && excludeDefunctServers)
 			insertValidServerCond(expect, option);
 		cppcut_assert_equal(expect, actual);
 	}
@@ -473,7 +473,7 @@ static void _assertMakeCondition(
 	option.setTargetServerId(targetServerId);
 	option.setTargetHostId(targetHostId);
 	option.setTargetHostgroupId(targetHostgroupId);
-	string cond = option.callMakeCondition(srvHostGrpSetMap);
+	string cond = option.callMakeConditionAllowedHosts(srvHostGrpSetMap);
 	cppcut_assert_equal(expect, cond);
 }
 #define assertMakeCondition(M, ...) \

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -426,7 +426,7 @@ void test_excludeServers(void)
 	serverIdList.push_back(211);
 	option.setExcludeServerIdList(serverIdList);
 	string expect("server_id IN (1,2,3,4,211,222,301)"
-		      " AND serverId<>3 AND serverId<>4 AND serverId<>211");
+		      " AND server_id<>3 AND server_id<>4 AND server_id<>211");
 	cppcut_assert_equal(expect, option.getCondition());
 }
 

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -417,6 +417,31 @@ void test_getDBTermCodec(void)
 	                    typeid(*option.getDBTermCodec()));
 }
 
+void test_excludeServers(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE, USER_ID_SYSTEM);
+	list<ServerIdType> serverIdList;
+	serverIdList.push_back(3);
+	serverIdList.push_back(4);
+	serverIdList.push_back(211);
+	option.setExcludeServerIdList(serverIdList);
+	string expect("server_id IN (1,2,3,4,211,222,301)"
+		      " AND serverId<>3 AND serverId<>4 AND serverId<>211");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
+void test_excludeServersWithoutPriviledge(void)
+{
+	HostResourceQueryOption option(TEST_SYNAPSE);
+	list<ServerIdType> serverIdList;
+	serverIdList.push_back(3);
+	serverIdList.push_back(4);
+	serverIdList.push_back(211);
+	option.setExcludeServerIdList(serverIdList);
+	string expect("0");
+	cppcut_assert_equal(expect, option.getCondition());
+}
+
 } // namespace testHostResourceQueryOption
 
 namespace testHostResourceQueryOptionWithoutDBSetup {

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -470,10 +470,11 @@ static void _assertAllowedServersAndHostgroups(
 {
 	// TEST_SYNAPSE requires DB setup so we use TEST_SYNAPSE_HGRP here
 	TestHostResourceQueryOption option(TEST_SYNAPSE_HGRP);
+	option.callSetAllowedServersAndHostgroups(&srvHostGrpSetMap);
 	option.setTargetServerId(targetServerId);
 	option.setTargetHostId(targetHostId);
 	option.setTargetHostgroupId(targetHostgroupId);
-	string cond = option.callMakeConditionAllowedHosts(srvHostGrpSetMap);
+	string cond = option.callMakeConditionAllowedHosts();
 	cppcut_assert_equal(expect, cond);
 }
 #define assertAllowedServersAndHostgroups(M, ...) \

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -42,7 +42,7 @@ static void initParamChecker(
   gconstpointer data, HostResourceQueryOption &option)
 {
 	option.setTargetServerId(2);
-	string expected = "server_id=2";
+	string expected = "(server_id=2";
 	const type_info &optionType = typeid(option);
 	if (optionType != typeid(HostgroupsQueryOption)) {
 		option.setTargetHostId("4");
@@ -50,6 +50,7 @@ static void initParamChecker(
 		expected += StringUtils::sprintf(" AND %s='4'",
 		                                 hostIdColumnName);
 	}
+	expected += ")";
 	if (typeid(option) == typeid(HostsQueryOption)) {
 		HostsQueryOption &hostsQueryOption =
 		  dynamic_cast<HostsQueryOption &>(option);
@@ -458,7 +459,7 @@ void test_eventQueryOptionGetServerIdColumnName(gconstpointer data)
 	option.setTargetHostgroupId("48");
 	option.setTargetHostId("32");
 	string expect = StringUtils::sprintf(
-	                  "%s.%s=26 AND %s.%s='32' AND %s.%s='48'",
+	                  "(%s.%s=26 AND %s.%s='32' AND %s.%s='48')",
 			  DBTablesMonitoring::TABLE_NAME_EVENTS,
 			  serverIdColumnName.c_str(),
 			  DBTablesMonitoring::TABLE_NAME_EVENTS,


### PR DESCRIPTION
Add member functions to set filters by plural {servers,hostgroups,hosts}.
