### PR TITLE
[WebUI] Make DEBUG False to avoid internal information from being shown.

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -14,7 +14,8 @@ nobase_dist_hatohol_client_DATA = \
 	hatohol/wsgi.py \
 	hatohol/urls.py \
 	hatohol/__init__.py \
-	hatohol/settings.py \
+	hatohol/base_settings.py \
+	hatohol/settings_devel.py hatohol/settings_product.py \
 	hatohol/django_realize.py \
 	hatohol/hatohol_def.py \
 	hatohol/hatoholserver.py \

--- a/client/conf/apache/django.wsgi
+++ b/client/conf/apache/django.wsgi
@@ -1,6 +1,6 @@
 import os
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'hatohol.settings'
+os.environ['DJANGO_SETTINGS_MODULE'] = 'hatohol.settings_product'
 
 import django.core.handlers.wsgi
 application = django.core.handlers.wsgi.WSGIHandler()

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Project Hatohol
+# Copyright (C) 2013,2015 Project Hatohol
 #
 # This file is part of Hatohol.
 #
@@ -22,9 +22,6 @@ import logging
 
 PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
-DEBUG = True
-TEMPLATE_DEBUG = DEBUG
-
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )
@@ -44,7 +41,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en//ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = "*"
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/client/hatohol/settings_devel.py
+++ b/client/hatohol/settings_devel.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2015 Project Hatohol
+#
+# This file is part of Hatohol.
+#
+# Hatohol is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License, version 3
+# as published by the Free Software Foundation.
+#
+# Hatohol is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Hatohol. If not, see
+# <http://www.gnu.org/licenses/>.
+
+from base_settings import *
+
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG

--- a/client/hatohol/settings_product.py
+++ b/client/hatohol/settings_product.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2015 Project Hatohol
+#
+# This file is part of Hatohol.
+#
+# Hatohol is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License, version 3
+# as published by the Free Software Foundation.
+#
+# Hatohol is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Hatohol. If not, see
+# <http://www.gnu.org/licenses/>.
+
+
+from base_settings import *
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG

--- a/client/manage.py
+++ b/client/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hatohol.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hatohol.settings_devel")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
When a DEBUG variable in settings.py is True and any problem happens in
WebUI code, some debug information is sent to the broweser. This behavior
is generally undesired.

This fix suggests two settings files for development and procduction
respectively.