### PR TITLE
[server] Add REST API to get only number of events

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2540,6 +2540,23 @@ HatoholError DBTablesMonitoring::getNumberOfMonitoredItemsPerSecond
 	return HatoholError(HTERR_OK);
 }
 
+size_t DBTablesMonitoring::getNumberOfEvents(const EventsQueryOption &option)
+{
+	DBClientJoinBuilder builder(tableProfileEvents, &option);
+	string stmt =
+	  StringUtils::sprintf("count(distinct %s)",
+	    option.getColumnName(IDX_EVENTS_UNIFIED_ID).c_str());
+	DBAgent::SelectExArg &arg = builder.build();
+	arg.add(stmt, SQL_COLUMN_TYPE_INT);
+
+	getDBAgent().runTransaction(arg);
+
+	// get the result
+	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
+	ItemGroupStream itemGroupStream(*grpList.begin());
+	return itemGroupStream.read<int>();
+}
+
 void DBTablesMonitoring::addIncidentInfo(IncidentInfo *incidentInfo)
 {
 	struct TrxProc : public DBAgent::TransactionProc {

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -262,6 +262,7 @@ public:
 	HatoholError getNumberOfMonitoredItemsPerSecond(
 	  const DataQueryOption &option,
 	  MonitoringServerStatus &serverStatus);
+	size_t getNumberOfEvents(const EventsQueryOption &option);
 
 	void addIncidentInfo(IncidentInfo *incidentInfo);
 	HatoholError getIncidentInfoVect(IncidentInfoVect &incidentInfoVect,

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -491,8 +491,15 @@ HatoholError RestResourceHost::parseEventParameter(EventsQueryOption &option,
 	// countOnly
 	value = static_cast<const gchar*>(
 	  g_hash_table_lookup(query, "countOnly"));
-	if (value && *value && string(value) == "true") {
-		isCountOnly = true;
+	if (value) {
+		string val(value);
+		isCountOnly = (val == "true");
+		if (val != "true" && val != "false") {
+			string message(
+			  StringUtils::sprintf(
+			    "Invalid value for countOnly: %s", value));
+			return HatoholError(HTERR_INVALID_PARAMETER, message);
+		}
 	}
 
 	return HatoholError(HTERR_OK);

--- a/server/src/RestResourceHost.h
+++ b/server/src/RestResourceHost.h
@@ -46,7 +46,8 @@ struct RestResourceHost : public RestResourceMemberHandler
 				    const HistoryInfoVect &historyInfoVect);
 
 	static HatoholError parseEventParameter(EventsQueryOption &option,
-						GHashTable *query);
+						GHashTable *query,
+						bool &isCountOnly);
 	static bool parseExtendedInfo(const std::string &extendedInfo,
 	                              std::string &extendedInfoValue);
 

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -609,6 +609,13 @@ HatoholError UnifiedDataStore::getNumberOfMonitoredItemsPerSecond(
 	return dbMonitoring.getNumberOfMonitoredItemsPerSecond(option, serverStatus);
 }
 
+size_t UnifiedDataStore::getNumberOfEvents(const EventsQueryOption &option)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	return dbMonitoring.getNumberOfEvents(option);
+}
+
 bool UnifiedDataStore::getCopyOnDemandEnabled(void) const
 {
 	return m_impl->isCopyOnDemandEnabled;

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -197,6 +197,7 @@ public:
 				bool fetchItemsSynchronously = false);
 	HatoholError getNumberOfMonitoredItemsPerSecond(const DataQueryOption &option,
 	                                                MonitoringServerStatus &serverStatus);
+	size_t getNumberOfEvents(const EventsQueryOption &option);
 
 	// User
 	void getUserList(UserInfoList &userList,

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1782,4 +1782,15 @@ void test_getSystemInfoByInvalidUser(void)
 	  DBTablesMonitoring::getSystemInfo(systemInfo, option));
 }
 
+void test_getNumberOfEvents(void)
+{
+	loadTestDBEvents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	EventsQueryOption option(USER_ID_SYSTEM);
+	option.setTargetServerId(1);
+	cppcut_assert_equal(static_cast<size_t>(3),
+			    dbMonitoring.getNumberOfEvents(option));
+}
+
 } // namespace testDBTablesMonitoring

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1793,4 +1793,17 @@ void test_getNumberOfEvents(void)
 			    dbMonitoring.getNumberOfEvents(option));
 }
 
+void test_getNumberOfEventsWithHostgroup(void)
+{
+	loadTestDBEvents();
+	loadTestDBHostgroupMember();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	EventsQueryOption option(USER_ID_SYSTEM);
+	option.setTargetServerId(3);
+	option.setTargetHostgroupId("1");
+	cppcut_assert_equal(static_cast<size_t>(2),
+			    dbMonitoring.getNumberOfEvents(option));
+}
+
 } // namespace testDBTablesMonitoring

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1083,7 +1083,7 @@ void test_getNumberOfEvents(void)
 	  "{"
 	  "\"apiVersion\":4,"
 	  "\"errorCode\":0,"
-	  "\"numberOfEvents:4\""
+	  "\"numberOfEvents\":4"
 	  "}");
 	cppcut_assert_equal(200, arg.httpStatusCode);
 	cppcut_assert_equal(expectedResponse, arg.response);

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1089,4 +1089,25 @@ void test_getNumberOfEvents(void)
 	cppcut_assert_equal(expectedResponse, arg.response);
 }
 
+void test_getNumberOfEventsWithInvalidQuery(void)
+{
+	loadTestDBEvents();
+	startFaceRest();
+
+	RequestArg arg("/events?countOnly=TRUE&serverId=3");
+	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
+	arg.request = "GET";
+	getServerResponse(arg);
+
+	string expectedResponse(
+	  "{"
+	  "\"apiVersion\":4,"
+	  "\"errorCode\":42,"
+	  "\"errorMessage\":\"Invalid parameter.\","
+	  "\"optionMessages\":\"Invalid value for countOnly: TRUE\""
+	  "}");
+	cppcut_assert_equal(200, arg.httpStatusCode);
+	cppcut_assert_equal(expectedResponse, arg.response);
+}
+
 } // namespace testFaceRestHost

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1069,4 +1069,24 @@ void test_getIncident(void)
 	cppcut_assert_equal(405, arg.httpStatusCode); // Method Not Allowed
 }
 
+void test_getNumberOfEvents(void)
+{
+	loadTestDBEvents();
+	startFaceRest();
+
+	RequestArg arg("/events?countOnly=true&serverId=3");
+	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
+	arg.request = "GET";
+	getServerResponse(arg);
+
+	string expectedResponse(
+	  "{"
+	  "\"apiVersion\":4,"
+	  "\"errorCode\":0,"
+	  "\"numberOfEvents:4\""
+	  "}");
+	cppcut_assert_equal(200, arg.httpStatusCode);
+	cppcut_assert_equal(expectedResponse, arg.response);
+}
+
 } // namespace testFaceRestHost

--- a/server/test/testFaceRestNoInit.cc
+++ b/server/test/testFaceRestNoInit.cc
@@ -40,7 +40,8 @@ public:
 		EventsQueryOption &option,
 		GHashTable *query)
 	{
-		return parseEventParameter(option, query);
+		bool countOnly = false;
+		return parseEventParameter(option, query, countOnly);
 	}
 };
 


### PR DESCRIPTION
An example query:

* /events?countOnly=true&serverId=3 (Any event filters can be added)
    
An example response:

    {
        "apiVersion": 4,
        "errorCode": 0,
        "numberOfEvents:4"
    }
