### PR TITLE
[DBTablesConfig][SeverityRank] Implement severity_ranks table elementary CRUD operations

### DIFF
--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -99,6 +99,9 @@ typedef int LastInfoServerIdType;
 typedef int SeverityRankIdType;
 #define FMT_SEVERITY_RANK_ID "d"
 
+typedef int SeverityRankStatusType;
+#define FMT_SEVERITY_RANK_Status "d"
+
 // Special Server IDs =========================================================
 static const ServerIdType ALL_SERVERS       = -1;
 static const ServerIdType INVALID_SERVER_ID = -2;

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -96,6 +96,9 @@ typedef uint64_t LastInfoIdType;
 typedef int LastInfoServerIdType;
 #define FMT_LAST_INFO_SERVER_ID "d"
 
+typedef int SeverityRankIdType;
+#define FMT_SEVERITY_RANK_ID "d"
+
 // Special Server IDs =========================================================
 static const ServerIdType ALL_SERVERS       = -1;
 static const ServerIdType INVALID_SERVER_ID = -2;

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1632,6 +1632,8 @@ DBTables::SetupInfo &DBTablesConfig::getSetupInfo(void)
 		&tableProfileArmPlugins,
 	}, {
 		&tableProfileIncidentTrackers,
+	}, {
+		&tableProfileSeverityRanks,
 	}
 	};
 

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1866,7 +1866,6 @@ string SeverityRankQueryOption::getCondition(void) const
 	HATOHOL_ASSERT(!m_impl->conditionTemplate.empty(),
 	               "SeverityRank condition template is empty.");
 
-	string severityRankColorCondition = m_impl->getSeverityRankColorCondition();
 	if (!m_impl->color.empty()) {
 		DBTermCStringProvider rhs(*getDBTermCodec());
 		string colorCondition = StringUtils::sprintf(

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1808,7 +1808,7 @@ string SeverityRankQueryOption::Impl::getSeverityRankStatusCondition(void)
 	case TRIGGER_SEVERITY_ALL:
 		return condition;
 	default:
-		condition += StringUtils::sprintf("status=%d", (int)status);
+		condition += StringUtils::sprintf("status=%d", static_cast<int>(status));
 		return condition;
 	}
 }

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -38,6 +38,7 @@ static const char *TABLE_NAME_SERVER_TYPES = "server_types";
 static const char *TABLE_NAME_SERVERS = "servers";
 static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
+static const char *TABLE_NAME_SEVERITY_RANKS = "severity_ranks";
 
 int DBTablesConfig::CONFIG_DB_VERSION = 16;
 
@@ -566,6 +567,51 @@ static const DBAgent::TableProfile tableProfileIncidentTrackers =
   DBAGENT_TABLEPROFILE_INIT(TABLE_NAME_INCIDENT_TRACKERS,
 			    COLUMN_DEF_INCIDENT_TRACKERS,
 			    NUM_IDX_INCIDENT_TRACKERS);
+
+static const ColumnDef COLUMN_DEF_SEVERITY_RANKS[] = {
+{
+	"id",                              // columnName
+	SQL_COLUMN_TYPE_INT,               // type
+	11,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_PRI,                       // keyType
+	SQL_COLUMN_FLAG_AUTO_INC,          // flags
+	NULL,                              // defaultValue
+},
+{
+	"status",                          // columnName
+	SQL_COLUMN_TYPE_INT,               // type
+	11,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+},
+{
+	"color",                           // columnName
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+},
+};
+
+enum {
+	IDX_SEVERITY_RANK_ID,
+	IDX_SEVERITY_RANK_STATUS,
+	IDX_SEVERITY_RANK_COLOR,
+	NUM_IDX_SEVERITY_RANKS,
+};
+
+static const DBAgent::TableProfile tableProfileSeverityRanks =
+  DBAGENT_TABLEPROFILE_INIT(TABLE_NAME_SEVERITY_RANKS,
+			    COLUMN_DEF_SEVERITY_RANKS,
+			    NUM_IDX_SEVERITY_RANKS);
 
 struct DBTablesConfig::Impl
 {

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1758,10 +1758,10 @@ HatoholError DBTablesConfig::deleteSeverityRanks(
 struct SeverityRankQueryOption::Impl {
 	static const string conditionTemplate;
 
-	SeverityRankQueryOption           *option;
-	TriggerSeverityType               status;
+	SeverityRankQueryOption       *option;
+	TriggerSeverityType           status;
 	std::list<SeverityRankIdType> idList;
-	string                            color;
+	string                        color;
 
 	Impl(SeverityRankQueryOption *_option)
 	: option(_option), status(TRIGGER_SEVERITY_ALL)

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1773,7 +1773,6 @@ struct SeverityRankQueryOption::Impl {
 
 	static string makeConditionTemplate(void);
 	string getSeverityRankStatusCondition(void);
-	string getSeverityRankColorCondition(void);
 };
 
 const string SeverityRankQueryOption::Impl::conditionTemplate
@@ -1812,15 +1811,6 @@ string SeverityRankQueryOption::Impl::getSeverityRankStatusCondition(void)
 		condition += StringUtils::sprintf("status=%d", (int)status);
 		return condition;
 	}
-}
-
-string SeverityRankQueryOption::Impl::getSeverityRankColorCondition(void)
-{
-	string condition;
-	return StringUtils::sprintf(
-		"%s=%s",
-		COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_COLOR].columnName,
-		color.c_str());
 }
 
 SeverityRankQueryOption::SeverityRankQueryOption(const UserIdType &userId)
@@ -1878,7 +1868,12 @@ string SeverityRankQueryOption::getCondition(void) const
 
 	string severityRankColorCondition = m_impl->getSeverityRankColorCondition();
 	if (!m_impl->color.empty()) {
-		addCondition(condition, severityRankColorCondition);
+		DBTermCStringProvider rhs(*getDBTermCodec());
+		string colorCondition = StringUtils::sprintf(
+		  "%s=%s",
+		  COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_COLOR].columnName,
+		  rhs(m_impl->color.c_str()));
+		addCondition(condition, colorCondition);
 	}
 
 	return condition;

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -40,7 +40,7 @@ static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
 static const char *TABLE_NAME_SEVERITY_RANKS = "severity_ranks";
 
-int DBTablesConfig::CONFIG_DB_VERSION = 16;
+int DBTablesConfig::CONFIG_DB_VERSION = 17;
 
 const ServerIdSet EMPTY_SERVER_ID_SET;
 const ServerIdSet EMPTY_INCIDENT_TRACKER_ID_SET;
@@ -702,6 +702,9 @@ static bool updateDB(
 		addArgForArmPlugins.columnIndexes.push_back(
 			IDX_ARM_PLUGINS_UUID);
 		dbAgent.addColumns(addArgForArmPlugins);
+	}
+	if (oldVer < 17) {
+		dbAgent.createTable(tableProfileSeverityRanks);
 	}
 	return true;
 }

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1660,12 +1660,15 @@ HatoholError DBTablesConfig::updateSeverityRankInfo(
 	return HTERR_OK;
 }
 
-void DBTablesConfig::getSeverityRankInfo(SeverityRankInfoVect &severityRankInfoVect)
+void DBTablesConfig::getSeverityRankInfo(
+  SeverityRankInfoVect &severityRankInfoVect,
+  const SeverityRankQueryOption &option)
 {
 	DBAgent::SelectExArg arg(tableProfileSeverityRanks);
 	arg.add(IDX_SEVERITY_RANK_ID);
 	arg.add(IDX_SEVERITY_RANK_STATUS);
 	arg.add(IDX_SEVERITY_RANK_COLOR);
+	arg.condition = option.getCondition();
 
 	getDBAgent().runTransaction(arg);
 

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1709,38 +1709,6 @@ static string makeConditionForSeverityRankDelete(
 	return condition;
 }
 
-HatoholError DBTablesConfig::checkPrivilegeForSeverityRankAdd(
-  const OperationPrivilege &privilege,
-  const SeverityRankInfo &severityRankInfo)
-{
-	const UserIdType userId = privilege.getUserId();
-	if (userId == INVALID_USER_ID)
-		return HTERR_INVALID_USER;
-
-	return HTERR_OK;
-}
-
-HatoholError DBTablesConfig::checkPrivilegeForSeverityRankDelete(
-  const OperationPrivilege &privilege, const std::list<SeverityRankIdType> &idList)
-{
-	const UserIdType userId = privilege.getUserId();
-	if (userId == INVALID_USER_ID)
-		return HTERR_INVALID_USER;
-
-	return HTERR_OK;
-}
-
-HatoholError DBTablesConfig::checkPrivilegeForSeverityRankUpdate(
-  const OperationPrivilege &privilege,
-  const SeverityRankInfo &severityRankInfo)
-{
-	const UserIdType userId = privilege.getUserId();
-	if (userId == INVALID_USER_ID)
-		return HTERR_INVALID_USER;
-
-	return HTERR_OK;
-}
-
 HatoholError DBTablesConfig::deleteSeverityRanks(
   const std::list<SeverityRankIdType> &idList,
   const OperationPrivilege &privilege)
@@ -1994,4 +1962,36 @@ void DBTablesConfig::deleteArmPluginInfoWithoutTransaction(
 	DBAgent::DeleteArg arg(tableProfileArmPlugins);
 	arg.condition = condition;
 	deleteRows(arg);
+}
+
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankAdd(
+  const OperationPrivilege &privilege,
+  const SeverityRankInfo &severityRankInfo)
+{
+	const UserIdType userId = privilege.getUserId();
+	if (userId == INVALID_USER_ID)
+		return HTERR_INVALID_USER;
+
+	return HTERR_OK;
+}
+
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankDelete(
+  const OperationPrivilege &privilege, const std::list<SeverityRankIdType> &idList)
+{
+	const UserIdType userId = privilege.getUserId();
+	if (userId == INVALID_USER_ID)
+		return HTERR_INVALID_USER;
+
+	return HTERR_OK;
+}
+
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankUpdate(
+  const OperationPrivilege &privilege,
+  const SeverityRankInfo &severityRankInfo)
+{
+	const UserIdType userId = privilege.getUserId();
+	if (userId == INVALID_USER_ID)
+		return HTERR_INVALID_USER;
+
+	return HTERR_OK;
 }

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1620,7 +1620,8 @@ SeverityRankIdType DBTablesConfig::upsertSeverityRankInfo(
   SeverityRankInfo &severityRankInfo,
   const OperationPrivilege &privilege)
 {
-	HatoholError err = checkPrivilegeForAdd(privilege, severityRankInfo);
+	HatoholError err =
+		checkPrivilegeForSeverityRankAdd(privilege, severityRankInfo);
 	if (err != HTERR_OK)
 		return INVALID_SEVERITY_RANK_ID;
 
@@ -1640,7 +1641,8 @@ HatoholError DBTablesConfig::updateSeverityRankInfo(
   SeverityRankInfo &severityRankInfo,
   const OperationPrivilege &privilege)
 {
-	HatoholError err = checkPrivilegeForUpdate(privilege, severityRankInfo);
+	HatoholError err =
+		checkPrivilegeForSeverityRankUpdate(privilege, severityRankInfo);
 	if (err != HTERR_OK)
 		return err;
 
@@ -1682,7 +1684,8 @@ void DBTablesConfig::getSeverityRankInfo(SeverityRankInfoVect &severityRankInfoV
 	}
 }
 
-static string makeIdListCondition(const std::list<SeverityRankIdType> &idList)
+static string makeSeverityRankIdListCondition(
+  const std::list<SeverityRankIdType> &idList)
 {
 	string condition;
 	const ColumnDef &colId = COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_ID];
@@ -1697,15 +1700,16 @@ static string makeIdListCondition(const std::list<SeverityRankIdType> &idList)
 	return condition;
 }
 
-static string makeConditionForDelete(const std::list<SeverityRankIdType> &idList,
-				     const OperationPrivilege &privilege)
+static string makeConditionForSeverityRankDelete(
+  const std::list<SeverityRankIdType> &idList,
+  const OperationPrivilege &privilege)
 {
-	string condition = makeIdListCondition(idList);
+	string condition = makeSeverityRankIdListCondition(idList);
 
 	return condition;
 }
 
-HatoholError DBTablesConfig::checkPrivilegeForAdd(
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankAdd(
   const OperationPrivilege &privilege,
   const SeverityRankInfo &severityRankInfo)
 {
@@ -1716,7 +1720,7 @@ HatoholError DBTablesConfig::checkPrivilegeForAdd(
 	return HTERR_OK;
 }
 
-HatoholError DBTablesConfig::checkPrivilegeForDelete(
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankDelete(
   const OperationPrivilege &privilege, const std::list<SeverityRankIdType> &idList)
 {
 	const UserIdType userId = privilege.getUserId();
@@ -1726,7 +1730,7 @@ HatoholError DBTablesConfig::checkPrivilegeForDelete(
 	return HTERR_OK;
 }
 
-HatoholError DBTablesConfig::checkPrivilegeForUpdate(
+HatoholError DBTablesConfig::checkPrivilegeForSeverityRankUpdate(
   const OperationPrivilege &privilege,
   const SeverityRankInfo &severityRankInfo)
 {
@@ -1741,7 +1745,7 @@ HatoholError DBTablesConfig::deleteSeverityRanks(
   const std::list<SeverityRankIdType> &idList,
   const OperationPrivilege &privilege)
 {
-	HatoholError err = checkPrivilegeForDelete(privilege, idList);
+	HatoholError err = checkPrivilegeForSeverityRankDelete(privilege, idList);
 	if (err != HTERR_OK)
 		return err;
 
@@ -1766,7 +1770,7 @@ HatoholError DBTablesConfig::deleteSeverityRanks(
 			numAffectedRows = dbAgent.getNumberOfAffectedRows();
 		}
 	} trx;
-	trx.arg.condition = makeConditionForDelete(idList, privilege);
+	trx.arg.condition = makeConditionForSeverityRankDelete(idList, privilege);
 	getDBAgent().runTransaction(trx);
 
 	// Check the result

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -298,7 +298,9 @@ public:
 	  SeverityRankInfo &severityRankInfo, const OperationPrivilege &privilege);
 	HatoholError updateSeverityRankInfo(
 	  SeverityRankInfo &severityRankInfo, const OperationPrivilege &privilege);
-	void getSeverityRankInfo(SeverityRankInfoVect &severityRankInfoVect);
+	void getSeverityRankInfo(
+	  SeverityRankInfoVect &severityRankInfoVect,
+	  const SeverityRankQueryOption &option);
 	HatoholError deleteSeverityRanks(
           const std::list<SeverityRankIdType> &idList, const OperationPrivilege &privilege);
 

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -64,6 +64,14 @@ typedef std::vector<ServerTypeInfo>        ServerTypeInfoVect;
 typedef ServerTypeInfoVect::iterator       ServerTypeInfoVectIterator;
 typedef ServerTypeInfoVect::const_iterator ServerTypeInfoVectConstIterator;
 
+struct SeverityRankInfo {
+	SeverityRankIdType id;
+	int                status;
+	std::string        color;
+};
+
+typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;
+
 class ServerQueryOption : public DataQueryOption {
 public:
 	ServerQueryOption(const UserIdType &userId = INVALID_USER_ID);

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -65,9 +65,9 @@ typedef ServerTypeInfoVect::iterator       ServerTypeInfoVectIterator;
 typedef ServerTypeInfoVect::const_iterator ServerTypeInfoVectConstIterator;
 
 struct SeverityRankInfo {
-	SeverityRankIdType id;
+	SeverityRankIdType  id;
 	TriggerSeverityType status;
-	std::string        color;
+	std::string         color;
 };
 
 typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -71,6 +71,7 @@ struct SeverityRankInfo {
 };
 
 typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;
+constexpr const static SeverityRankIdType INVALID_SEVERITY_RANK_ID = -1;
 
 class ServerQueryOption : public DataQueryOption {
 public:
@@ -272,6 +273,14 @@ public:
 	void getIncidentTrackerIdSet(
 	  IncidentTrackerIdSet &incidentTrackerIdSet);
 
+	SeverityRankIdType upsertSeverityRankInfo(
+	  SeverityRankInfo &severityRankInfo, const OperationPrivilege &privilege);
+	HatoholError updateSeverityRankInfo(
+	  SeverityRankInfo &severityRankInfo, const OperationPrivilege &privilege);
+	void getSeverityRankInfo(SeverityRankInfoVect &severityRankInfoVect);
+	HatoholError deleteSeverityRanks(
+          const std::list<SeverityRankIdType> &idList, const OperationPrivilege &privilege);
+
 protected:
 	static SetupInfo &getSetupInfo(void);
 	static void tableInitializerSystem(DBAgent &dbAgent, void *data);
@@ -300,6 +309,16 @@ protected:
 	void preprocForDeleteArmPluginInfo(
 	  const ServerIdType &serverId, std::string &condition);
 	void deleteArmPluginInfoWithoutTransaction(const std::string &condition);
+
+	HatoholError checkPrivilegeForAdd(
+	  const OperationPrivilege &privilege,
+	  const SeverityRankInfo &severityRankInfo);
+	HatoholError checkPrivilegeForDelete(
+	  const OperationPrivilege &privilege,
+	  const std::list<SeverityRankIdType> &idList);
+	HatoholError checkPrivilegeForUpdate(
+	  const OperationPrivilege &privilege,
+	  const SeverityRankInfo &severityRankInfo);
 
 private:
 	struct Impl;

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -65,9 +65,9 @@ typedef ServerTypeInfoVect::iterator       ServerTypeInfoVectIterator;
 typedef ServerTypeInfoVect::const_iterator ServerTypeInfoVectConstIterator;
 
 struct SeverityRankInfo {
-	SeverityRankIdType  id;
-	TriggerSeverityType status;
-	std::string         color;
+	SeverityRankIdType     id;
+	SeverityRankStatusType status;
+	std::string            color;
 };
 
 typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -310,13 +310,13 @@ protected:
 	  const ServerIdType &serverId, std::string &condition);
 	void deleteArmPluginInfoWithoutTransaction(const std::string &condition);
 
-	HatoholError checkPrivilegeForAdd(
+	HatoholError checkPrivilegeForSeverityRankAdd(
 	  const OperationPrivilege &privilege,
 	  const SeverityRankInfo &severityRankInfo);
-	HatoholError checkPrivilegeForDelete(
+	HatoholError checkPrivilegeForSeverityRankDelete(
 	  const OperationPrivilege &privilege,
 	  const std::list<SeverityRankIdType> &idList);
-	HatoholError checkPrivilegeForUpdate(
+	HatoholError checkPrivilegeForSeverityRankUpdate(
 	  const OperationPrivilege &privilege,
 	  const SeverityRankInfo &severityRankInfo);
 

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -106,6 +106,27 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
+class SeverityRankQueryOption : public DataQueryOption {
+public:
+	SeverityRankQueryOption(const UserIdType &userId = INVALID_USER_ID);
+	SeverityRankQueryOption(DataQueryContext *dataQueryContext);
+	virtual ~SeverityRankQueryOption();
+
+	void setTargetStatus(const TriggerSeverityType &status);
+	const TriggerSeverityType getTargetStatus(void);
+	void setTargetColor(const std::string &color);
+	const std::string getTargetColor(void);
+
+	virtual std::string getCondition(void) const override;
+
+protected:
+	bool hasPrivilegeCondition(std::string &condition) const;
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
 class DBTablesConfig : public DBTables {
 public:
 	static int CONFIG_DB_VERSION;

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -66,7 +66,7 @@ typedef ServerTypeInfoVect::const_iterator ServerTypeInfoVectConstIterator;
 
 struct SeverityRankInfo {
 	SeverityRankIdType id;
-	int                status;
+	TriggerSeverityType status;
 	std::string        color;
 };
 

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1514,32 +1514,32 @@ const SeverityRankInfo testSeverityRankInfoDef[] = {
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_UNKNOWN,  // status
-        "#BCBCBC"                  // color
+	"#BCBCBC"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_INFO,     // status
-        "#CCE2CC"                  // color
+	"#CCE2CC"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_WARNING,  // status
-        "#FDFD96"                  // color
+	"#FDFD96"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_ERROR,    // status
-        "#DDAAAA"                  // color
+	"#DDAAAA"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
-        "#FF8888"                  // color
+	"#FF8888"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
-        "#FF0000"                  // color
+	"#FF0000"                  // color
 },
 };
 const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -2419,3 +2419,12 @@ void loadTestDBLastInfo(void)
 	for (auto lastInfoDef : testLastInfoDef)
 		dbLastInfo.upsertLastInfo(lastInfoDef, privilege);
 }
+
+void loadTestDBSeverityRankInfo(void)
+{
+	ThreadLocalDBCache cache;
+	DBTablesConfig &dbConfig = cache.getConfig();
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	for (auto severityRankInfo : testSeverityRankInfoDef)
+		dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
+}

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1510,6 +1510,40 @@ const LastInfoDef testLastInfoDef[] = {
 };
 const size_t NumTestLastInfoDef = ARRAY_SIZE(testLastInfoDef);
 
+const SeverityRankInfo testSeverityRankInfoDef[] = {
+{
+	AUTO_INCREMENT_VALUE,     // id
+	TRIGGER_SEVERITY_UNKNOWN, // status
+        "#BCBCBC"
+},
+{
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_INFO,     // status
+        "#CCE2CC"
+},
+{
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_WARNING,  // status
+        "#FDFD96"
+},
+{
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_ERROR,    // status
+        "#DDAAAA"
+},
+{
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_CRITICAL, // status
+        "#FF8888"
+},
+{
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_CRITICAL, // status
+        "#FF0000"
+},
+};
+const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);
+
 const TriggerInfo &searchTestTriggerInfo(const EventInfo &eventInfo)
 {
 	for (size_t i = 0; i < NumTestTriggerInfo; i++) {

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1512,34 +1512,34 @@ const size_t NumTestLastInfoDef = ARRAY_SIZE(testLastInfoDef);
 
 const SeverityRankInfo testSeverityRankInfoDef[] = {
 {
-	AUTO_INCREMENT_VALUE,     // id
-	TRIGGER_SEVERITY_UNKNOWN, // status
-        "#BCBCBC"
+	AUTO_INCREMENT_VALUE,      // id
+	TRIGGER_SEVERITY_UNKNOWN,  // status
+        "#BCBCBC"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_INFO,     // status
-        "#CCE2CC"
+        "#CCE2CC"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_WARNING,  // status
-        "#FDFD96"
+        "#FDFD96"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_ERROR,    // status
-        "#DDAAAA"
+        "#DDAAAA"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
-        "#FF8888"
+        "#FF8888"                  // color
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
-        "#FF0000"
+        "#FF0000"                  // color
 },
 };
 const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1537,9 +1537,9 @@ const SeverityRankInfo testSeverityRankInfoDef[] = {
 	"#FF8888"                  // color
 },
 {
-	AUTO_INCREMENT_VALUE,      // id
-	TRIGGER_SEVERITY_CRITICAL, // status
-	"#FF0000"                  // color
+	AUTO_INCREMENT_VALUE,       // id
+	TRIGGER_SEVERITY_EMERGENCY, // status
+	"#FF0000"                   // color
 },
 };
 const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -106,6 +106,10 @@ extern const size_t NumTestHostgroupMember;
 
 extern const LastInfoDef testLastInfoDef[];
 extern const size_t NumTestLastInfoDef;
+
+extern const SeverityRankInfo testSeverityRankInfoDef[];
+extern const size_t NumTestSeverityRankInfoDef;
+
 /**
  * get the test trigger data indexes whose serverId and hostId are
  * matched with the specified.

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -274,5 +274,6 @@ void loadTestDBHostgroup(void);
 void loadTestDBHostgroupMember(void);
 
 void loadTestDBLastInfo(void);
+void loadTestDBSeverityRankInfo(void);
 
 #endif // DBClientTest_h

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1458,7 +1458,8 @@ void test_getSeverityRankInfo(void)
 	DECLARE_DBTABLES_CONFIG(dbConfig);
 
 	SeverityRankInfoVect severityRankInfoVect;
-	dbConfig.getSeverityRankInfo(severityRankInfoVect);
+	SeverityRankQueryOption option(USER_ID_SYSTEM);
+	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
 	{
 		size_t i = 0;
 		for (auto severityRankInfo : severityRankInfoVect) {

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1472,6 +1472,26 @@ void test_getSeverityRankInfo(void)
 	}
 }
 
+void test_getSeverityRankInfoWithOption(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+
+	SeverityRankInfoVect severityRankInfoVect;
+	SeverityRankQueryOption option(USER_ID_SYSTEM);
+	option.setTargetStatus(TRIGGER_SEVERITY_ERROR);
+	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
+	cppcut_assert_equal((size_t)1, severityRankInfoVect.size());
+	for (auto severityRankInfo : severityRankInfoVect) {
+		// ignore id assertion. Because id is auto increment.
+		severityRankInfo.id = 0;
+		int targetId = 3;
+		assertSeverityRankInfo(testSeverityRankInfoDef[targetId],
+				       severityRankInfo);
+	}
+}
+
 void test_deleteSeverityRankInfo(void)
 {
 	loadTestDBSeverityRankInfo();

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1472,7 +1472,7 @@ void test_getSeverityRankInfoWithoutOption(void)
 	}
 }
 
-void test_getSeverityRankInfoWithOption(void)
+void test_getSeverityRankInfoWithStatusOption(void)
 {
 	loadTestDBSeverityRankInfo();
 

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1492,6 +1492,26 @@ void test_getSeverityRankInfoWithOption(void)
 	}
 }
 
+void test_getSeverityRankInfoWithColorOption(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+
+	SeverityRankInfoVect severityRankInfoVect;
+	SeverityRankQueryOption option(USER_ID_SYSTEM);
+	option.setTargetColor("#DDAAAA");
+	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
+	cppcut_assert_equal((size_t)1, severityRankInfoVect.size());
+	for (auto severityRankInfo : severityRankInfoVect) {
+		// ignore id assertion. Because id is auto increment.
+		severityRankInfo.id = 0;
+		int targetId = 3;
+		assertSeverityRankInfo(testSeverityRankInfoDef[targetId],
+				       severityRankInfo);
+	}
+}
+
 void test_deleteSeverityRankInfo(void)
 {
 	loadTestDBSeverityRankInfo();

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1356,4 +1356,152 @@ void test_deleteIncidentTrackerWithoutPrivilege(void)
 	assertIncidentTrackersInDB(EMPTY_INCIDENT_TRACKER_ID_SET);
 }
 
+static void _assertSeverityRankInfo(
+  const SeverityRankInfo &expect, const SeverityRankInfo &actual)
+{
+	cppcut_assert_equal(expect.id, actual.id);
+	cppcut_assert_equal(expect.status, actual.status);
+	cppcut_assert_equal(expect.color, actual.color);
+}
+#define assertSeverityRankInfo(E,A) cut_trace(_assertSeverityRankInfo(E,A))
+
+void test_createTableSeverityRanks(void)
+{
+	const string tableName = "severity_ranks";
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+	assertCreateTable(&dbConfig.getDBAgent(), tableName);
+
+	// check content
+	const string statement = "SELECT * FROM " + tableName;
+	const string expectedOut = ""; // currently no data
+	assertDBContent(&dbConfig.getDBAgent(), statement, expectedOut);
+}
+
+void test_upsertSeverityRankInfo(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+	SeverityRankInfo severityRankInfo;
+	severityRankInfo.id = AUTO_INCREMENT_VALUE;
+	severityRankInfo.status = TRIGGER_SEVERITY_INFO;
+	severityRankInfo.color = "#00FF00";
+
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	SeverityRankIdType severityRankId =
+		dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
+	const string statement = "SELECT * FROM severity_ranks WHERE id = "+
+		StringUtils::toString(static_cast<int>(NumTestSeverityRankInfoDef + 1));
+	const string expect =
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+			       severityRankId, severityRankInfo.status,
+			       severityRankInfo.color.c_str());
+	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
+	cppcut_assert_not_equal((SeverityRankIdType)AUTO_INCREMENT_VALUE,
+				severityRankId);
+}
+
+void test_upsertSeverityRankInfoUpdate(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+	SeverityRankInfo severityRankInfo;
+	severityRankInfo.id = AUTO_INCREMENT_VALUE;
+	severityRankInfo.status = TRIGGER_SEVERITY_INFO;
+	severityRankInfo.color = "#00FF00";
+
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	SeverityRankIdType id0 =
+		dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
+	severityRankInfo.id = id0;
+	SeverityRankIdType id1 =
+		dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
+	const string statement = "SELECT * FROM severity_ranks WHERE id = "+
+		StringUtils::toString(static_cast<int>(NumTestSeverityRankInfoDef + 1));
+	const string expect =
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+			       id1, severityRankInfo.status,
+			       severityRankInfo.color.c_str());
+	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
+	cppcut_assert_not_equal((SeverityRankIdType)AUTO_INCREMENT_VALUE, id1);
+}
+
+void test_updateSeverityRankInfo(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+	SeverityRankInfo severityRankInfo;
+	SeverityRankIdType targetId = 3;
+	severityRankInfo.id = targetId;
+	severityRankInfo.status = TRIGGER_SEVERITY_CRITICAL;
+	severityRankInfo.color = "#AABC00";
+
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	dbConfig.updateSeverityRankInfo(severityRankInfo, privilege);
+	const string statement =
+	  StringUtils::sprintf(
+	    "SELECT * FROM severity_ranks WHERE id = %" FMT_SEVERITY_RANK_ID,
+	    targetId);
+	const string expect =
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+			       severityRankInfo.id, severityRankInfo.status,
+			       severityRankInfo.color.c_str());
+	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
+}
+
+void test_getSeverityRankInfo(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+
+	SeverityRankInfoVect severityRankInfoVect;
+	dbConfig.getSeverityRankInfo(severityRankInfoVect);
+	{
+		size_t i = 0;
+		for (auto severityRankInfo : severityRankInfoVect) {
+			// ignore id assertion. Because id is auto increment.
+			severityRankInfo.id = 0;
+			assertSeverityRankInfo(testSeverityRankInfoDef[i],
+					       severityRankInfo);
+			i++;
+		}
+	}
+}
+
+void test_deleteSeverityRankInfo(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+	SeverityRankInfo severityRankInfo;
+	SeverityRankIdType targetId = 2;
+	SeverityRankIdType actualId = targetId + 1;
+
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	const string statement =
+	  StringUtils::sprintf(
+	    "SELECT * FROM severity_ranks WHERE id = %" FMT_SEVERITY_RANK_ID,
+	    actualId);
+	// ignore id assertion. Because id is auto incremnt
+	const string expect =
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+			       actualId,
+			       testSeverityRankInfoDef[targetId].status,
+			       testSeverityRankInfoDef[targetId].color.c_str());
+	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
+
+	std::list<SeverityRankIdType> idList = {actualId};
+	dbConfig.deleteSeverityRanks(idList, privilege);
+
+	const string afterDeleteStatement =
+	  StringUtils::sprintf(
+	    "SELECT * FROM severity_ranks WHERE id = %" FMT_SEVERITY_RANK_ID,
+	    actualId);
+	const string afterDeleteExpect = "";
+	assertDBContent(&dbConfig.getDBAgent(),
+	                afterDeleteStatement, afterDeleteExpect);
+}
 } // namespace testDBTablesConfig

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1451,7 +1451,7 @@ void test_updateSeverityRankInfo(void)
 	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
 }
 
-void test_getSeverityRankInfo(void)
+void test_getSeverityRankInfoWithoutOption(void)
 {
 	loadTestDBSeverityRankInfo();
 


### PR DESCRIPTION
## SeverityRanks Table Definition

| id | status| color         |
| ---| ------------- | ----------- |
| int(11) `auto increment` `primary key` |  int(11)   | varchar(255) |

## Added CRUD functions

* upsertSeverityRankInfo(Create|Update)
* updateSeverityRankInfo(Update)
* getSeverityRankInfo(Read)
* deleteSeverityRanks(Delete)

## SeverityRankQueryOption

Used by getSeverityRankInfo.

* (get|set)targetStatus
* (get|set)targetColor

## Not included in this pull request

* Define CRUD `severity_ranks` related privileges
* Check `severity_ranks` related privileges in CRUD phase