### PR TITLE
[IncidentTrackerEditor][WebUI] Add Hatohol incident tracker settings

### DIFF
--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -808,7 +808,11 @@ HatoholAddActionDialog.prototype.updateIncidentTrackers = function(incidentTrack
   for (i = 0; i < incidentTrackers.length; i++) {
     incidentTracker = incidentTrackers[i];
     label = "" + incidentTracker.id + ": " + incidentTracker.nickname;
-    label += " (" + gettext("Project: ")  + incidentTracker.projectId;
+    if (incidentTracker.projectId) {
+      label += " (" + gettext("Project: ") + incidentTracker.projectId;
+    } else {
+      label += " (" + gettext("Hatohol");
+    }
     if (incidentTracker.trackerId)
       label += ", " + gettext("Tracker: ") + incidentTracker.trackerId;
     label += ")";

--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -808,7 +808,7 @@ HatoholAddActionDialog.prototype.updateIncidentTrackers = function(incidentTrack
   for (i = 0; i < incidentTrackers.length; i++) {
     incidentTracker = incidentTrackers[i];
     label = "" + incidentTracker.id + ": " + incidentTracker.nickname;
-    if (incidentTracker.projectId) {
+    if (incidentTracker.type == hatohol.INCIDENT_TRACKER_REDMINE) {
       label += " (" + gettext("Project: ") + incidentTracker.projectId;
     } else {
       label += " (" + gettext("Hatohol");

--- a/client/static/js/hatohol_incident_trackers_editor.js
+++ b/client/static/js/hatohol_incident_trackers_editor.js
@@ -418,6 +418,7 @@ HatoholIncidentTrackerEditor.prototype.onAppendMainElement = function() {
   this.setIncidentTracker(this.incidentTracker);
   this.resetWidgetState();
 
+  this.applyEditIncidentTrackerAreaState();
   this.toggleEditIncidentTrackerArea();
 };
 
@@ -428,6 +429,13 @@ HatoholIncidentTrackerEditor.prototype.toggleEditIncidentTrackerArea = function(
     else
       $("#editIncidentTrackerArea").removeAttr("style");
   });
+};
+
+HatoholIncidentTrackerEditor.prototype.applyEditIncidentTrackerAreaState = function() {
+  if ($("#selectIncidentTrackerType").val() == hatohol.INCIDENT_TRACKER_HATOHOL)
+    $("#editIncidentTrackerArea").attr("style", "display: none");
+  else
+    $("#editIncidentTrackerArea").removeAttr("style");
 };
 
 HatoholIncidentTrackerEditor.prototype.resetWidgetState = function() {

--- a/client/static/js/hatohol_incident_trackers_editor.js
+++ b/client/static/js/hatohol_incident_trackers_editor.js
@@ -363,8 +363,11 @@ HatoholIncidentTrackerEditor.prototype.createMainElement = function() {
   '<select id="selectIncidentTrackerType" style="width:10em">' +
   '  <option value="' + hatohol.INCIDENT_TRACKER_REDMINE + '">' +
     gettext("Redmine") + '</option>' +
+  '  <option value="' + hatohol.INCIDENT_TRACKER_HATOHOL + '">' +
+    gettext("Hatohol") + '</option>' +
   '</select>' +
   '</div>' +
+  '<div id="editIncidentTrackerArea">' +
   '<div>' +
   '<label for="editIncidentTrackerNickname">' + gettext("Nickname") + '</label>' +
   '<input id="editIncidentTrackerNickname" type="text" ' +
@@ -396,6 +399,7 @@ HatoholIncidentTrackerEditor.prototype.createMainElement = function() {
   '<input id="editIncidentTrackerPassword" type="password" ' +
   '       class="input-xlarge">' +
   '<input type="checkbox" id="editIncidentTrackerPasswordCheckbox"> ' +
+  '</div>' +
   '</div>';
 
   return html;
@@ -404,6 +408,17 @@ HatoholIncidentTrackerEditor.prototype.createMainElement = function() {
 HatoholIncidentTrackerEditor.prototype.onAppendMainElement = function() {
   this.setIncidentTracker(this.incidentTracker);
   this.resetWidgetState();
+
+  this.toggleEditIncidentTrackerArea();
+};
+
+HatoholIncidentTrackerEditor.prototype.toggleEditIncidentTrackerArea = function() {
+  $("#selectIncidentTrackerType").change(function() {
+    if ($(this).val() == hatohol.INCIDENT_TRACKER_HATOHOL)
+      $("#editIncidentTrackerArea").attr("style", "display: none");
+    else
+      $("#editIncidentTrackerArea").removeAttr("style");
+  });
 };
 
 HatoholIncidentTrackerEditor.prototype.resetWidgetState = function() {

--- a/client/static/js/hatohol_incident_trackers_editor.js
+++ b/client/static/js/hatohol_incident_trackers_editor.js
@@ -311,6 +311,10 @@ var HatoholIncidentTrackerEditor = function(params) {
   function validateParameters() {
     var label;
 
+    if($("#selectIncidentTrackerType").val() == hatohol.INCIDENT_TRACKER_HATOHOL) {
+      return true;
+    }
+
     if ($("#editIncidentTrackerNickname").val() == "") {
       hatoholErrorMsgBox(gettext("Nickname is empty!"));
       return false;

--- a/client/static/js/hatohol_incident_trackers_editor.js
+++ b/client/static/js/hatohol_incident_trackers_editor.js
@@ -194,7 +194,12 @@ HatoholIncidentTrackersEditor.prototype.generateTableRows = function(data) {
 
   for (var i = 0; i < data.incidentTrackers.length; i++) {
     tracker = data.incidentTrackers[i];
-    type = tracker.type == 0 ? gettext("Redmine") : gettext("Unknown");
+    type = gettext("Unknown");
+    if (tracker.type == hatohol.INCIDENT_TRACKER_REDMINE) {
+      type = gettext("Redmine");
+    } else if (tracker.type == hatohol.INCIDENT_TRACKER_HATOHOL) {
+      type = gettext("Hatohol");
+    }
     html +=
     '<tr>' +
     '<td class="deleteIncidentTracker">' +

--- a/client/static/js/hatohol_incident_trackers_editor.js
+++ b/client/static/js/hatohol_incident_trackers_editor.js
@@ -423,11 +423,9 @@ HatoholIncidentTrackerEditor.prototype.onAppendMainElement = function() {
 };
 
 HatoholIncidentTrackerEditor.prototype.toggleEditIncidentTrackerArea = function() {
+  var self = this;
   $("#selectIncidentTrackerType").change(function() {
-    if ($(this).val() == hatohol.INCIDENT_TRACKER_HATOHOL)
-      $("#editIncidentTrackerArea").attr("style", "display: none");
-    else
-      $("#editIncidentTrackerArea").removeAttr("style");
+    self.applyEditIncidentTrackerAreaState();
   });
 };
 

--- a/client/static/js/incident_settings_view.js
+++ b/client/static/js/incident_settings_view.js
@@ -190,7 +190,11 @@ var IncidentSettingsView = function(userProfile) {
       s += "<td>";
       if (incidentTracker) {
 	s += incidentTracker.nickname;
-        s += " (" + gettext("Project: ") + incidentTracker.projectId;
+        if (incidentTracker.projectId) {
+          s += " (" + gettext("Project: ") + incidentTracker.projectId;
+        } else {
+          s += " (" + gettext("Hatohol");
+        }
         if (incidentTracker.trackerId) {
           s += ", " + gettext("Tracker: ") + incidentTracker.trackerId;
         }

--- a/client/static/js/incident_settings_view.js
+++ b/client/static/js/incident_settings_view.js
@@ -190,7 +190,7 @@ var IncidentSettingsView = function(userProfile) {
       s += "<td>";
       if (incidentTracker) {
 	s += incidentTracker.nickname;
-        if (incidentTracker.projectId) {
+        if (incidentTracker.type == hatohol.INCIDENT_TRACKER_REDMINE) {
           s += " (" + gettext("Project: ") + incidentTracker.projectId;
         } else {
           s += " (" + gettext("Hatohol");

--- a/client/test/browser/index.html
+++ b/client/test/browser/index.html
@@ -43,6 +43,7 @@
 <script src="../../static/js/hatohol_time_range_selector.js"></script>
 <script src="../../static/js/hatohol_version.js"></script>
 <script src="../../static/js/hatohol_events_view_config.js"></script>
+<script src="../../static/js/hatohol_incident_trackers_editor.js"></script>
 <script src="../../static/js/servers_view.js"></script>
 <script src="../../static/js/events_view.js"></script>
 <script src="../../static/js/users_view.js"></script>
@@ -72,6 +73,7 @@
 <script src="test_hatohol_user_profile.js"></script>
 <script src="test_hatohol_user_roles_editor.js"></script>
 <script src="test_hatohol_user_edit_dialog.js"></script>
+<script src="test_hatohol_incident_tracker_editor.js"></script>
 <script src="test_utils.js"></script>
 <script src="test_hatohol_monitoring_view.js"></script>
 <script src="test_server_view.js"></script>

--- a/client/test/browser/test_hatohol_incident_tracker_editor.js
+++ b/client/test/browser/test_hatohol_incident_tracker_editor.js
@@ -20,4 +20,18 @@ describe('HatoholIncidentTrackerEditor', function() {
     expect(buttons[0].text).to.be(gettext("ADD"));
     expect(buttons[1].text).to.be(gettext("CANCEL"));
   });
+
+  it('change to Hatohol incident tracker type', function() {
+    var expectedId = "#incident-tracker-editor";
+    var editFormsArea = "#editIncidentTrackerArea";
+    editor = new HatoholIncidentTrackerEditor({});
+    expect(editor).not.to.be(undefined);
+    expect($(expectedId)).to.have.length(1);
+    var buttons = $(expectedId).dialog("option", "buttons");
+    $("#selectIncidentTrackerType").val(gettext("Hatohol")).change();
+    // Make synchronous
+    setTimeout(function() {
+      expect($(editFormsArea).css('display')).to.be("none");
+    }, 0);
+  });
 });

--- a/client/test/browser/test_hatohol_incident_tracker_editor.js
+++ b/client/test/browser/test_hatohol_incident_tracker_editor.js
@@ -1,0 +1,23 @@
+describe('HatoholIncidentTrackerEditor', function() {
+  var editor;
+
+  beforeEach(function() {
+    editor = undefined;
+  });
+
+  afterEach(function() {
+    if (editor)
+      editor.closeDialog();
+  });
+
+  it('new', function() {
+    var expectedId = "#incident-tracker-editor";
+    editor = new HatoholIncidentTrackerEditor({});
+    expect(editor).not.to.be(undefined);
+    expect($(expectedId)).to.have.length(1);
+    var buttons = $(expectedId).dialog("option", "buttons");
+    expect(buttons).to.have.length(2);
+    expect(buttons[0].text).to.be(gettext("ADD"));
+    expect(buttons[1].text).to.be(gettext("CANCEL"));
+  });
+});

--- a/server/src/ArmIncidentTracker.cc
+++ b/server/src/ArmIncidentTracker.cc
@@ -89,6 +89,10 @@ ArmIncidentTracker *ArmIncidentTracker::create(
 	switch (trackerInfo.type) {
 	case INCIDENT_TRACKER_REDMINE:
 		return new ArmRedmine(trackerInfo);
+	case INCIDENT_TRACKER_HATOHOL:
+		// TODO: should treat more appropriate way
+		MLPL_INFO("Hatohol incident tracking system selected: %d\n",
+			 trackerInfo.type);
 	default:
 		MLPL_BUG("Invalid incident tracking system: %d\n",
 			 trackerInfo.type);

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -229,8 +229,12 @@ struct UnifiedDataStore::Impl
 		  = armIncidentTrackerMap.find(trackerInfo.id);
 		ArmIncidentTracker *arm = NULL;
 		if (it == armIncidentTrackerMap.end()) {
-			arm = ArmIncidentTracker::create(trackerInfo);
-			armIncidentTrackerMap[trackerInfo.id] = arm;
+			if (trackerInfo.type == INCIDENT_TRACKER_REDMINE) {
+				arm = ArmIncidentTracker::create(trackerInfo);
+				armIncidentTrackerMap[trackerInfo.id] = arm;
+			} else {
+				return;
+			}
 		} else {
 			arm = it->second;
 		}


### PR DESCRIPTION
Add Hatohol incident tracker type to IncidentTrackerEditor.

### Redmine (hitherto)

![screenshot from 2015-09-30 17 48 08](https://cloud.githubusercontent.com/assets/700876/10188604/8c447962-679b-11e5-8029-784d4610e1a4.png)

### Hatohol (new)

![screenshot from 2015-09-30 17 49 33](https://cloud.githubusercontent.com/assets/700876/10188616/9fab09ee-679b-11e5-90b1-db32a1af3425.png)
