### PR TITLE
[wercker][CentOS] Specify commit in Wercker with its environment variable

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -5,4 +5,5 @@ build:
         name: Build a CentOS 6.6 Docker Hatohol image box
         code: |
           docker -v
+          echo ${WERCKER_GIT_COMMIT} > wercker/GIT_REVISION
           docker build -t centos66/build-hatohol wercker/

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -22,6 +22,10 @@ RUN rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-
 RUN yum install -y cutter tar
 # git clone
 RUN git clone https://github.com/project-hatohol/hatohol.git ~/hatohol
+# set CI terget to WERCKER_GIT_COMMIT
+ADD ./GIT_REVISION /root/hatohol/wercker/
+RUN cd ~/hatohol && git fetch origin
+RUN cd ~/hatohol && git checkout -qf `cat ~/hatohol/wercker/GIT_REVISION`
 # build
 RUN cd ~/hatohol && libtoolize && autoreconf -i
 RUN cd ~/hatohol && scl enable devtoolset-2 "./configure"


### PR DESCRIPTION
Related to #1563.

Wercker is working like this: https://app.wercker.com/#build/55ff8629ee52f86b6d085d88

For future work:
Docker 1.9 or later will support environment variables interpolation in building time.
In more detail, refer to this docker repo's PR: https://github.com/docker/docker/pull/15182