### PR TITLE
Add a new method: DBTablesMonitoring::getSystemInfo()

### DIFF
--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -29,6 +29,7 @@
 #include "SmartTime.h"
 #include "Monitoring.h"
 #include "DBTablesHost.h"
+#include "StatisticsCounter.h"
 
 class EventsQueryOption : public HostResourceQueryOption {
 public:
@@ -139,6 +140,7 @@ private:
 class DBTablesMonitoring : public DBTables {
 public:
 	static const int         MONITORING_DB_VERSION;
+	static constexpr size_t  NUM_EVENTS_COUNTERS = 3;
 	static void reset(void);
 	static const SetupInfo &getConstSetupInfo(void);
 
@@ -274,6 +276,13 @@ public:
 	 * @rerurn A HatoholError insntace.
 	 */
 	HatoholError updateIncidentInfo(IncidentInfo &incidentInfo);
+
+	struct SystemInfo {
+		StatisticsCounter::Slot
+		  eventsCounterPrevSlots[NUM_EVENTS_COUNTERS],
+		  eventsCounterCurrSlots[NUM_EVENTS_COUNTERS];
+	};
+	static void getSystemInfo(SystemInfo &info);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1747,4 +1747,34 @@ void test_getEventsExcludeByHostgroup(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getSystemInfo(void)
+{
+	// get the current number of the events
+	DBTablesMonitoring::SystemInfo systemInfo0;
+	DBTablesMonitoring::getSystemInfo(systemInfo0);
+
+	// write events
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	EventInfoList eventInfoList;
+	for (size_t i = 0; i < NumTestEventInfo; i++)
+		eventInfoList.push_back(testEventInfo[i]);
+	dbMonitoring.addEventInfoList(eventInfoList);
+
+	// get the latest one
+	DBTablesMonitoring::SystemInfo systemInfo1;
+	DBTablesMonitoring::getSystemInfo(systemInfo1);
+
+	for (size_t i = 0; i < DBTablesMonitoring::NUM_EVENTS_COUNTERS; i++) {
+		uint64_t diffPrev =
+		  systemInfo1.eventsCounterPrevSlots[i].number
+		  - systemInfo0.eventsCounterPrevSlots[i].number;
+		cppcut_assert_equal(static_cast<uint64_t>(0), diffPrev);
+
+		uint64_t diffCurr =
+		   systemInfo1.eventsCounterCurrSlots[i].number
+		   - systemInfo0.eventsCounterCurrSlots[i].number;
+		cppcut_assert_equal(NumTestEventInfo, diffCurr);
+	}
+}
+
 } // namespace testDBTablesMonitoring


### PR DESCRIPTION
This methods provides runtime information of the componet.
At this point, events statistics are only available.