### PR TITLE
[server][FaceRest::ResourceHandler] Eleminate redundant lines.

### DIFF
--- a/server/src/RestResourceAction.cc
+++ b/server/src/RestResourceAction.cc
@@ -36,7 +36,7 @@ void RestResourceAction::registerFactories(FaceRest *faceRest)
 }
 
 RestResourceAction::RestResourceAction(FaceRest *faceRest)
-: FaceRest::ResourceHandler(faceRest, NULL)
+: FaceRest::ResourceHandler(faceRest)
 {
 }
 

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -74,18 +74,13 @@ void RestResourceHost::registerFactories(FaceRest *faceRest)
 }
 
 RestResourceHost::RestResourceHost(FaceRest *faceRest, HandlerFunc handler)
-: FaceRest::ResourceHandler(faceRest, NULL), m_handlerFunc(handler)
+: FaceRest::ResourceHandler(faceRest, NULL,
+                            static_cast<RestMemberHandler>(handler))
 {
 }
 
 RestResourceHost::~RestResourceHost()
 {
-}
-
-void RestResourceHost::handle(void)
-{
-	HATOHOL_ASSERT(m_handlerFunc, "No handler function!");
-	(this->*m_handlerFunc)();
 }
 
 static HatoholError parseSortTypeFromQuery(

--- a/server/src/RestResourceHost.h
+++ b/server/src/RestResourceHost.h
@@ -31,8 +31,6 @@ struct RestResourceHost : public FaceRest::ResourceHandler
 	RestResourceHost(FaceRest *faceRest, HandlerFunc handler);
 	virtual ~RestResourceHost();
 
-	virtual void handle(void) override;
-
 	void handlerGetOverview(void);
 	void handlerGetHost(void);
 	void handlerGetTrigger(void);

--- a/server/src/RestResourceIncidentTracker.cc
+++ b/server/src/RestResourceIncidentTracker.cc
@@ -39,7 +39,7 @@ void RestResourceIncidentTracker::registerFactories(FaceRest *faceRest)
 }
 
 RestResourceIncidentTracker::RestResourceIncidentTracker(FaceRest *faceRest)
-: FaceRest::ResourceHandler(faceRest, NULL)
+: FaceRest::ResourceHandler(faceRest)
 {
 }
 

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -54,18 +54,13 @@ void RestResourceServer::registerFactories(FaceRest *faceRest)
 
 RestResourceServer::RestResourceServer(
   FaceRest *faceRest, RestResourceServer::HandlerFunc handler)
-: FaceRest::ResourceHandler(faceRest, NULL), m_handlerFunc(handler)
+: FaceRest::ResourceHandler(
+    faceRest, NULL, static_cast<RestMemberHandler>(handler))
 {
 }
 
 RestResourceServer::~RestResourceServer()
 {
-}
-
-void RestResourceServer::handle(void)
-{
-	HATOHOL_ASSERT(m_handlerFunc, "No handler function!");
-	(this->*m_handlerFunc)();
 }
 
 static bool canUpdateServer(

--- a/server/src/RestResourceServer.h
+++ b/server/src/RestResourceServer.h
@@ -31,8 +31,6 @@ struct RestResourceServer : public FaceRest::ResourceHandler
 	RestResourceServer(FaceRest *faceRest, HandlerFunc handler);
 	virtual ~RestResourceServer();
 
-	virtual void handle(void) override;
-
 	void handlerServer(void);
 	void handlerGetServer(void);
 	void handlerPostServer(void);
@@ -47,8 +45,6 @@ struct RestResourceServer : public FaceRest::ResourceHandler
 	static const char *pathForServerConnStat;
 
 	void triggerFetchedCallback(Closure0 *closure);
-
-	HandlerFunc m_handlerFunc;
 };
 
 #endif // RestResourceServer_h

--- a/server/src/RestResourceUser.cc
+++ b/server/src/RestResourceUser.cc
@@ -50,18 +50,13 @@ const string &RestResourceUser::getPathForUserMe(void)
 }
 
 RestResourceUser::RestResourceUser(FaceRest *faceRest, HandlerFunc handler)
-: FaceRest::ResourceHandler(faceRest, NULL), m_handlerFunc(handler)
+: FaceRest::ResourceHandler(
+    faceRest, NULL, static_cast<RestMemberHandler>(handler))
 {
 }
 
 RestResourceUser::~RestResourceUser()
 {
-}
-
-void RestResourceUser::handle(void)
-{
-	HATOHOL_ASSERT(m_handlerFunc, "No handler function!");
-	(this->*m_handlerFunc)();
 }
 
 bool RestResourceUser::pathIsUserMe(void)

--- a/server/src/RestResourceUser.h
+++ b/server/src/RestResourceUser.h
@@ -32,8 +32,6 @@ struct RestResourceUser : public FaceRest::ResourceHandler
 	RestResourceUser(FaceRest *faceRest, HandlerFunc handler);
 	virtual ~RestResourceUser();
 
-	virtual void handle(void) override;
-
 	bool pathIsUserMe(void);
 
 	void handlerUser(void);
@@ -72,8 +70,6 @@ struct RestResourceUser : public FaceRest::ResourceHandler
 	static const char *pathForUser;
 	static const char *pathForUserRole;
 	static const std::string pathForUserMe;
-
-	HandlerFunc m_handlerFunc;
 };
 
 #endif // RestResourceUser_h


### PR DESCRIPTION
Some sub classes of ResoureHandler had to implement similar manadatory
methods such as handler(). This patch addressed the boring work by
calling the handler in the base class: ResourceHandler instead of
each sub class.