### PR TITLE
[test] Terminate launced Hatohol server and manage.py.

### DIFF
--- a/test/launch-hatohol-for-test.sh
+++ b/test/launch-hatohol-for-test.sh
@@ -33,11 +33,13 @@ fi
 
 HATOHOL_DB_DIR=/tmp $server_dir/src/.libs/hatohol --pid-file /tmp/hatohol.pid --foreground --test-mode &
 server_pid=$!
+test ! -z $PIDS_FILE && echo $server_pid >> $PIDS_FILE
 
 cd $client_dir
 ./manage.py syncdb
 HATOHOL_DEBUG=1 ./manage.py runserver 0.0.0.0:8000 &
 client_pid=$!
+test ! -z $PIDS_FILE && echo $client_pid >> $PIDS_FILE
 
 # wait for the boot completion
 NUM_RETRY=30

--- a/test/run-client-test.sh
+++ b/test/run-client-test.sh
@@ -5,6 +5,12 @@ BASE_DIR="`dirname $0`"
 TOP_DIR="$BASE_DIR/.."
 
 ${TOP_DIR}/client/test/python/run-test.sh || FAILED=1
+
+export PIDS_FILE=`pwd`/pids_file
+rm -fr $PIDS_FILE
 ${TOP_DIR}/test/launch-hatohol-for-test.sh || exit 1
 $(npm bin)/mocha-phantomjs http://localhost:8000/test/index.html || FAILED=1
+# manage.py has a child process. We have to kill it too.
+cat $PIDS_FILE | awk '{ print "ps h -p " $1 " --ppid " $1 " -o pid" }' | sh | awk '{ print "kill " $1 }' | sh
+
 exit $FAILED


### PR DESCRIPTION
test/run-client-tesst.sh launches Hatohol server and manage.py,
although it never terminate them.
It is no problem unless this script is used in Travis CI, because
the new Hatohol server and manange.py is not required and launched.
However, on developemnet, some situation need to terminate them
in order to run the script again.