### PR TITLE
Rest resource factory template

### DIFF
--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -115,6 +115,25 @@ struct FaceRest::ResourceHandlerFactory
 	RestHandlerFunc  m_staticHandlerFunc;
 };
 
+template <class T>
+struct FaceRestResourceHandlerSimpleFactoryTemplate :
+  public FaceRest::ResourceHandlerFactory
+{
+	FaceRestResourceHandlerSimpleFactoryTemplate(
+	  FaceRest *faceRest, typename T::HandlerFunc handler)
+	: FaceRest::ResourceHandlerFactory(faceRest, NULL),
+	  m_handlerFunc(handler)
+	{
+	}
+
+	virtual FaceRest::ResourceHandler *createHandler(void) override
+	{
+		return new T(m_faceRest, m_handlerFunc);
+	}
+
+	typename T::HandlerFunc m_handlerFunc;
+};
+
 #define REPLY_ERROR(JOB, ERR_CODE, ERR_MSG_FMT, ...) \
 do { \
 	std::string optMsg \

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -116,6 +116,21 @@ struct FaceRest::ResourceHandlerFactory
 };
 
 template <class T>
+struct FaceRestResourceHandlerArg0FactoryTemplate :
+  public FaceRest::ResourceHandlerFactory
+{
+	FaceRestResourceHandlerArg0FactoryTemplate(FaceRest *faceRest)
+	: FaceRest::ResourceHandlerFactory(faceRest, NULL)
+	{
+	}
+
+	virtual FaceRest::ResourceHandler *createHandler(void) override
+	{
+		return new T(m_faceRest);
+	}
+};
+
+template <class T>
 struct FaceRestResourceHandlerSimpleFactoryTemplate :
   public FaceRest::ResourceHandlerFactory
 {

--- a/server/src/RestResourceAction.cc
+++ b/server/src/RestResourceAction.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -23,6 +23,9 @@
 
 using namespace std;
 using namespace mlpl;
+
+typedef FaceRestResourceHandlerArg0FactoryTemplate<RestResourceAction>
+  RestResourceActionFactory;
 
 const char *RestResourceAction::pathForAction = "/action";
 
@@ -375,14 +378,4 @@ void RestResourceAction::handlePut(void)
 	agent.add("id", actionDef.id);
 	agent.endObject();
 	replyJSONData(agent);
-}
-
-RestResourceActionFactory::RestResourceActionFactory(FaceRest *faceRest)
-: FaceRest::ResourceHandlerFactory(faceRest, NULL)
-{
-}
-
-FaceRest::ResourceHandler *RestResourceActionFactory::createHandler()
-{
-	return new RestResourceAction(m_faceRest);
 }

--- a/server/src/RestResourceAction.h
+++ b/server/src/RestResourceAction.h
@@ -39,10 +39,4 @@ struct RestResourceAction : public FaceRest::ResourceHandler
 	static const char *pathForAction;
 };
 
-struct RestResourceActionFactory : public FaceRest::ResourceHandlerFactory
-{
-	RestResourceActionFactory(FaceRest *faceRest);
-	virtual FaceRest::ResourceHandler *createHandler(void) override;
-};
-
 #endif // RestResourceAction_h

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -24,6 +24,9 @@
 
 using namespace std;
 using namespace mlpl;
+
+typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceHost>
+  RestResourceHostFactory;
 
 const char *RestResourceHost::pathForOverview  = "/overview";
 const char *RestResourceHost::pathForHost      = "/host";
@@ -1327,15 +1330,4 @@ void RestResourceHost::handlerGetHostgroup(void)
 	agent.endObject();
 
 	replyJSONData(agent);
-}
-
-RestResourceHostFactory::RestResourceHostFactory(
-  FaceRest *faceRest, RestResourceHost::HandlerFunc handler)
-: FaceRest::ResourceHandlerFactory(faceRest, NULL), m_handlerFunc(handler)
-{
-}
-
-FaceRest::ResourceHandler *RestResourceHostFactory::createHandler()
-{
-	return new RestResourceHost(m_faceRest, m_handlerFunc);
 }

--- a/server/src/RestResourceHost.h
+++ b/server/src/RestResourceHost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -62,15 +62,6 @@ struct RestResourceHost : public FaceRest::ResourceHandler
 	static const char *pathForHostgroup;
 
 	HandlerFunc m_handlerFunc;
-};
-
-struct RestResourceHostFactory : public FaceRest::ResourceHandlerFactory
-{
-	RestResourceHostFactory(FaceRest *faceRest,
-				RestResourceHost::HandlerFunc handler);
-	virtual FaceRest::ResourceHandler *createHandler(void) override;
-
-	RestResourceHost::HandlerFunc m_handlerFunc;
 };
 
 #endif // RestResourceHost_h

--- a/server/src/RestResourceIncidentTracker.cc
+++ b/server/src/RestResourceIncidentTracker.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -24,6 +24,9 @@
 
 using namespace std;
 using namespace mlpl;
+
+typedef FaceRestResourceHandlerArg0FactoryTemplate<RestResourceIncidentTracker>
+  RestResourceIncidentTrackerFactory;
 
 const char *RestResourceIncidentTracker::pathForIncidentTracker =
   "/incident-tracker";
@@ -230,15 +233,4 @@ void RestResourceIncidentTracker::handleDelete(void)
 	agent.add("id", incidentTrackerId);
 	agent.endObject();
 	replyJSONData(agent);
-}
-
-RestResourceIncidentTrackerFactory::RestResourceIncidentTrackerFactory(
-  FaceRest *faceRest)
-: FaceRest::ResourceHandlerFactory(faceRest, NULL)
-{
-}
-
-FaceRest::ResourceHandler *RestResourceIncidentTrackerFactory::createHandler()
-{
-	return new RestResourceIncidentTracker(m_faceRest);
 }

--- a/server/src/RestResourceIncidentTracker.h
+++ b/server/src/RestResourceIncidentTracker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -37,13 +37,6 @@ struct RestResourceIncidentTracker : public FaceRest::ResourceHandler
 	void handleDelete(void);
 
 	static const char *pathForIncidentTracker;
-};
-
-struct RestResourceIncidentTrackerFactory
-: public FaceRest::ResourceHandlerFactory
-{
-	RestResourceIncidentTrackerFactory(FaceRest *faceRest);
-	virtual FaceRest::ResourceHandler *createHandler(void) override;
 };
 
 #endif // RestResourceIncidentTracker_h

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -29,6 +29,9 @@
 using namespace std;
 using namespace mlpl;
 
+typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceServer>
+  RestResourceServerFactory;
+
 const char *RestResourceServer::pathForServer         = "/server";
 const char *RestResourceServer::pathForServerType     = "/server-type";
 const char *RestResourceServer::pathForServerConnStat = "/server-conn-stat";
@@ -745,14 +748,3 @@ void RestResourceServer::handlerServerConnStat(void)
 	replyJSONData(agent);
 }
 
-RestResourceServerFactory::RestResourceServerFactory(
-  FaceRest *faceRest, RestResourceServer::HandlerFunc handler)
-: FaceRest::ResourceHandlerFactory(faceRest, NULL),
-  m_handlerFunc(handler)
-{
-}
-
-FaceRest::ResourceHandler *RestResourceServerFactory::createHandler()
-{
-	return new RestResourceServer(m_faceRest, m_handlerFunc);
-}

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *

--- a/server/src/RestResourceServer.h
+++ b/server/src/RestResourceServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *

--- a/server/src/RestResourceServer.h
+++ b/server/src/RestResourceServer.h
@@ -51,13 +51,4 @@ struct RestResourceServer : public FaceRest::ResourceHandler
 	HandlerFunc m_handlerFunc;
 };
 
-struct RestResourceServerFactory : public FaceRest::ResourceHandlerFactory
-{
-	RestResourceServerFactory(FaceRest *faceRest,
-				  RestResourceServer::HandlerFunc handler);
-	virtual FaceRest::ResourceHandler *createHandler(void) override;
-
-	RestResourceServer::HandlerFunc m_handlerFunc;
-};
-
 #endif // RestResourceServer_h

--- a/server/src/RestResourceUser.cc
+++ b/server/src/RestResourceUser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -23,6 +23,9 @@
 
 using namespace std;
 using namespace mlpl;
+
+typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceUser>
+  RestResourceUserFactory;
 
 const char *RestResourceUser::pathForUser     = "/user";
 const char *RestResourceUser::pathForUserRole = "/user-role";
@@ -612,15 +615,4 @@ HatoholError RestResourceUser::updateOrAddUser(GHashTable *query,
 	if (err != HTERR_OK)
 		return err;
 	return HatoholError(HTERR_OK);
-}
-
-RestResourceUserFactory::RestResourceUserFactory(
-  FaceRest *faceRest, RestResourceUser::HandlerFunc handler)
-: FaceRest::ResourceHandlerFactory(faceRest, NULL), m_handlerFunc(handler)
-{
-}
-
-FaceRest::ResourceHandler *RestResourceUserFactory::createHandler()
-{
-	return new RestResourceUser(m_faceRest, m_handlerFunc);
 }

--- a/server/src/RestResourceUser.h
+++ b/server/src/RestResourceUser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -74,15 +74,6 @@ struct RestResourceUser : public FaceRest::ResourceHandler
 	static const std::string pathForUserMe;
 
 	HandlerFunc m_handlerFunc;
-};
-
-struct RestResourceUserFactory : public FaceRest::ResourceHandlerFactory
-{
-	RestResourceUserFactory(FaceRest *faceRest,
-				RestResourceUser::HandlerFunc handler);
-	virtual FaceRest::ResourceHandler *createHandler(void) override;
-
-	RestResourceUser::HandlerFunc m_handlerFunc;
 };
 
 #endif // RestResourceUser_h


### PR DESCRIPTION
Currently, subclasses of FaceRest::ResourceHandler have their own
Factory classes. However, their implementations are basically similar.
So these patches provide the following two template methods to realize
them with a tiny code.
- FaceRestResourceHandlerSimpleFactoryTemplate
- FaceRestResourceHandlerArg0FactoryTemplate