### PR TITLE
Events statistics system wide

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2681,9 +2681,12 @@ uint64_t DBTablesMonitoring::getLastUpdateTimeOfIncidents(
 	return itemGroupStream.read<uint64_t>();
 }
 
-void DBTablesMonitoring::getSystemInfo(
-  DBTablesMonitoring::SystemInfo &systemInfo)
+HatoholError DBTablesMonitoring::getSystemInfo(
+  DBTablesMonitoring::SystemInfo &systemInfo, const DataQueryOption &option)
 {
+	if (!option.has(OPPRVLG_GET_SYSTEM_INFO))
+		return HatoholError(HTERR_INVALID_USER);
+
 	StatisticsCounter::Slot *prevSlot = NULL;
 	StatisticsCounter::Slot *currSlot = NULL;
 	for (size_t i = 0; i < NUM_EVENTS_COUNTERS; i++) {
@@ -2691,6 +2694,7 @@ void DBTablesMonitoring::getSystemInfo(
 		currSlot = &systemInfo.eventsCounterCurrSlots[i];
 		eventsCounters[i]->get(prevSlot, currSlot);
 	}
+	return HatoholError(HTERR_OK);
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -287,7 +287,8 @@ public:
 		  eventsCounterPrevSlots[NUM_EVENTS_COUNTERS],
 		  eventsCounterCurrSlots[NUM_EVENTS_COUNTERS];
 	};
-	static void getSystemInfo(SystemInfo &info);
+	static HatoholError getSystemInfo(SystemInfo &info,
+	                                  const DataQueryOption &option);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -43,6 +43,7 @@
 #include "HatoholArmPluginInterface.h"
 #include "HatoholArmPluginGate.h"
 #endif
+#include "RestResourceSystem.h"
 #include "RestResourceAction.h"
 #include "RestResourceHost.h"
 #include "RestResourceIncidentTracker.h"
@@ -398,6 +399,7 @@ gpointer FaceRest::mainThread(HatoholThreadArg *arg)
 	m_impl->addHandler(
 	  pathForLogout,
 	  new RestResourceStaticHandlerFactory(this, handlerLogout));
+	RestResourceSystem::registerFactories(this);
 	RestResourceUser::registerFactories(this);
 	RestResourceServer::registerFactories(this);
 	RestResourceHost::registerFactories(this);

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -68,6 +68,7 @@ libhatohol_la_SOURCES = \
 	RestResourceHost.cc RestResourceHost.h \
 	RestResourceIncidentTracker.cc RestResourceIncidentTracker.h \
 	RestResourceServer.cc RestResourceServer.h \
+	RestResourceSystem.cc RestResourceSystem.h \
 	RestResourceUser.cc RestResourceUser.h \
 	SessionManager.cc SessionManager.h \
 	SQLProcessorTypes.h \

--- a/server/src/OperationPrivilege.h
+++ b/server/src/OperationPrivilege.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Project Hatohol
+ * Copyright (C) 2013,2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -64,6 +64,10 @@ enum OperationPrivilegeType
 	OPPRVLG_UPDATE_INCIDENT_SETTING,  // can update IncidentTracker & IncidentSender
 	OPPRVLG_DELETE_INCIDENT_SETTING,  // can delete IncidentTracker & IncidentSender
 	OPPRVLG_GET_ALL_INCIDENT_SETTINGS,// can get all IncidentTracker & IncidentSender
+
+	// Othrer
+	OPPRVLG_GET_SYSTEM_INFO,
+	OPPRVLG_SYSTEM_OPERATION,
 
 	NUM_OPPRVLG,
 };

--- a/server/src/RestResourceSystem.cc
+++ b/server/src/RestResourceSystem.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "RestResourceSystem.h"
+#include "UnifiedDataStore.h"
+
+typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceSystem>
+  RestResourceSystemFactory;
+
+const char *RestResourceSystem::pathForSystemInfo = "/system-info";
+
+void RestResourceSystem::registerFactories(FaceRest *faceRest)
+{
+	faceRest->addResourceHandlerFactory(
+	  pathForSystemInfo,
+	  new RestResourceSystemFactory(
+	        faceRest, &RestResourceSystem::handlerSystemInfo));
+}
+
+RestResourceSystem::RestResourceSystem(FaceRest *faceRest, HandlerFunc handler)
+: RestResourceMemberHandler(faceRest, static_cast<RestMemberHandler>(handler))
+{
+}
+
+void RestResourceSystem::handlerSystemInfo(void)
+{
+	if (!httpMethodIs("GET")) {
+		MLPL_ERR("Unknown method: %s\n", m_message->method);
+		replyHttpStatus(SOUP_STATUS_METHOD_NOT_ALLOWED);
+	}
+
+	DataQueryOption option(m_dataQueryContextPtr);
+
+	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+	UnifiedDataStore::SystemInfo systemInfo;
+	dataStore->getSystemInfo(systemInfo, option);
+
+	JSONBuilder reply;
+	reply.startObject();
+	reply.startArray("eventRates");
+	for (size_t i = 0; i < DBTablesMonitoring::NUM_EVENTS_COUNTERS; i++) {
+		struct {
+			const char *label;
+			StatisticsCounter::Slot *slot;
+		} const params[] = {
+		{
+			"previous",
+			&systemInfo.monitoring.eventsCounterPrevSlots[i],
+		}, {
+			"current",
+			&systemInfo.monitoring.eventsCounterCurrSlots[i],
+		},
+		};
+
+		reply.startObject();
+		for (auto &param : params) {
+			reply.startObject(param.label);
+			reply.add("startTime", param.slot->startTime);
+			reply.add("endTime", param.slot->endTime);
+			reply.add("number", param.slot->number);
+			reply.endObject(); // label
+		}
+		reply.endObject();
+	}
+	reply.endArray(); // eventRates
+
+	addHatoholError(reply, HatoholError(HTERR_OK));
+	reply.endObject();
+	replyJSONData(reply);
+}
+

--- a/server/src/RestResourceSystem.h
+++ b/server/src/RestResourceSystem.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef RestResourceSystem_h
+#define RestResourceSystem_h
+
+#include "FaceRestPrivate.h"
+
+struct RestResourceSystem : public RestResourceMemberHandler
+{
+public:
+	typedef void (RestResourceSystem::*HandlerFunc)(void);
+
+	static const char *pathForSystemInfo;
+
+	static void registerFactories(FaceRest *faceRest);
+
+	RestResourceSystem(FaceRest *faceRest, HandlerFunc handler);
+	void handlerSystemInfo(void);
+};
+
+#endif // RestResourceSystem_h
+

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -919,6 +919,12 @@ DataStorePtr UnifiedDataStore::getDataStore(const ServerIdType &serverId)
 	return m_impl->getDataStore(serverId);
 }
 
+void UnifiedDataStore::getSystemInfo(
+  SystemInfo &systemInfo, const DataQueryOption &option)
+{
+	DBTablesMonitoring::getSystemInfo(systemInfo.monitoring, option);
+}
+
 bool UnifiedDataStore::getIncidentTrackerInfo(const IncidentTrackerIdType &trackerId,
 					      IncidentTrackerInfo &trackerInfo)
 {

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -294,6 +294,13 @@ public:
 	bool getIncidentTrackerInfo(const IncidentTrackerIdType &trackerId,
                                     IncidentTrackerInfo &trackerInfo);
 
+
+	struct SystemInfo {
+		DBTablesMonitoring::SystemInfo monitoring;
+	};
+	void getSystemInfo(SystemInfo &systemInfo,
+	                   const DataQueryOption &option);
+
 protected:
 	void fetchItems(const ServerIdType &targetServerId = ALL_SERVERS);
 

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -1160,6 +1160,19 @@ UserIdType findUserWith(const OperationPrivilegeType &type,
 	return findUserCommon(type, true, excludeFlags);
 }
 
+UserIdType findUserWith(const OperationPrivilegeFlag &privFlag)
+{
+	UserIdType userId = INVALID_USER_ID;
+	for (size_t i = 0; i < NumTestUserInfo; i++) {
+		const UserInfo &userInfo = testUserInfo[i];
+		if (userInfo.flags == privFlag)
+			userId = i + 1;
+	}
+	cppcut_assert_not_equal(INVALID_USER_ID, userId);
+	cppcut_assert_not_equal(USER_ID_SYSTEM, userId);
+	return userId;
+}
+
 UserIdType findUserWithout(const OperationPrivilegeType &type)
 {
 	return findUserCommon(type, false);

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -220,6 +220,7 @@ void releaseDefaultContext(void);
 UserIdType searchMaxTestUserId(void);
 UserIdType findUserWith(const OperationPrivilegeType &type,
                         const OperationPrivilegeFlag &excludeFlags = 0);
+UserIdType findUserWith(const OperationPrivilegeFlag &privFlag);
 UserIdType findUserWithout(const OperationPrivilegeType &type);
 void initActionDef(ActionDef &actionDef);
 std::string getSyslogTail(size_t numLines);

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -65,7 +65,8 @@ testHatohol_la_SOURCES = \
 	testOperationPrivilege.cc \
 	testSQLUtils.cc \
 	testMySQLWorkerZabbix.cc \
-	testFaceRest.cc testFaceRestAction.cc testFaceRestHost.cc \
+	testFaceRest.cc \
+	testFaceRestSystem.cc testFaceRestAction.cc testFaceRestHost.cc \
 	testFaceRestServer.cc testFaceRestUser.cc testFaceRestNoInit.cc \
 	testFaceRestIncidentTracker.cc testSessionManager.cc \
 	testIncidentSenderRedmine.cc \

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1741,9 +1741,11 @@ void test_getEventsExcludeByHostgroup(void)
 
 void test_getSystemInfo(void)
 {
+	DataQueryOption option(findUserWith(OPPRVLG_GET_SYSTEM_INFO));
 	// get the current number of the events
 	DBTablesMonitoring::SystemInfo systemInfo0;
-	DBTablesMonitoring::getSystemInfo(systemInfo0);
+	assertHatoholError(
+	  HTERR_OK, DBTablesMonitoring::getSystemInfo(systemInfo0, option));
 
 	// write events
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
@@ -1754,7 +1756,8 @@ void test_getSystemInfo(void)
 
 	// get the latest one
 	DBTablesMonitoring::SystemInfo systemInfo1;
-	DBTablesMonitoring::getSystemInfo(systemInfo1);
+	assertHatoholError(
+	  HTERR_OK, DBTablesMonitoring::getSystemInfo(systemInfo1, option));
 
 	for (size_t i = 0; i < DBTablesMonitoring::NUM_EVENTS_COUNTERS; i++) {
 		uint64_t diffPrev =
@@ -1768,6 +1771,15 @@ void test_getSystemInfo(void)
 		cppcut_assert_equal(static_cast<uint64_t>(NumTestEventInfo),
 				    diffCurr);
 	}
+}
+
+void test_getSystemInfoByInvalidUser(void)
+{
+	DataQueryOption option(findUserWithout(OPPRVLG_GET_SYSTEM_INFO));
+	DBTablesMonitoring::SystemInfo systemInfo;
+	assertHatoholError(
+	  HTERR_INVALID_USER,
+	  DBTablesMonitoring::getSystemInfo(systemInfo, option));
 }
 
 } // namespace testDBTablesMonitoring

--- a/server/test/testFaceRestSystem.cc
+++ b/server/test/testFaceRestSystem.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <cppcutter.h>
+#include "Hatohol.h"
+#include "Helpers.h"
+#include "DBTablesTest.h"
+#include "RestResourceSystem.h"
+#include "FaceRestTestUtils.h"
+using namespace std;
+using namespace mlpl;
+
+namespace testFaceRestSystem {
+
+void cut_setup(void)
+{
+	hatoholInit();
+	setupTestDB();
+	loadTestDBTablesConfig();
+	loadTestDBUser();
+}
+
+void cut_teardown(void)
+{
+	stopFaceRest();
+}
+
+void test_systemInfo(void)
+{
+	startFaceRest();
+	RequestArg arg("/system-info");
+	arg.userId = findUserWith(OPPRVLG_GET_SYSTEM_INFO);
+	unique_ptr<JSONParser> parserPtr(getResponseAsJSONParser(arg));
+	JSONParser *parser = parserPtr.get();
+	assertErrorCode(parser);
+
+	auto assertTime = [&](const char *label) {
+		string s;
+		cppcut_assert_equal(true, parser->read(label, s));
+		cppcut_assert_equal(false, s.empty());
+		cppcut_assert_equal(true, StringUtils::isNumber(s));
+	};
+
+	auto assertNumber = [&]() {
+		int64_t n;
+		cppcut_assert_equal(true, parser->read("number", n));
+	};
+
+	assertStartObject(parser, "eventRates");
+	for (size_t i = 0; i < DBTablesMonitoring::NUM_EVENTS_COUNTERS; i++) {
+		parser->startElement(i);
+		for (auto label : {"previous", "current"}) {
+			assertStartObject(parser, label);
+			for (auto label : {"startTime", "endTime"})
+				assertTime(label);
+			assertNumber();
+			parser->endObject();
+		}
+		parser->endElement();
+	}
+}
+
+} // namespace testFaceRestSystem

--- a/server/tools/hatohol/voyager.py
+++ b/server/tools/hatohol/voyager.py
@@ -210,6 +210,11 @@ def server_conn_stat(url, args):
     return {"url": url, "postproc": open_url_and_show_response}
 
 
+def system_info(url, args):
+    url = url + "/system-info"
+    return {"url": url, "postproc": open_url_and_show_response}
+
+
 command_map = {
     "test": do_test,
     "login": login,
@@ -226,6 +231,7 @@ command_map = {
     "add-user": add_user,
     "del-user": del_user,
     "server-conn-stat": server_conn_stat,
+    "system-info": system_info,
 }
 
 
@@ -295,6 +301,9 @@ def main(arg_list=None, exec_postproc=True):
 
     # server-conn-stat
     sub_svconnstat = subparsers.add_parser("server-conn-stat")
+
+    # system-info
+    sub_system_info = subparsers.add_parser("system-info")
 
     args = parser.parse_args(arg_list)
     cmd_ctx = command_map[args.sub_command](args.server_url, args)


### PR DESCRIPTION
This Pull Request adds a new REST API /system-info.

The API provides the system information. However, Currently
the feature only deals with the number of events every
10, 100, and 1000 seconds.