### PR TITLE
[UnifiedDataStore] Add severity rate CRUD functions

### DIFF
--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1660,7 +1660,7 @@ HatoholError DBTablesConfig::updateSeverityRankInfo(
 	return HTERR_OK;
 }
 
-void DBTablesConfig::getSeverityRankInfo(
+void DBTablesConfig::getSeverityRanks(
   SeverityRankInfoVect &severityRankInfoVect,
   const SeverityRankQueryOption &option)
 {

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -299,7 +299,7 @@ public:
           SeverityRankIdType &severityRankId);
 	HatoholError updateSeverityRankInfo(
 	  SeverityRankInfo &severityRankInfo, const OperationPrivilege &privilege);
-	void getSeverityRankInfo(
+	void getSeverityRanks(
 	  SeverityRankInfoVect &severityRankInfoVect,
 	  const SeverityRankQueryOption &option);
 	HatoholError deleteSeverityRanks(

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -961,6 +961,38 @@ bool UnifiedDataStore::getIncidentTrackerInfo(const IncidentTrackerIdType &track
 	return true;
 }
 
+HatoholError UnifiedDataStore::upsertSeverityRank(
+  SeverityRankInfo &severityRankInfo, const OperationPrivilege privilege,
+  SeverityRankIdType &severityRankId)
+{
+	ThreadLocalDBCache cache;
+	return cache.getConfig().upsertSeverityRankInfo(severityRankInfo, privilege,
+							severityRankId);
+}
+
+HatoholError UnifiedDataStore::updateSeverityRank(
+  SeverityRankInfo &severityRankInfo, const OperationPrivilege privilege)
+{
+	ThreadLocalDBCache cache;
+	return cache.getConfig().updateSeverityRankInfo(severityRankInfo, privilege);
+}
+
+HatoholError UnifiedDataStore::getSeverityRanks(
+  SeverityRankInfoVect &severityRankInfoVect, const SeverityRankQueryOption &option)
+{
+	ThreadLocalDBCache cache;
+	cache.getConfig().getSeverityRankInfo(severityRankInfoVect, option);
+
+	return HTERR_OK;
+}
+
+HatoholError UnifiedDataStore::deleteSeverityRanks(
+  std::list<SeverityRankIdType> &idList, const OperationPrivilege privilege)
+{
+	ThreadLocalDBCache cache;
+	return cache.getConfig().deleteSeverityRanks(idList, privilege);
+}
+
 void UnifiedDataStore::startArmIncidentTrackerIfNeeded(
   const IncidentTrackerIdType &trackerId)
 {

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -981,7 +981,7 @@ HatoholError UnifiedDataStore::getSeverityRanks(
   SeverityRankInfoVect &severityRankInfoVect, const SeverityRankQueryOption &option)
 {
 	ThreadLocalDBCache cache;
-	cache.getConfig().getSeverityRankInfo(severityRankInfoVect, option);
+	cache.getConfig().getSeverityRanks(severityRankInfoVect, option);
 
 	return HTERR_OK;
 }

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -301,6 +301,16 @@ public:
 	};
 	void getSystemInfo(SystemInfo &systemInfo,
 	                   const DataQueryOption &option);
+	// SeverityRank
+	HatoholError upsertSeverityRank(SeverityRankInfo &severityRankInfo,
+	                                const OperationPrivilege privilege,
+	                                SeverityRankIdType &severityRankId);
+	HatoholError updateSeverityRank(SeverityRankInfo &severityRankInfo,
+	                                const OperationPrivilege privilege);
+	HatoholError getSeverityRanks(SeverityRankInfoVect &severityRankInfoVect,
+	                              const SeverityRankQueryOption &option);
+	HatoholError deleteSeverityRanks(std::list<SeverityRankIdType> &idList,
+	                                 const OperationPrivilege privilege);
 
 protected:
 	void fetchItems(const ServerIdType &targetServerId = ALL_SERVERS);

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1498,7 +1498,7 @@ void test_getSeverityRankInfoWithoutOption(void)
 
 	SeverityRankInfoVect severityRankInfoVect;
 	SeverityRankQueryOption option(USER_ID_SYSTEM);
-	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
+	dbConfig.getSeverityRanks(severityRankInfoVect, option);
 	{
 		size_t i = 0;
 		for (auto severityRankInfo : severityRankInfoVect) {
@@ -1520,7 +1520,7 @@ void test_getSeverityRankInfoWithStatusOption(void)
 	SeverityRankInfoVect severityRankInfoVect;
 	SeverityRankQueryOption option(USER_ID_SYSTEM);
 	option.setTargetStatus(TRIGGER_SEVERITY_ERROR);
-	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
+	dbConfig.getSeverityRanks(severityRankInfoVect, option);
 	cppcut_assert_equal((size_t)1, severityRankInfoVect.size());
 	for (auto severityRankInfo : severityRankInfoVect) {
 		// ignore id assertion. Because id is auto increment.
@@ -1540,7 +1540,7 @@ void test_getSeverityRankInfoWithColorOption(void)
 	SeverityRankInfoVect severityRankInfoVect;
 	SeverityRankQueryOption option(USER_ID_SYSTEM);
 	option.setTargetColor("#DDAAAA");
-	dbConfig.getSeverityRankInfo(severityRankInfoVect, option);
+	dbConfig.getSeverityRanks(severityRankInfoVect, option);
 	cppcut_assert_equal((size_t)1, severityRankInfoVect.size());
 	for (auto severityRankInfo : severityRankInfoVect) {
 		// ignore id assertion. Because id is auto increment.


### PR DESCRIPTION
And this PR contains the commit which renames `getSeverityRateInfo` function to  `getSeverityRates`.