### PR TITLE
Use m4_esyscmd in order to build on CentOS6.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.63)
 
-AC_INIT(hatohol,  m4_esyscmd_s([./version-generator.sh]))
+AC_INIT(hatohol,  m4_esyscmd([./version-generator.sh]))
 AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADER(config.h)

--- a/version-generator.sh
+++ b/version-generator.sh
@@ -3,4 +3,4 @@ version=15.07_dev1
 if [ x$ADD_DATE_TO_VERSION = "x1" ]; then
   version=${version}_`eval date +%Y%m%d_%H%M%S`
 fi
-echo $version
+echo -n $version


### PR DESCRIPTION
This is a fix for the problem that was pointed out at #1541.
I confirmed that it can be build on CentOS 6.