### PR TITLE
[WebUI] Make DEBUG False to avoid internal information from being shown.

### DIFF
--- a/client/HowToTest.md
+++ b/client/HowToTest.md
@@ -62,11 +62,11 @@ Ex.)
 
 run djang with debug mode (set an environment variable: HATOHOL_DEBUG=1)
 
-    $ HATOHOL_DEBUG=1 ./manage.py runserver 0.0.0.0:8000
+    $ HATOHOL_DEBUG=1 ./manage.py runserver --insecure 0.0.0.0:8000
 
 or if you want to use a different database on a test, you can specify the test settings that use the database named 'test_hatohol_client'.
 
-    $ DJANGO_SETTINGS_MODULE=test.python.testsettings HATOHOL_DEBUG=1 ./manage.py runserver 0.0.0.0:8008
+    $ DJANGO_SETTINGS_MODULE=test.python.testsettings HATOHOL_DEBUG=1 ./manage.py runserver --insecure 0.0.0.0:8008
 
 > ** Memo ** The set of the above environment variable make 'tasting' and 'test'
 directories accessible.

--- a/client/README.md
+++ b/client/README.md
@@ -67,7 +67,7 @@ You must change the current directory to "client" under the top directory.
 
     $ ./manage.py syncdb
 
-## How to run
+## How to run as a test
 Hatohol Client is a standard Django project. So you can run it on any WSGI
 compliant application server.
 
@@ -75,11 +75,11 @@ You must change the current directory to "client" under the top directory.
 
 Alternatively you can run with a runserver sub-command of Django's manage.py.
 
-	$ ./manage.py runserver
+	$ ./manage.py runserver --insecure
 
 If you allow to access from the outside, you need specifying the address like
 
-	$ ./manage.py runserver 0.0.0.0:8000
+	$ ./manage.py runserver --insecure 0.0.0.0:8000
 
 ## Hints
 ### How to set a Hatohol server address and the port

--- a/client/hatohol/settings.py
+++ b/client/hatohol/settings.py
@@ -22,7 +22,7 @@ import logging
 
 PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
-DEBUG = True
+DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
@@ -44,7 +44,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en//ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = "*"
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/test/launch-hatohol-for-test.sh
+++ b/test/launch-hatohol-for-test.sh
@@ -36,7 +36,7 @@ server_pid=$!
 
 cd $client_dir
 ./manage.py syncdb
-HATOHOL_DEBUG=1 ./manage.py runserver 0.0.0.0:8000 &
+HATOHOL_DEBUG=1 ./manage.py runserver --insecure 0.0.0.0:8000 &
 client_pid=$!
 
 # wait for the boot completion


### PR DESCRIPTION
When the DEBUG variable is True and any problem happens in WebUI code,
the debug information is sent to the viewer. This behavior is generally
undesired.