### PR TITLE
Save lastinfo body atomic #1569 2

### DIFF
--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -436,7 +436,7 @@ void DBAgent::runTransaction(TransactionProc &proc)
 	begin();
 	try {
 		proc(*this);
-	} catch(...) {
+	} catch (...) {
 		rollback();
 		throw;
 	};


### PR DESCRIPTION
This feature aims to be used for adressing #1569 in which
last info and data body isn't save atomically.