### PR TITLE
Add an option easy to select date-version package or not.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,13 +1,25 @@
 #!/bin/sh
 
-# The date and time can be added to the version by
-# setting the environment variable like
-#
-#   $ rm -fr autom4te.cache
-#   $ ADD_DATE_TO_VERSION=1 ./autogen.sh
+date_version_package=0
+
+while [ "$1" != "" ]; do
+  if [ $1 == "-d" ]; then
+    date_version_package=1
+    echo Date Version Package: yes
+  fi
+
+  shift
+done
 
 if [ ! -d m4 ]; then
   mkdir m4
+fi
+
+# Deletetion m4 cache here to make sure to run
+# m4_esyscmd() in configure.ac every time
+rm -fr autom4te.cache
+if [ $date_version_package -eq 1 ]; then
+  export ADD_DATE_TO_VERSION=1
 fi
 
 autoreconf -i


### PR DESCRIPTION
Previously we have to remove m4 cache dir and add an environemnt
variable to autogen.sh.

This patch does it only with -d option.