### PR TITLE
Can add date and time to the package version.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = server client data data/init.d data/systemd
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-EXTRA_DIST = autogen.sh README.md hatohol.spec \
+EXTRA_DIST = autogen.sh version-generator.sh README.md hatohol.spec \
              COPYING.GPLv3 COPYING.LGPLv3
 
 rpm:    dist hatohol.spec

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# The date and time can be added to the version by
+# setting the environment variable like
+#
+#   $ rm -fr autom4te.cache
+#   $ ADD_DATE_TO_VERSION=1 ./autogen.sh
+
 if [ ! -d m4 ]; then
   mkdir m4
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.63)
 
-AC_INIT(hatohol, 15.07_dev1)
+AC_INIT(hatohol,  m4_esyscmd_s([./version-generator.sh]))
 AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADER(config.h)

--- a/version-generator.sh
+++ b/version-generator.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+version=15.07_dev1
+if [ x$ADD_DATE_TO_VERSION = "x1" ]; then
+  version=${version}_`eval date +%Y%m%d_%H%M%S`
+fi
+echo $version


### PR DESCRIPTION
Developers and tester sometimes would like to use a temporarily
built package. However, it's needed to have a large version number
update the package on the test platfrom.

This patch enables to include date and time to the version string
automatically.