### PR TITLE
[server][test] Compare the return value with sorting.

### DIFF
--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -984,6 +984,17 @@ string joinStringVector(const StringVector &strVect, const string &pad,
 	return output;
 }
 
+string sortedJoin(const EventInfoList &events)
+{
+	set<string> strSet;
+	for (auto &event: events)
+		strSet.insert(makeEventOutput(event));
+	string joined;
+	for (auto &output : strSet)
+		joined += output;
+	return joined;
+}
+
 void crash(void)
 {
 	// Accessing the invalid address (NULL) finally causes SIGILL

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -190,6 +190,8 @@ std::string joinStringVector(const mlpl::StringVector &strVect,
                              const std::string &pad = "",
                              bool isPaddingTail = true);
 
+std::string sortedJoin(const EventInfoList &events);
+
 void crash(void);
 void prepareTestDataExcludeDefunctServers(void);
 void fixupForFilteringDefunctServer(

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1563,12 +1563,10 @@ void test_getEventsSelectByHosts(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
-	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
 	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n"
+	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
 	  "3|4|1390000100|123456789|2|4|2|4|41|10002|hostZ2|"
 	    "Status:Unknown, Severity:Critical|\n");
 	cppcut_assert_equal(expected, actual);
@@ -1591,12 +1589,10 @@ void test_getEventsExcludeByHosts(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
-	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
 	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n"
+	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
 	  "3|4|1390000100|123456789|2|4|2|4|41|10002|hostZ2|"
 	    "Status:Unknown, Severity:Critical|\n");
 	cppcut_assert_equal(expected, actual);
@@ -1622,14 +1618,12 @@ void test_getEventsSelectByServersAndHosts(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
+	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n"
 	  "3|1|1362957200|0|0|2|1|2|35|10001|hostZ1|TEST Trigger 2|"
 	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n"
 	  "3|2|1362958000|0|0|3|1|1|41|10002|hostZ2|TEST Trigger 3|\n"
-	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n"
 	  "3|3|1390000000|123456789|1|2|1|2|35|10001|hostZ1|TEST Trigger 2|"
 	    "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n"
 	  "3|4|1390000100|123456789|2|4|2|4|41|10002|hostZ2|"
@@ -1658,9 +1652,7 @@ void test_getEventsExcludeByServersAndSelectByHosts(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
 	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
@@ -1686,9 +1678,7 @@ void test_getEventsSelectByServersAndExcludeByHosts(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
 	  "1|3|1389123457|0|0|3|1|1|11|235013|hostX2|TEST Trigger 1b|\n");
 	cppcut_assert_equal(expected, actual);
@@ -1712,9 +1702,7 @@ void test_getEventsSelectByHostgroup(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
 	  "1|1|1363123456|0|0|2|1|1|10|235012|hostX1|TEST Trigger 1a|"
 	    "{\"expandedDescription\":\"Test Trigger on hostX1\"}\n"
@@ -1743,9 +1731,7 @@ void test_getEventsExcludeByHostgroup(void)
 
 	EventInfoList events;
 	dbMonitoring.getEventInfoList(events, option, NULL);
-	string actual;
-	for (auto &event: events)
-		actual += makeEventOutput(event);
+	string actual = sortedJoin(events);
 	string expected(
 	  "1|1|1363123456|0|0|2|1|1|10|235012|hostX1|TEST Trigger 1a|"
 	    "{\"expandedDescription\":\"Test Trigger on hostX1\"}\n"


### PR DESCRIPTION
The order of a returned event list by getEventInfoList() is
undetermined and depends on the used storage engine.
Thus comparision between the output and the expectation should be
done after sorting.

Actually, some tests such as test_getEventsSelectByServersAndHosts()
fail w/o this fix when MEMORY storage engine is used as.
<pre>
  $ HATOHOL_MYSQL_ENGINE_MEMORY=1 MLPL_LOGGER_LEVEL=WARN ./run-test.sh -t /Monitoring/
</pre>