### PR TITLE
[server] Filter events by incident statuses

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -972,7 +972,7 @@ string EventsQueryOption::getCondition(void) const
 	}
 
 	string severityCondition;
-	for (auto severity: m_impl->triggerSeverities) {
+	for (const auto &severity: m_impl->triggerSeverities) {
 		addCondition(
 		  severityCondition,
 		  StringUtils::sprintf(
@@ -986,7 +986,7 @@ string EventsQueryOption::getCondition(void) const
 	addCondition(condition, severityCondition);
 
 	string statusCondition;
-	for (auto status: m_impl->triggerStatuses) {
+	for (const auto &status: m_impl->triggerStatuses) {
 		addCondition(
 		  statusCondition,
 		  StringUtils::sprintf(
@@ -1000,7 +1000,7 @@ string EventsQueryOption::getCondition(void) const
 	addCondition(condition, statusCondition);
 
 	string incidentStatusCondition;
-	for (auto status: m_impl->incidentStatuses) {
+	for (const auto &status: m_impl->incidentStatuses) {
 		DBTermCStringProvider rhs(*getDBTermCodec());
 		addCondition(
 		  incidentStatusCondition,

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1146,7 +1146,7 @@ void EventsQueryOption::setTriggerSeverities(
 	m_impl->triggerSeverities = severities;
 }
 
-const set<TriggerSeverityType> &EventsQueryOption::getTriggerSeverities(void)
+const set<TriggerSeverityType> &EventsQueryOption::getTriggerSeverities(void) const
 {
 	return m_impl->triggerSeverities;
 }
@@ -1157,7 +1157,7 @@ void EventsQueryOption::setTriggerStatuses(
 	m_impl->triggerStatuses = statuses;
 }
 
-const std::set<TriggerStatusType> &EventsQueryOption::getTriggerStatuses(void)
+const std::set<TriggerStatusType> &EventsQueryOption::getTriggerStatuses(void) const
 {
 	return m_impl->triggerStatuses;
 }

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -850,6 +850,7 @@ struct EventsQueryOption::Impl {
 	timespec endTime;
 	set<TriggerSeverityType> triggerSeverities;
 	set<TriggerStatusType> triggerStatuses;
+	set<string> incidentStatuses;
 
 	Impl()
 	: limitOfUnifiedId(NO_LIMIT),
@@ -998,6 +999,25 @@ string EventsQueryOption::getCondition(void) const
 		statusCondition = string("(") + statusCondition + string(")");
 	addCondition(condition, statusCondition);
 
+	string incidentStatusCondition;
+	for (auto status: m_impl->incidentStatuses) {
+		DBTermCStringProvider rhs(*getDBTermCodec());
+		addCondition(
+		  incidentStatusCondition,
+		  StringUtils::sprintf(
+		    "%s.%s=%s",
+		    DBTablesMonitoring::TABLE_NAME_INCIDENTS,
+		    COLUMN_DEF_INCIDENTS[IDX_INCIDENTS_STATUS].columnName,
+		    rhs(status)),
+		  ADD_TYPE_OR);
+	}
+	if (m_impl->incidentStatuses.size() > 1)
+		incidentStatusCondition =
+			string("(") +
+			incidentStatusCondition +
+			string(")");
+	addCondition(condition, incidentStatusCondition);
+
 	return condition;
 }
 
@@ -1140,6 +1160,16 @@ void EventsQueryOption::setTriggerStatuses(
 const std::set<TriggerStatusType> &EventsQueryOption::getTriggerStatuses(void)
 {
 	return m_impl->triggerStatuses;
+}
+
+void EventsQueryOption::setIncidentStatuses(const std::set<std::string> &statuses)
+{
+	m_impl->incidentStatuses = statuses;
+}
+
+const std::set<std::string> &EventsQueryOption::getIncidentStatuses(void) const
+{
+	return m_impl->incidentStatuses;
 }
 
 //
@@ -1972,7 +2002,7 @@ HatoholError DBTablesMonitoring::getEventInfoList(
 	builder.add(IDX_EVENTS_BRIEF);
 	builder.add(IDX_EVENTS_EXTENDED_INFO);
 
-	if (incidentInfoVect) {
+	if (incidentInfoVect || !option.getIncidentStatuses().empty()) {
 		builder.addTable(
 		  tableProfileIncidents, DBClientJoinBuilder::LEFT_JOIN,
 		  tableProfileEvents, IDX_EVENTS_UNIFIED_ID, IDX_INCIDENTS_UNIFIED_EVENT_ID);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -73,6 +73,9 @@ public:
 	void setTriggerStatuses(const std::set<TriggerStatusType> &statuses);
 	const std::set<TriggerStatusType> &getTriggerStatuses(void);
 
+	void setIncidentStatuses(const std::set<std::string> &statuses);
+	const std::set<std::string> &getIncidentStatuses(void) const;
+
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -69,9 +69,9 @@ public:
 	const timespec &getEndTime(void);
 
 	void setTriggerSeverities(const std::set<TriggerSeverityType> &severities);
-	const std::set<TriggerSeverityType> &getTriggerSeverities(void);
+	const std::set<TriggerSeverityType> &getTriggerSeverities(void) const;
 	void setTriggerStatuses(const std::set<TriggerStatusType> &statuses);
-	const std::set<TriggerStatusType> &getTriggerStatuses(void);
+	const std::set<TriggerStatusType> &getTriggerStatuses(void) const;
 
 	void setIncidentStatuses(const std::set<std::string> &statuses);
 	const std::set<std::string> &getIncidentStatuses(void) const;

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -488,6 +488,18 @@ HatoholError RestResourceHost::parseEventParameter(EventsQueryOption &option,
 		option.setTriggerStatuses(statuses);
 	}
 
+	// statuses
+	value = static_cast<const gchar*>(
+	  g_hash_table_lookup(query, "incidentStatuses"));
+	if (value && *value) {
+		StringVector values;
+		StringUtils::split(values, value, ',');
+		std::set<string> statuses;
+		for (auto &status: values)
+			statuses.insert(status);
+		option.setIncidentStatuses(statuses);
+	}
+
 	// countOnly
 	value = static_cast<const gchar*>(
 	  g_hash_table_lookup(query, "countOnly"));

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1739,6 +1739,32 @@ void test_getEventsExcludeByHostgroup(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getEventsSelectByIncidentStatuses(void)
+{
+	loadTestDBServerHostDef();
+	loadTestDBHostgroup();
+	loadTestDBHostgroupMember();
+	loadTestDBEvents();
+	loadTestDBIncidents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	set<string> statuses;
+	statuses.insert("New");
+	statuses.insert("NONE");
+	option.setIncidentStatuses(statuses);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual = sortedJoin(events);
+	string expected(
+	  "1|1|1363123456|0|0|2|1|1|10|235012|hostX1|TEST Trigger 1a|"
+	    "{\"expandedDescription\":\"Test Trigger on hostX1\"}\n"
+	  "1|2|1378900022|0|0|1|0|1|10|235012|hostX1|TEST Trigger 1|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
 void test_getSystemInfo(void)
 {
 	DataQueryOption option(findUserWith(OPPRVLG_GET_SYSTEM_INFO));

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -955,6 +955,61 @@ void test_eventsWithStatusesFilter(void)
 	assertEqualJSONString(expected, arg.response);
 }
 
+void test_eventsWithIncidentStatusesFilter(void)
+{
+	loadTestDBArmPlugin();
+	loadTestDBTriggers();
+	loadTestDBEvents();
+	loadTestDBIncidents();
+	loadTestDBServerHostDef();
+	startFaceRest();
+
+	RequestArg arg("/event?incidentStatuses=New%2CNONE"
+		       "&sortOrder=1&sortType=time");
+	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
+	getServerResponse(arg);
+	string expected(
+	  "{"
+	  "\"apiVersion\":4,"
+	  "\"errorCode\":0,"
+	  "\"lastUnifiedEventId\":7,"
+	  "\"haveIncident\":false,"
+	  "\"events\":"
+	  "["
+	  "{"
+	  "\"unifiedId\":3,"
+	  "\"serverId\":1,"
+	  "\"time\":1363123456,"
+	  "\"type\":0,"
+	  "\"triggerId\":\"2\","
+	  "\"eventId\":\"1\","
+	  "\"status\":1,"
+	  "\"severity\":1,"
+	  "\"hostId\":\"235012\","
+	  "\"brief\":\"TEST Trigger 1a\","
+	  "\"extendedInfo\":"
+	  "\"{\\\"expandedDescription\\\":\\\"Test Trigger on hostX1\\\"}\""
+	  "},"
+	  "{"
+	  "\"unifiedId\":4,"
+	  "\"serverId\":1,"
+	  "\"time\":1378900022,"
+	  "\"type\":0,"
+	  "\"triggerId\":\"1\","
+	  "\"eventId\":\"2\","
+	  "\"status\":0,"
+	  "\"severity\":1,"
+	  "\"hostId\":\"235012\","
+	  "\"brief\":\"TEST Trigger 1\","
+	  "\"extendedInfo\":\"\""
+	  "}"
+	  "],"
+	  "\"numberOfEvents\":2,");
+
+	expected += getExpectedServers() + "}";
+	cppcut_assert_equal(expected, arg.response);
+}
+
 static void incidentInfo2StringMap(
   const IncidentInfo &src, StringMap &dest)
 {

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -902,6 +902,7 @@ void test_eventsWithSeveritiesFilter(void)
 	expected += getExpectedServers() + "}";
 	assertEqualJSONString(expected, arg.response);
 }
+
 void test_eventsWithStatusesFilter(void)
 {
 	loadTestDBArmPlugin();

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -578,6 +578,28 @@ void test_eventQueryOptionWithStatuses(gconstpointer data)
 	cppcut_assert_equal(expected, option.getCondition());
 }
 
+void data_eventQueryOptionWithIncidentStatuses(void)
+{
+	prepareTestDataExcludeDefunctServers();
+}
+
+void test_eventQueryOptionWithIncidentStatuses(gconstpointer data)
+{
+	EventsQueryOption option(USER_ID_SYSTEM);
+	set<string> statuses;
+	statuses.insert("DONE");
+	statuses.insert("IN PROGRESS");
+	statuses.insert("HOLD");
+	option.setIncidentStatuses(statuses);
+
+	string expected =
+	  "(incidents.status='DONE' OR"
+	  " incidents.status='HOLD' OR"
+	  " incidents.status='IN PROGRESS')";
+	fixupForFilteringDefunctServer(data, expected, option);
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
 //
 // ItemsQueryOption
 //


### PR DESCRIPTION
Example query:

* /event?incidentStatuses=NONE%2CHOLD

Decodeded query part:

* incidentStatuses=NONE,HOLD
