### PR TITLE
[HatoholArmPluginGateHAPI2] Use a simpler expression.

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1063,11 +1063,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerLastInfo(JSONParser &parser)
 	option.setTargetServerId(m_impl->m_serverInfo.id);
 	LastInfoDefList lastInfoList;
 	dbLastInfo.getLastInfoList(lastInfoList, option);
-	string lastInfoValue = "";
-	for (auto lastInfo : lastInfoList) {
-		lastInfoValue = lastInfo.value;
-		break;
-	}
+	string lastInfoValue =
+	  lastInfoList.empty() ? "" : lastInfoList.begin()->value;
 
 	JSONBuilder builder;
 	builder.startObject();


### PR DESCRIPTION
In addition, auto value: lastInfo was a copy. It might degrade
the performance slightly. This expression doesn't have a copy.