### PR TITLE
[server][FaceRest] Use an organized name.

### DIFF
--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -616,8 +616,9 @@ void FaceRest::handlerLogout(ResourceHandler *job)
 // ---------------------------------------------------------------------------
 
 FaceRest::ResourceHandler::ResourceHandler(
-  FaceRest *faceRest, RestHandlerFunc handler, RestMemberHandler memberHandler)
-: m_faceRest(faceRest), m_staticHandlerFunc(handler),
+  FaceRest *faceRest,
+  RestStaticHandler staticHandler, RestMemberHandler memberHandler)
+: m_faceRest(faceRest), m_staticHandler(staticHandler),
   m_memberHandler(memberHandler), m_message(NULL),
   m_path(), m_query(NULL), m_client(NULL), m_mimeType(NULL),
   m_userId(INVALID_USER_ID), m_replyIsPrepared(false)
@@ -655,8 +656,8 @@ void FaceRest::ResourceHandler::handle(void)
 		(this->*m_memberHandler)();
 		return;
 	}
-	HATOHOL_ASSERT(m_staticHandlerFunc, "No handler function!");
-	m_staticHandlerFunc(this);
+	HATOHOL_ASSERT(m_staticHandler, "No handler!");
+	m_staticHandler(this);
 }
 
 void FaceRest::ResourceHandler::handleInTryBlock(void)
@@ -1097,9 +1098,10 @@ void FaceRest::ResourceHandler::addServersMap(
 }
 
 FaceRest::ResourceHandlerFactory::ResourceHandlerFactory(
-  FaceRest *faceRest, RestHandlerFunc handler, RestMemberHandler memberHandler)
-: m_faceRest(faceRest), m_staticHandlerFunc(handler),
-  m_memberHandler(memberHandler)
+  FaceRest *faceRest,
+  RestStaticHandler staticHandler, RestMemberHandler memberHandler)
+: m_faceRest(faceRest),
+  m_staticHandler(staticHandler), m_memberHandler(memberHandler)
 {
 }
 
@@ -1117,6 +1119,5 @@ void FaceRest::ResourceHandlerFactory::destroy(gpointer data)
 FaceRest::ResourceHandler *
 FaceRest::ResourceHandlerFactory::createHandler(void)
 {
-	return new ResourceHandler(m_faceRest, m_staticHandlerFunc,
-	                           m_memberHandler);
+	return new ResourceHandler(m_faceRest, m_staticHandler, m_memberHandler);
 }

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -29,7 +29,7 @@ static const uint64_t INVALID_ID = -1;
 typedef std::map<TriggerIdType, std::string> TriggerBriefMap;
 typedef std::map<ServerIdType, TriggerBriefMap> TriggerBriefMaps;
 
-typedef void (*RestHandlerFunc) (FaceRest::ResourceHandler *job);
+typedef void (*RestStaticHandler)(FaceRest::ResourceHandler *job);
 typedef void (FaceRest::ResourceHandler::*RestMemberHandler)(void);
 
 enum FormatType {
@@ -44,14 +44,15 @@ public:
 	/**
 	 * Constructor of ResourceHandler.
 	 *
-	 * At least handler or memberHandler should be non-NULL. When both
-	 * are set, memberHandler is used on handle().
+	 * At least staticHandler or memberHandler should be non-NULL.
+	 * When both are set, memberHandler is used on handle().
 	 *
 	 * @param faceRest A FaceRest instance.
-	 * @param handler  A handler (a static function).
+	 * @param staticHandler A handler (a static function).
 	 * @param memberHandler A handler (a member function).
 	 */
-	ResourceHandler(FaceRest *faceRest, RestHandlerFunc handler = NULL,
+	ResourceHandler(FaceRest *faceRest,
+	                RestStaticHandler staticHandler = NULL,
 	                RestMemberHandler memberHandler = NULL);
 	virtual ~ResourceHandler();
 	virtual bool setRequest(SoupMessage *msg,
@@ -91,7 +92,7 @@ public:
 
 public:
 	FaceRest          *m_faceRest;
-	RestHandlerFunc    m_staticHandlerFunc;
+	RestStaticHandler  m_staticHandler;
 	RestMemberHandler  m_memberHandler;
 
 	// arguments of SoupServerCallback
@@ -119,14 +120,15 @@ protected:
 
 struct FaceRest::ResourceHandlerFactory
 {
-	ResourceHandlerFactory(FaceRest *faceRest, RestHandlerFunc handler,
+	ResourceHandlerFactory(FaceRest *faceRest,
+	                       RestStaticHandler staticHandler = NULL,
 	                       RestMemberHandler memberHandler = NULL);
 	virtual ~ResourceHandlerFactory();
 	virtual ResourceHandler *createHandler(void);
 	static void destroy(gpointer data);
 
 	FaceRest         *m_faceRest;
-	RestHandlerFunc   m_staticHandlerFunc;
+	RestStaticHandler m_staticHandler;
 	RestMemberHandler m_memberHandler;
 };
 


### PR DESCRIPTION
m_staticHandlerFunc ->
m_staticHandler

RestHandlerFunc ->
RestStaticHandler

As a result, we can make it easy to see the following pair.

  RestStaticHandler <-> RestMemberHandler