### PR TITLE
[REST API][SeverityRank] Severity rank REST API fix

### DIFF
--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1656,6 +1656,15 @@ void DBTablesConfig::getIncidentTrackerIdSet(
 	}
 }
 
+void SeverityRankInfo::initialize(SeverityRankInfo &severityRankInfo)
+{
+	severityRankInfo.id = INVALID_SEVERITY_RANK_ID;
+	severityRankInfo.status = INVALID_SEVERITY_STATUS_TYPE;
+	severityRankInfo.color = "#000000";
+	severityRankInfo.label = "";
+	severityRankInfo.asImportant = false;
+}
+
 HatoholError DBTablesConfig::upsertSeverityRankInfo(
   SeverityRankInfo &severityRankInfo,
   const OperationPrivilege &privilege)

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1723,12 +1723,14 @@ void DBTablesConfig::getSeverityRanks(
 	for (auto itemGrp : grpList) {
 		ItemGroupStream itemGroupStream(itemGrp);
 		SeverityRankInfo severityRankInfo;
+		int asImportant;
 
 		itemGroupStream >> severityRankInfo.id;
 		itemGroupStream >> severityRankInfo.status;
 		itemGroupStream >> severityRankInfo.color;
 		itemGroupStream >> severityRankInfo.label;
-		itemGroupStream >> severityRankInfo.asImportant;
+		itemGroupStream >> asImportant;
+		severityRankInfo.asImportant = static_cast<bool>(asImportant);
 
 		severityRankInfoVect.push_back(severityRankInfo);
 	}

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1670,6 +1670,8 @@ HatoholError DBTablesConfig::upsertSeverityRankInfo(
 	arg.add(severityRankInfo.id);
 	arg.add(severityRankInfo.status);
 	arg.add(severityRankInfo.color);
+	arg.add(severityRankInfo.label);
+	arg.add(severityRankInfo.asImportant);
 	arg.upsertOnDuplicate = true;
 
 	getDBAgent().runTransaction(arg, &severityRankInfo.id);
@@ -1694,6 +1696,8 @@ HatoholError DBTablesConfig::updateSeverityRankInfo(
 	                                     severityRankInfo.id);
 	arg.add(IDX_SEVERITY_RANK_STATUS, severityRankInfo.status);
 	arg.add(IDX_SEVERITY_RANK_COLOR, severityRankInfo.color);
+	arg.add(IDX_SEVERITY_RANK_LABEL, severityRankInfo.label);
+	arg.add(IDX_SEVERITY_RANK_AS_IMPORTANT, severityRankInfo.asImportant);
 
 	getDBAgent().runTransaction(arg);
 	return HTERR_OK;
@@ -1707,6 +1711,8 @@ void DBTablesConfig::getSeverityRanks(
 	arg.add(IDX_SEVERITY_RANK_ID);
 	arg.add(IDX_SEVERITY_RANK_STATUS);
 	arg.add(IDX_SEVERITY_RANK_COLOR);
+	arg.add(IDX_SEVERITY_RANK_LABEL);
+	arg.add(IDX_SEVERITY_RANK_AS_IMPORTANT);
 	arg.condition = option.getCondition();
 
 	getDBAgent().runTransaction(arg);
@@ -1721,6 +1727,8 @@ void DBTablesConfig::getSeverityRanks(
 		itemGroupStream >> severityRankInfo.id;
 		itemGroupStream >> severityRankInfo.status;
 		itemGroupStream >> severityRankInfo.color;
+		itemGroupStream >> severityRankInfo.label;
+		itemGroupStream >> severityRankInfo.asImportant;
 
 		severityRankInfoVect.push_back(severityRankInfo);
 	}

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1962,11 +1962,11 @@ string SeverityRankQueryOption::getCondition(void) const
 
 	if (!m_impl->label.empty()) {
 		DBTermCStringProvider rhs(*getDBTermCodec());
-		string colorCondition = StringUtils::sprintf(
+		string labelCondition = StringUtils::sprintf(
 		  "%s=%s",
 		  COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_LABEL].columnName,
 		  rhs(m_impl->label.c_str()));
-		addCondition(condition, colorCondition);
+		addCondition(condition, labelCondition);
 	}
 
 	return condition;

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -41,7 +41,7 @@ static const char *TABLE_NAME_ARM_PLUGINS = "arm_plugins";
 static const char *TABLE_NAME_INCIDENT_TRACKERS = "incident_trackers";
 static const char *TABLE_NAME_SEVERITY_RANKS = "severity_ranks";
 
-int DBTablesConfig::CONFIG_DB_VERSION = 17;
+int DBTablesConfig::CONFIG_DB_VERSION = 18;
 
 const ServerIdSet EMPTY_SERVER_ID_SET;
 const ServerIdSet EMPTY_INCIDENT_TRACKER_ID_SET;
@@ -738,6 +738,14 @@ static bool updateDB(
 	}
 	if (oldVer < 17) {
 		dbAgent.createTable(tableProfileSeverityRanks);
+	}
+	if (oldVer < 18) {
+		DBAgent::AddColumnsArg addColumnsArg(tableProfileSeverityRanks);
+		addColumnsArg.columnIndexes.push_back(
+			IDX_SEVERITY_RANK_LABEL);
+		addColumnsArg.columnIndexes.push_back(
+			IDX_SEVERITY_RANK_AS_IMPORTANT);
+		dbAgent.addColumns(addColumnsArg);
 	}
 	return true;
 }

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -1814,6 +1814,7 @@ struct SeverityRankQueryOption::Impl {
 	TriggerSeverityType           status;
 	std::list<SeverityRankIdType> idList;
 	string                        color;
+	string                        label;
 
 	Impl(SeverityRankQueryOption *_option)
 	: option(_option), status(TRIGGER_SEVERITY_ALL)
@@ -1845,6 +1846,14 @@ string SeverityRankQueryOption::Impl::makeConditionTemplate(void)
 	cond += StringUtils::sprintf(
 	  "((%s IS NULL) OR (%s=%%s))",
 	  colDefColor.columnName, colDefColor.columnName);
+	cond += " AND ";
+
+	// label;
+	const ColumnDef &colDefLabel =
+		COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_LABEL];
+	cond += StringUtils::sprintf(
+	  "((%s IS NULL) OR (%s=%%s))",
+	  colDefLabel.columnName, colDefLabel.columnName);
 	cond += " AND ";
 
 	return cond;
@@ -1904,6 +1913,16 @@ const list<SeverityRankIdType> SeverityRankQueryOption::getTargetIdList(void) {
 	return m_impl->idList;
 }
 
+void SeverityRankQueryOption::setTargetLabel(const string &label)
+{
+	m_impl->label = label;
+}
+
+const string SeverityRankQueryOption::getTargetLabel(void)
+{
+	return m_impl->label;
+}
+
 string SeverityRankQueryOption::getCondition(void) const
 {
 	string condition = DataQueryOption::getCondition();
@@ -1929,6 +1948,15 @@ string SeverityRankQueryOption::getCondition(void) const
 		  "%s=%s",
 		  COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_COLOR].columnName,
 		  rhs(m_impl->color.c_str()));
+		addCondition(condition, colorCondition);
+	}
+
+	if (!m_impl->label.empty()) {
+		DBTermCStringProvider rhs(*getDBTermCodec());
+		string colorCondition = StringUtils::sprintf(
+		  "%s=%s",
+		  COLUMN_DEF_SEVERITY_RANKS[IDX_SEVERITY_RANK_LABEL].columnName,
+		  rhs(m_impl->label.c_str()));
 		addCondition(condition, colorCondition);
 	}
 

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -600,12 +600,34 @@ static const ColumnDef COLUMN_DEF_SEVERITY_RANKS[] = {
 	0,                                 // flags
 	NULL,                              // defaultValue
 },
+{
+	"label",                           // columnName
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+},
+{
+	"as_important",                    // columnName
+	SQL_COLUMN_TYPE_INT,               // type
+	11,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	"1",                               // defaultValue
+},
 };
 
 enum {
 	IDX_SEVERITY_RANK_ID,
 	IDX_SEVERITY_RANK_STATUS,
 	IDX_SEVERITY_RANK_COLOR,
+	IDX_SEVERITY_RANK_LABEL,
+	IDX_SEVERITY_RANK_AS_IMPORTANT,
 	NUM_IDX_SEVERITY_RANKS,
 };
 

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -70,10 +70,13 @@ struct SeverityRankInfo {
 	std::string            color;
 	std::string            label;
 	bool                   asImportant;
+
+	static void initialize(SeverityRankInfo &severityRankInfo);
 };
 
 typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;
 constexpr const static SeverityRankIdType INVALID_SEVERITY_RANK_ID = -1;
+constexpr const static SeverityRankStatusType INVALID_SEVERITY_STATUS_TYPE = -1;
 
 class ServerQueryOption : public DataQueryOption {
 public:

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -68,6 +68,8 @@ struct SeverityRankInfo {
 	SeverityRankIdType     id;
 	SeverityRankStatusType status;
 	std::string            color;
+	std::string            label;
+	bool                   asImportant;
 };
 
 typedef std::vector<SeverityRankInfo> SeverityRankInfoVect;

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -120,6 +120,8 @@ public:
 	const std::string getTargetColor(void);
 	void setTargetIdList(std::list<SeverityRankIdType> idList);
 	const std::list<SeverityRankIdType> getTargetIdList(void);
+	void setTargetLabel(const std::string &label);
+	const std::string getTargetLabel(void);
 
 	virtual std::string getCondition(void) const override;
 

--- a/server/src/RestResourceSeverityRank.cc
+++ b/server/src/RestResourceSeverityRank.cc
@@ -128,6 +128,7 @@ static HatoholError parseSeverityRankParameter(
 void RestResourceSeverityRank::handlePost(void)
 {
 	SeverityRankInfo severityRankInfo;
+	SeverityRankInfo::initialize(severityRankInfo);
 	severityRankInfo.id = AUTO_INCREMENT_VALUE;
 	HatoholError err = parseSeverityRankParameter(severityRankInfo,
 							 m_query);
@@ -163,6 +164,7 @@ void RestResourceSeverityRank::handlePut(void)
 	}
 
 	SeverityRankInfo severityRankInfo;
+	SeverityRankInfo::initialize(severityRankInfo);
 	severityRankInfo.id = severityRankId;
 
 	SeverityRankInfoVect severityRanks;

--- a/server/src/RestResourceSeverityRank.cc
+++ b/server/src/RestResourceSeverityRank.cc
@@ -81,7 +81,11 @@ void RestResourceSeverityRank::handleGet(void)
 		agent.add("status", severityRank.status);
 		agent.add("color", severityRank.color);
 		agent.add("label", severityRank.label);
-		agent.add("asImportant", severityRank.asImportant);
+		if (severityRank.asImportant) {
+			agent.addTrue("asImportant");
+		} else {
+			agent.addFalse("asImportant");
+		}
 
 		agent.endObject();
 	}

--- a/server/src/RestResourceSeverityRank.cc
+++ b/server/src/RestResourceSeverityRank.cc
@@ -80,6 +80,9 @@ void RestResourceSeverityRank::handleGet(void)
 		agent.add("id", severityRank.id);
 		agent.add("status", severityRank.status);
 		agent.add("color", severityRank.color);
+		agent.add("label", severityRank.label);
+		agent.add("asImportant", severityRank.asImportant);
+
 		agent.endObject();
 	}
 	agent.endArray();
@@ -116,6 +119,8 @@ static HatoholError parseSeverityRankParameter(
 
 	PARSE_VALUE(severityRankInfo, status, SeverityRankStatusType, allowEmpty);
 	PARSE_STRING_VALUE(severityRankInfo, color, allowEmpty);
+	PARSE_STRING_VALUE(severityRankInfo, label, allowEmpty);
+	PARSE_VALUE(severityRankInfo, asImportant, bool, allowEmpty);
 
 	return HatoholError(HTERR_OK);
 }

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1514,32 +1514,44 @@ const SeverityRankInfo testSeverityRankInfoDef[] = {
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_UNKNOWN,  // status
-	"#BCBCBC"                  // color
+	"#BCBCBC",                 // color
+	"Not classified",          // label
+	0                          // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_INFO,     // status
-	"#CCE2CC"                  // color
+	"#CCE2CC",                 // color
+	"Information",             // label
+	0                          // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_WARNING,  // status
-	"#FDFD96"                  // color
+	"#FDFD96",                 // color
+	"Warning",                 // label
+	0                          // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_ERROR,    // status
-	"#DDAAAA"                  // color
+	"#DDAAAA",                 // color
+	"Error",                   // label
+	1                          // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
-	"#FF8888"                  // color
+	"#FF8888",                 // color
+	"Critical",                // label
+	1                          // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,       // id
 	TRIGGER_SEVERITY_EMERGENCY, // status
-	"#FF0000"                   // color
+	"#FF0000",                   // color
+	"Emergency",                // label
+	1                           // asImportant
 },
 };
 const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1516,42 +1516,42 @@ const SeverityRankInfo testSeverityRankInfoDef[] = {
 	TRIGGER_SEVERITY_UNKNOWN,  // status
 	"#BCBCBC",                 // color
 	"Not classified",          // label
-	0                          // asImportant
+	false                      // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_INFO,     // status
 	"#CCE2CC",                 // color
 	"Information",             // label
-	0                          // asImportant
+	false                      // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_WARNING,  // status
 	"#FDFD96",                 // color
 	"Warning",                 // label
-	0                          // asImportant
+	false                      // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_ERROR,    // status
 	"#DDAAAA",                 // color
 	"Error",                   // label
-	1                          // asImportant
+	true                       // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,      // id
 	TRIGGER_SEVERITY_CRITICAL, // status
 	"#FF8888",                 // color
 	"Critical",                // label
-	1                          // asImportant
+	true                       // asImportant
 },
 {
 	AUTO_INCREMENT_VALUE,       // id
 	TRIGGER_SEVERITY_EMERGENCY, // status
 	"#FF0000",                   // color
 	"Emergency",                // label
-	1                           // asImportant
+	true                        // asImportant
 },
 };
 const size_t NumTestSeverityRankInfoDef = ARRAY_SIZE(testSeverityRankInfoDef);

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -699,9 +699,11 @@ string makeMapHostsHostgroupsOutput(
 std::string makeSeverityRankInfoOutput(const SeverityRankInfo &severityRankInfo)
 {
 	return StringUtils::sprintf(
-		 "%" FMT_SEVERITY_RANK_ID "|%d|%s\n",
+		 "%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d\n",
 		 severityRankInfo.id, severityRankInfo.status,
-		 severityRankInfo.color.c_str());
+		 severityRankInfo.color.c_str(),
+		 severityRankInfo.label.c_str(),
+		 severityRankInfo.asImportant);
 }
 
 static void assertDBContentForComponets(const string &expect,

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1580,6 +1580,26 @@ void test_getSeverityRankInfoWithidListOption(void)
 	}
 }
 
+void test_getSeverityRankInfoWithLabelOption(void)
+{
+	loadTestDBSeverityRankInfo();
+
+	DECLARE_DBTABLES_CONFIG(dbConfig);
+
+	SeverityRankInfoVect severityRankInfoVect;
+	SeverityRankQueryOption option(USER_ID_SYSTEM);
+	option.setTargetLabel("Error");
+	dbConfig.getSeverityRanks(severityRankInfoVect, option);
+	cppcut_assert_equal((size_t)1, severityRankInfoVect.size());
+	for (auto severityRankInfo : severityRankInfoVect) {
+		// ignore id assertion. Because id is auto increment.
+		severityRankInfo.id = 0;
+		int targetId = 3;
+		assertSeverityRankInfo(testSeverityRankInfoDef[targetId],
+				       severityRankInfo);
+	}
+}
+
 void test_deleteSeverityRankInfo(void)
 {
 	loadTestDBSeverityRankInfo();

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -1362,6 +1362,8 @@ static void _assertSeverityRankInfo(
 	cppcut_assert_equal(expect.id, actual.id);
 	cppcut_assert_equal(expect.status, actual.status);
 	cppcut_assert_equal(expect.color, actual.color);
+	cppcut_assert_equal(expect.label, actual.label);
+	cppcut_assert_equal(expect.asImportant, actual.asImportant);
 }
 #define assertSeverityRankInfo(E,A) cut_trace(_assertSeverityRankInfo(E,A))
 
@@ -1384,14 +1386,18 @@ void test_upsertSeverityRankInfo(void)
 	severityRankInfo.id = AUTO_INCREMENT_VALUE;
 	severityRankInfo.status = TRIGGER_SEVERITY_INFO;
 	severityRankInfo.color = "#00FF00";
+	severityRankInfo.label = "Information";
+	severityRankInfo.asImportant = false;
 
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
 	const string statement = "SELECT * FROM severity_ranks WHERE id = 1";
 	const string expect =
-	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d",
 			       severityRankInfo.id, severityRankInfo.status,
-			       severityRankInfo.color.c_str());
+			       severityRankInfo.color.c_str(),
+			       severityRankInfo.label.c_str(),
+			       severityRankInfo.asImportant);
 	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
 	cppcut_assert_not_equal((SeverityRankIdType)AUTO_INCREMENT_VALUE,
 				severityRankInfo.id);
@@ -1404,6 +1410,8 @@ void test_upsertSeverityRankInfoWithoutPrivilege(void)
 	severityRankInfo.id = AUTO_INCREMENT_VALUE;
 	severityRankInfo.status = TRIGGER_SEVERITY_INFO;
 	severityRankInfo.color = "#00FF00";
+	severityRankInfo.label = "Information";
+	severityRankInfo.asImportant = false;
 
 	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_CREATE_SEVERITY_RANK);
@@ -1425,6 +1433,8 @@ void test_upsertSeverityRankInfoUpdate(void)
 	severityRankInfo.id = actualId;
 	severityRankInfo.status = TRIGGER_SEVERITY_INFO;
 	severityRankInfo.color = "#00FF00";
+	severityRankInfo.label = "Information";
+	severityRankInfo.asImportant = false;
 
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
@@ -1432,9 +1442,11 @@ void test_upsertSeverityRankInfoUpdate(void)
 	const string statement = "SELECT * FROM severity_ranks WHERE id = "+
 		StringUtils::toString(static_cast<int>(actualId));
 	const string expect =
-	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d",
 			       actualId, severityRankInfo.status,
-			       severityRankInfo.color.c_str());
+			       severityRankInfo.color.c_str(),
+			       severityRankInfo.label.c_str(),
+			       severityRankInfo.asImportant);
 	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
 }
 
@@ -1448,6 +1460,8 @@ void test_updateSeverityRankInfo(void)
 	severityRankInfo.id = targetId;
 	severityRankInfo.status = TRIGGER_SEVERITY_CRITICAL;
 	severityRankInfo.color = "#AABC00";
+	severityRankInfo.label = "Critical";
+	severityRankInfo.asImportant = true;
 
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	dbConfig.updateSeverityRankInfo(severityRankInfo, privilege);
@@ -1456,9 +1470,11 @@ void test_updateSeverityRankInfo(void)
 	    "SELECT * FROM severity_ranks WHERE id = %" FMT_SEVERITY_RANK_ID,
 	    targetId);
 	const string expect =
-	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d",
 			       severityRankInfo.id, severityRankInfo.status,
-			       severityRankInfo.color.c_str());
+			       severityRankInfo.color.c_str(),
+			       severityRankInfo.label.c_str(),
+			       severityRankInfo.asImportant);
 	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
 }
 
@@ -1472,6 +1488,8 @@ void test_updateSeverityRankInfoWithoutPrivilege(void)
 	severityRankInfo.id = targetId;
 	severityRankInfo.status = TRIGGER_SEVERITY_CRITICAL;
 	severityRankInfo.color = "#AABC00";
+	severityRankInfo.label = "Critical";
+	severityRankInfo.asImportant = true;
 
 	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_UPDATE_SEVERITY_RANK);
@@ -1578,10 +1596,12 @@ void test_deleteSeverityRankInfo(void)
 	    actualId);
 	// ignore id assertion. Because id is auto incremnt
 	const string expect =
-	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s",
+	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d",
 			       actualId,
 			       testSeverityRankInfoDef[targetId].status,
-			       testSeverityRankInfoDef[targetId].color.c_str());
+			       testSeverityRankInfoDef[targetId].color.c_str(),
+			       testSeverityRankInfoDef[targetId].label.c_str(),
+			       testSeverityRankInfoDef[targetId].asImportant);
 	assertDBContent(&dbConfig.getDBAgent(), statement, expect);
 
 	std::list<SeverityRankIdType> idList = {actualId};

--- a/server/test/testFaceRestSeverityRank.cc
+++ b/server/test/testFaceRestSeverityRank.cc
@@ -65,6 +65,8 @@ static void _assertSeverityRanks(
 		assertValueInParser(g_parser, "id", i + 1);
 		assertValueInParser(g_parser, "status", severityRank.status);
 		assertValueInParser(g_parser, "color", severityRank.color);
+		assertValueInParser(g_parser, "label", severityRank.label);
+		assertValueInParser(g_parser, "asImportant", severityRank.asImportant);
 		g_parser->endElement();
 	}
 	g_parser->endObject();
@@ -134,6 +136,8 @@ static void createTestSeverityRank(SeverityRankInfo &severityRank)
 	// should be create new status value
 	severityRank.status = static_cast<int>(TRIGGER_SEVERITY_EMERGENCY) + 1;
 	severityRank.color  = "#00FF00";
+	severityRank.label  = "UserDefined 1";
+	severityRank.asImportant  = true;
 }
 
 static void createPostData(const SeverityRankInfo &severityRank,
@@ -142,6 +146,8 @@ static void createPostData(const SeverityRankInfo &severityRank,
 	params["id"]     = StringUtils::toString(severityRank.id);
 	params["status"] = StringUtils::toString(static_cast<int>(severityRank.status));
 	params["color"]  = severityRank.color;
+	params["label"]  = severityRank.label;
+	params["asImportant"]  = StringUtils::toString(severityRank.asImportant);
 }
 
 void test_addSeverityRank(void)
@@ -167,6 +173,8 @@ void test_updateSeverityRank(void)
 	  = testSeverityRankInfoDef[targetId - 1];
 	severityRank.id    = targetId;
 	severityRank.color = "#00FAFA";
+	severityRank.label = "Information";
+	severityRank.asImportant = false;
 	StringMap params;
 	createPostData(severityRank, params);
 

--- a/server/test/testFaceRestSeverityRank.cc
+++ b/server/test/testFaceRestSeverityRank.cc
@@ -147,7 +147,8 @@ static void createPostData(const SeverityRankInfo &severityRank,
 	params["status"] = StringUtils::toString(static_cast<int>(severityRank.status));
 	params["color"]  = severityRank.color;
 	params["label"]  = severityRank.label;
-	params["asImportant"]  = StringUtils::toString(severityRank.asImportant);
+	params["asImportant"] =
+		StringUtils::toString(static_cast<int>(severityRank.asImportant));
 }
 
 void test_addSeverityRank(void)


### PR DESCRIPTION
I've found missing label and as_important in severity_ranks table and its REST API.... :'(

Follow up #1618.