### PR TITLE
[Wercker] Try to use CentOS 6.7 docker image

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -2,8 +2,8 @@ box: wercker-labs/docker
 build:
   steps:
     - script:
-        name: Build a CentOS 6.6 Docker Hatohol image box
+        name: Build a CentOS 6.7 Docker Hatohol image box
         code: |
           docker -v
           echo ${WERCKER_GIT_COMMIT} > wercker/GIT_REVISION
-          docker build -t centos66/build-hatohol wercker/
+          docker build -t centos67/build-hatohol wercker/

--- a/wercker/Dockerfile
+++ b/wercker/Dockerfile
@@ -1,4 +1,4 @@
-from centos:6.6
+from centos:6.7
 
 maintainer hatohol project
 


### PR DESCRIPTION
Wercker says: age (6.6) from centos, Server error: 400 trying to fetch remote history.

It seems that centos:6.6 image has been deleted from DockerHub.
We should start using CentOS 6.7 image in Wercker.