### PR TITLE
Fix #1569

### DIFF
--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -851,7 +851,8 @@ GenericIdType DBTablesHost::upsertHostgroup(const Hostgroup &hostgroup,
 	return id;
 }
 
-void DBTablesHost::upsertHostgroups(const HostgroupVect &hostgroups)
+void DBTablesHost::upsertHostgroups(const HostgroupVect &hostgroups,
+                                    DBAgent::TransactionHooks *hooks)
 {
 	struct Proc : public DBAgent::TransactionProc {
 		DBTablesHost &dbHost;
@@ -871,7 +872,7 @@ void DBTablesHost::upsertHostgroups(const HostgroupVect &hostgroups)
 				dbHost.upsertHostgroup(*hostgrpItr, false);
 		}
 	} proc(*this, hostgroups);
-	getDBAgent().runTransaction(proc);
+	getDBAgent().runTransaction(proc, hooks);
 }
 
 HatoholError DBTablesHost::getHostgroups(HostgroupVect &hostgroups,
@@ -1363,7 +1364,7 @@ static bool isHostgroupNameChanged(
 
 HatoholError DBTablesHost::syncHostgroups(
   const HostgroupVect &incomingHostgroups,
-  const ServerIdType &serverId)
+  const ServerIdType &serverId, DBAgent::TransactionHooks *hooks)
 {
 	HostgroupsQueryOption option(USER_ID_SYSTEM);
 	option.setTargetServerId(serverId);
@@ -1400,7 +1401,7 @@ HatoholError DBTablesHost::syncHostgroups(
 	if (invalidHostgroupIdList.size() > 0)
 		err = deleteHostgroupList(invalidHostgroupIdList);
 	if (serverHostgroups.size() > 0)
-		upsertHostgroups(serverHostgroups);
+		upsertHostgroups(serverHostgroups, hooks);
 	return err;
 }
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -750,7 +750,7 @@ HostIdType DBTablesHost::upsertHost(
 
 void DBTablesHost::upsertHosts(
   const ServerHostDefVect &serverHostDefs,
-  HostHostIdMap *hostHostIdMapPtr)
+  HostHostIdMap *hostHostIdMapPtr, DBAgent::TransactionHooks *hooks)
 {
 	struct Proc : public DBAgent::TransactionProc {
 		DBTablesHost &dbHost;
@@ -785,7 +785,7 @@ void DBTablesHost::upsertHosts(
 			(*hostHostIdMapPtr)[svHostDef.hostIdInServer] = hostId;
 		}
 	} proc(*this, serverHostDefs, hostHostIdMapPtr);
-	getDBAgent().runTransaction(proc);
+	getDBAgent().runTransaction(proc, hooks);
 }
 
 GenericIdType DBTablesHost::upsertServerHostDef(
@@ -1303,7 +1303,7 @@ static bool isHostNameChanged(
 
 HatoholError DBTablesHost::syncHosts(
   const ServerHostDefVect &svHostDefs, const ServerIdType &serverId,
-  HostHostIdMap *hostHostIdMapPtr)
+  HostHostIdMap *hostHostIdMapPtr, DBAgent::TransactionHooks *hooks)
 {
 	// Make a set that contains current hosts records
 	HostsQueryOption option(USER_ID_SYSTEM);
@@ -1344,7 +1344,7 @@ HatoholError DBTablesHost::syncHosts(
 		m_impl->storedHostsChanged = true;
 		return HTERR_OK;
 	}
-	upsertHosts(serverHostDefs, hostHostIdMapPtr);
+	upsertHosts(serverHostDefs, hostHostIdMapPtr, hooks);
 	m_impl->storedHostsChanged = false;
 	return HTERR_OK;
 }

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -1036,7 +1036,8 @@ GenericIdType DBTablesHost::upsertHostgroupMember(
 }
 
 void DBTablesHost::upsertHostgroupMembers(
-  const HostgroupMemberVect &hostgroupMembers)
+  const HostgroupMemberVect &hostgroupMembers,
+  DBAgent::TransactionHooks *hooks)
 {
 	struct Proc : public DBAgent::TransactionProc {
 		DBTablesHost &dbHost;
@@ -1057,7 +1058,7 @@ void DBTablesHost::upsertHostgroupMembers(
 				dbHost.upsertHostgroupMember(*hgrpMemIt, false);
 		}
 	} proc(*this, hostgroupMembers);
-	getDBAgent().runTransaction(proc);
+	getDBAgent().runTransaction(proc, hooks);
 }
 
 HatoholError DBTablesHost::getHostgroupMembers(
@@ -1458,7 +1459,8 @@ HatoholError DBTablesHost::syncHostgroups(
 
 HatoholError DBTablesHost::syncHostgroupMembers(
   const HostgroupMemberVect &incomingHostgroupMembers,
-  const ServerIdType &serverId)
+  const ServerIdType &serverId,
+  DBAgent::TransactionHooks *hooks)
 {
 	HostgroupMembersQueryOption option(USER_ID_SYSTEM);
 	option.setTargetServerId(serverId);
@@ -1496,7 +1498,7 @@ HatoholError DBTablesHost::syncHostgroupMembers(
 	if (invalidHostgroupMemberIdList.size() > 0)
 		err = deleteHostgroupMemberList(invalidHostgroupMemberIdList);
 	if (serverHostgroupMembers.size() > 0)
-		upsertHostgroupMembers(serverHostgroupMembers);
+		upsertHostgroupMembers(serverHostgroupMembers, hooks);
 	return HTERR_OK;
 }
 

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -228,9 +228,11 @@ public:
 	 * @param hostHostIdMapPtr
 	 * If this parameter is not NULL, the address of the ServerHostDef
 	 * and the corresponding host IDs are stored in it.
+	 * @param hook Transaction hook functions.
 	 */
 	void upsertHosts(const ServerHostDefVect &serverHostDefs,
-	                 HostHostIdMap *hostHostIdMapPtr = NULL);
+	                 HostHostIdMap *hostHostIdMapPtr = NULL,
+	                 DBAgent::TransactionHooks *hooks = NULL);
 
 	/**
 	 * Insert or update a record to/in the server-host-definition table
@@ -387,7 +389,8 @@ public:
 	 */
 	HatoholError syncHosts(
 	  const ServerHostDefVect &svHostDefs, const ServerIdType &serverId,
-	  HostHostIdMap *hostHostIdMapPtr = NULL);
+	  HostHostIdMap *hostHostIdMapPtr = NULL,
+	  DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError syncHostgroups(const HostgroupVect &hostgroups,
 	                            const ServerIdType &serverId);
 	HatoholError syncHostgroupMembers(const HostgroupMemberVect &hostgroupMembers,

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -287,7 +287,8 @@ public:
 	GenericIdType upsertHostgroup(const Hostgroup &hostgroup,
 	                              const bool &useTransaction = true);
 
-	void upsertHostgroups(const HostgroupVect &hostgroups);
+	void upsertHostgroups(const HostgroupVect &hostgroups,
+	                      DBAgent::TransactionHooks *hooks = NULL);
 
 	/**
 	 * Get hostgroups.
@@ -392,7 +393,8 @@ public:
 	  HostHostIdMap *hostHostIdMapPtr = NULL,
 	  DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError syncHostgroups(const HostgroupVect &hostgroups,
-	                            const ServerIdType &serverId);
+	                            const ServerIdType &serverId,
+	                            DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError syncHostgroupMembers(const HostgroupMemberVect &hostgroupMembers,
 	                                  const ServerIdType &serverId);
 

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -268,10 +268,15 @@ public:
 	 * the record is updated.
 	 *
 	 * @param vmInfo A data to be inserted/updated.
+	 * @param useTransaction A flag to use a transaction.
 	 * @return
 	 * The ID of inserted/updated record.
 	 */
-	GenericIdType upsertVMInfo(const VMInfo &vmInfo);
+	GenericIdType upsertVMInfo(const VMInfo &vmInfo,
+	                           const bool &useTransaction = true);
+
+	void upsertVMInfoVect(const VMInfoVect &vmInfoVect,
+	                      DBAgent::TransactionHooks *hooks);
 
 	/**
 	 * Insert or update a record to/in the hostgroup_list table

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -323,7 +323,8 @@ public:
 	  const bool &useTransaction = true);
 
 	void upsertHostgroupMembers(
-	  const HostgroupMemberVect &hostgroupMembers);
+	  const HostgroupMemberVect &hostgroupMembers,
+	  DBAgent::TransactionHooks *hooks = NULL);
 
 	HatoholError getHostgroupMembers(
 	  HostgroupMemberVect &hostgrpMembers,
@@ -400,8 +401,10 @@ public:
 	HatoholError syncHostgroups(const HostgroupVect &hostgroups,
 	                            const ServerIdType &serverId,
 	                            DBAgent::TransactionHooks *hooks = NULL);
-	HatoholError syncHostgroupMembers(const HostgroupMemberVect &hostgroupMembers,
-	                                  const ServerIdType &serverId);
+	HatoholError syncHostgroupMembers(
+	  const HostgroupMemberVect &hostgroupMembers,
+	  const ServerIdType &serverId,
+	  DBAgent::TransactionHooks *hooks = NULL);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/DBTablesLastInfo.cc
+++ b/server/src/DBTablesLastInfo.cc
@@ -151,8 +151,9 @@ DBTablesLastInfo::~DBTablesLastInfo()
 {
 }
 
-LastInfoIdType DBTablesLastInfo::upsertLastInfo(LastInfoDef &lastInfoDef,
-                                                const OperationPrivilege &privilege)
+LastInfoIdType DBTablesLastInfo::upsertLastInfo(
+  LastInfoDef &lastInfoDef, const OperationPrivilege &privilege,
+  const bool &useTransaction)
 {
 	HatoholError err = checkPrivilegeForAdd(privilege, lastInfoDef);
 	if (err != HTERR_OK)
@@ -166,7 +167,13 @@ LastInfoIdType DBTablesLastInfo::upsertLastInfo(LastInfoDef &lastInfoDef,
 	arg.add(lastInfoDef.serverId);
 	arg.upsertOnDuplicate = true;
 
-	getDBAgent().runTransaction(arg, &lastInfoId);
+	DBAgent &dbAgent = getDBAgent();
+	if (useTransaction) {
+		dbAgent.runTransaction(arg, &lastInfoId);
+	} else {
+		dbAgent.insert(arg);
+		lastInfoId = dbAgent.getLastInsertId();
+	}
 	return lastInfoId;
 }
 

--- a/server/src/DBTablesLastInfo.h
+++ b/server/src/DBTablesLastInfo.h
@@ -109,7 +109,8 @@ public:
 	DBTablesLastInfo(DBAgent &dbAgent);
 	virtual ~DBTablesLastInfo();
 	LastInfoIdType upsertLastInfo(LastInfoDef &lastInfoDef,
-	                              const OperationPrivilege &privilege);
+	                              const OperationPrivilege &privilege,
+	                              const bool &useTransaction = true);
 	HatoholError getLastInfoList(LastInfoDefList &lastInfoDefList,
 	                             const LastInfoQueryOption &option);
 	HatoholError deleteLastInfoList(const LastInfoIdList &idList,

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1959,7 +1959,8 @@ void DBTablesMonitoring::addEventInfo(EventInfo *eventInfo)
 	m_impl->addEventStatistics(trx.numAdded);
 }
 
-void DBTablesMonitoring::addEventInfoList(EventInfoList &eventInfoList)
+void DBTablesMonitoring::addEventInfoList(EventInfoList &eventInfoList,
+                                          DBAgent::TransactionHooks *hooks)
 {
 	struct TrxProc : public DBAgent::TransactionProc {
 		EventInfoList &eventInfoList;
@@ -1978,7 +1979,7 @@ void DBTablesMonitoring::addEventInfoList(EventInfoList &eventInfoList)
 				addEventInfoWithoutTransaction(dbAgent, *it);
 		}
 	} trx(eventInfoList);
-	getDBAgent().runTransaction(trx);
+	getDBAgent().runTransaction(trx, hooks);
 	m_impl->addEventStatistics(trx.numAdded);
 }
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1574,7 +1574,9 @@ void DBTablesMonitoring::addTriggerInfo(const TriggerInfo *triggerInfo)
 	getDBAgent().runTransaction(trx);
 }
 
-void DBTablesMonitoring::addTriggerInfoList(const TriggerInfoList &triggerInfoList)
+void DBTablesMonitoring::addTriggerInfoList(
+  const TriggerInfoList &triggerInfoList,
+  DBAgent::TransactionHooks *hooks)
 {
 	struct TrxProc : public DBAgent::TransactionProc {
 		const TriggerInfoList &triggerInfoList;
@@ -1592,7 +1594,7 @@ void DBTablesMonitoring::addTriggerInfoList(const TriggerInfoList &triggerInfoLi
 				addTriggerInfoWithoutTransaction(dbAgent, *it);
 		}
 	} trx(triggerInfoList);
-	getDBAgent().runTransaction(trx);
+	getDBAgent().runTransaction(trx, hooks);
 }
 
 bool DBTablesMonitoring::getTriggerInfo(TriggerInfo &triggerInfo,
@@ -1896,7 +1898,8 @@ static bool isTriggerDescriptionChanged(
 
 HatoholError DBTablesMonitoring::syncTriggers(
   const TriggerInfoList &incomingTriggerInfoList,
-  const ServerIdType &serverId)
+  const ServerIdType &serverId,
+  DBAgent::TransactionHooks *hooks)
 {
 	TriggersQueryOption option(USER_ID_SYSTEM);
 	option.setTargetServerId(serverId);
@@ -1933,7 +1936,7 @@ HatoholError DBTablesMonitoring::syncTriggers(
 	if (invalidTriggerIdList.size() > 0)
 		err = deleteTriggerInfo(invalidTriggerIdList, serverId);
 	if (serverTriggers.size() > 0)
-		addTriggerInfoList(serverTriggers);
+		addTriggerInfoList(serverTriggers, hooks);
 	return err;
 }
 

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -201,7 +201,8 @@ public:
 	int  getLastChangeTimeOfTrigger(const ServerIdType &serverId);
 
 	void addEventInfo(EventInfo *eventInfo);
-	void addEventInfoList(EventInfoList &eventInfoList);
+	void addEventInfoList(EventInfoList &eventInfoList,
+	                      DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError getEventInfoList(EventInfoList &eventInfoList,
 	                              const EventsQueryOption &option,
 				      IncidentInfoVect *incidentInfoVect = NULL);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -162,14 +162,16 @@ public:
 	virtual ~DBTablesMonitoring();
 
 	void addTriggerInfo(const TriggerInfo *triggerInfo);
-	void addTriggerInfoList(const TriggerInfoList &triggerInfoList);
+	void addTriggerInfoList(const TriggerInfoList &triggerInfoList,
+	                        DBAgent::TransactionHooks *hooks = NULL);
 
 	void updateTrigger(const TriggerInfoList &triggerInfoList,
 			   const ServerIdType &serverId);
 	HatoholError deleteTriggerInfo(const TriggerIdList &idList,
 	                               const ServerIdType &serverId);
 	HatoholError syncTriggers(const TriggerInfoList &triggerInfoList,
-	                          const ServerIdType &serverId);
+	                          const ServerIdType &serverId,
+	                          DBAgent::TransactionHooks *hooks = NULL);
 
 	/**
 	 * Get the trigger information with the specified server ID and

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1834,7 +1834,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutEvents(
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	EventInfoList eventInfoList;
 	JSONRPCError errObj;
-	string fetchId, lastInfo;
+	string fetchId;
+	Impl::UpsertLastInfoHook lastInfoUpserter(*m_impl, LAST_INFO_EVENT);
 	bool mayMoreFlag = false;
 	CHECK_MANDATORY_PARAMS_EXISTENCE("params", errObj);
 	parser.startObject("params");
@@ -1852,7 +1853,7 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutEvents(
 		}
 	}
 	if (parser.isMember("lastInfo")) {
-		parser.read("lastInfo", lastInfo);
+		parser.read("lastInfo", lastInfoUpserter.lastInfo);
 	}
 	parser.endObject(); // params
 
@@ -1867,11 +1868,7 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutEvents(
 		  &errObj.getErrors(), &parser);
 	}
 
-	if (!lastInfo.empty()) {
-		upsertLastInfo(lastInfo, LAST_INFO_EVENT);
-	}
-
-	dataStore->addEventList(eventInfoList);
+	dataStore->addEventList(eventInfoList, lastInfoUpserter);
 
 	if (!mayMoreFlag)
 		m_impl->runFetchCallback(fetchId);
@@ -2046,6 +2043,7 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutArmInfo(
 // Protected methods
 // ---------------------------------------------------------------------------
 
+// TODO: Remove all the upsertLastaInfo() are replaced ones in Impl.
 void HatoholArmPluginGateHAPI2::upsertLastInfo(string lastInfoValue, LastInfoType type)
 {
 	ThreadLocalDBCache cache;

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1682,10 +1682,10 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutTriggers(
   JSONParser &parser)
 {
 	ThreadLocalDBCache cache;
-	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	TriggerInfoList triggerInfoList;
 	JSONRPCError errObj;
-	string lastInfo;
+	Impl::UpsertLastInfoHook lastInfoUpserter(*m_impl, LAST_INFO_TRIGGER);
 	CHECK_MANDATORY_PARAMS_EXISTENCE("params", errObj);
 	parser.startObject("params");
 
@@ -1700,7 +1700,7 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutTriggers(
 		parser.read("fetchId", fetchId);
 	}
 	if (parser.isMember("lastInfo")) {
-		parser.read("lastInfo", lastInfo);
+		parser.read("lastInfo", lastInfoUpserter.lastInfo);
 	}
 	parser.endObject(); // params
 
@@ -1715,15 +1715,12 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutTriggers(
 		  &errObj.getErrors(), &parser);
 	}
 
-	if (!lastInfo.empty()) {
-		upsertLastInfo(lastInfo, LAST_INFO_TRIGGER);
-	}
-
 	// TODO: reflect error in response
 	if (checkInvalidTriggers) {
-		dbMonitoring.syncTriggers(triggerInfoList, serverInfo.id);
+		dataStore->syncTriggers(triggerInfoList, serverInfo.id,
+		                        lastInfoUpserter);
 	} else {
-		dbMonitoring.addTriggerInfoList(triggerInfoList);
+		dataStore->addTriggers(triggerInfoList, lastInfoUpserter);
 	}
 
 	if (!fetchId.empty()) {

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -2029,22 +2029,6 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutArmInfo(
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------
-
-// TODO: Remove all the upsertLastaInfo() are replaced ones in Impl.
-void HatoholArmPluginGateHAPI2::upsertLastInfo(string lastInfoValue, LastInfoType type)
-{
-	ThreadLocalDBCache cache;
-	DBTablesLastInfo &dbLastInfo = cache.getLastInfo();
-	OperationPrivilege privilege(USER_ID_SYSTEM);
-	const MonitoringServerInfo &serverInfo = m_impl->m_serverInfo;
-	LastInfoDef lastInfo;
-	lastInfo.id = AUTO_INCREMENT_VALUE;
-	lastInfo.dataType = type;
-	lastInfo.value = lastInfoValue;
-	lastInfo.serverId = serverInfo.id;
-	dbLastInfo.upsertLastInfo(lastInfo, privilege);
-}
-
 void HatoholArmPluginGateHAPI2::updateSelfMonitoringTrigger(
   bool hasError,
   const HAPI2PluginCollectType &type,

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -647,6 +647,45 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 		return false;
 	}
+
+	void upsertLastInfo(const string &lastInfoValue,
+	                    const LastInfoType &type)
+	{
+		ThreadLocalDBCache cache;
+		DBTablesLastInfo &dbLastInfo = cache.getLastInfo();
+		OperationPrivilege privilege(USER_ID_SYSTEM);
+		const MonitoringServerInfo &serverInfo = m_serverInfo;
+		LastInfoDef lastInfo;
+		lastInfo.id = AUTO_INCREMENT_VALUE;
+		lastInfo.dataType = type;
+		lastInfo.value = lastInfoValue;
+		lastInfo.serverId = serverInfo.id;
+		const bool useTransaction = false;
+		dbLastInfo.upsertLastInfo(lastInfo, privilege, useTransaction);
+	}
+
+	struct UpsertLastInfoHook : public DBAgent::TransactionHooks {
+		Impl &impl;
+		const LastInfoType &type;
+		string lastInfo;
+
+		UpsertLastInfoHook(Impl &_impl, const LastInfoType &_type)
+		: impl(_impl),
+		  type(_type)
+		{
+		}
+
+		virtual bool postAction(DBAgent &dbAgent) override
+		{
+			impl.upsertLastInfo(lastInfo, type);
+			return true;
+		}
+
+		operator DBAgent::TransactionHooks *()
+		{
+			return lastInfo.empty() ? NULL : this;
+		}
+	};
 };
 
 // ---------------------------------------------------------------------------

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -541,19 +541,22 @@ HatoholError UnifiedDataStore::syncHostgroups(
 }
 
 HatoholError UnifiedDataStore::upsertHostgroupMembers(
-  const HostgroupMemberVect &hostgroupMembers)
+  const HostgroupMemberVect &hostgroupMembers,
+  DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	cache.getHost().upsertHostgroupMembers(hostgroupMembers);
+	cache.getHost().upsertHostgroupMembers(hostgroupMembers, hooks);
 	return HTERR_OK;
 }
 
 HatoholError UnifiedDataStore::syncHostgroupMembers(
   const HostgroupMemberVect &hostgroupMembers,
-  const ServerIdType &serverId)
+  const ServerIdType &serverId,
+  DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	return cache.getHost().syncHostgroupMembers(hostgroupMembers, serverId);
+	return cache.getHost().syncHostgroupMembers(hostgroupMembers, serverId,
+	                                            hooks);
 }
 
 HatoholError UnifiedDataStore::getHostgroupMembers(

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -524,18 +524,20 @@ bool UnifiedDataStore::wasStoredHostsChanged(void)
 	return cache.getHost().wasStoredHostsChanged();
 }
 
-HatoholError UnifiedDataStore::upsertHostgroups(const HostgroupVect &hostgroups)
+HatoholError UnifiedDataStore::upsertHostgroups(
+  const HostgroupVect &hostgroups, DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	cache.getHost().upsertHostgroups(hostgroups);
+	cache.getHost().upsertHostgroups(hostgroups, hooks);
 	return HTERR_OK;
 }
 
-HatoholError UnifiedDataStore::syncHostgroups(const HostgroupVect &hostgroups,
-					      const ServerIdType &serverId)
+HatoholError UnifiedDataStore::syncHostgroups(
+  const HostgroupVect &hostgroups, const ServerIdType &serverId,
+  DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	return cache.getHost().syncHostgroups(hostgroups, serverId);
+	return cache.getHost().syncHostgroups(hostgroups, serverId, hooks);
 }
 
 HatoholError UnifiedDataStore::upsertHostgroupMembers(

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -496,21 +496,22 @@ HatoholError UnifiedDataStore::getHostgroups(
 }
 
 HatoholError UnifiedDataStore::upsertHosts(
-  const ServerHostDefVect &serverHostDefs, HostHostIdMap *hostHostIdMapPtr)
+  const ServerHostDefVect &serverHostDefs, HostHostIdMap *hostHostIdMapPtr,
+  DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	cache.getHost().upsertHosts(serverHostDefs, hostHostIdMapPtr);
+	cache.getHost().upsertHosts(serverHostDefs, hostHostIdMapPtr, hooks);
 	return HTERR_OK;
 }
 
 HatoholError UnifiedDataStore::syncHosts(
   const ServerHostDefVect &svHostDefs, const ServerIdType &serverId,
-  HostInfoCache &hostInfoCache)
+  HostInfoCache &hostInfoCache, DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
 	HostHostIdMap hostHostIdMap;
 	HatoholError err = cache.getHost().syncHosts(svHostDefs, serverId,
-	                                             &hostHostIdMap);
+	                                             &hostHostIdMap, hooks);
 	if (err != HTERR_OK)
 		return err;
 	hostInfoCache.update(svHostDefs, &hostHostIdMap);

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -582,12 +582,22 @@ size_t UnifiedDataStore::getNumberOfTriggers(const TriggersQueryOption &option)
 	return cache.getMonitoring().getNumberOfTriggers(option);
 }
 
-HatoholError UnifiedDataStore::syncTriggers(
+void UnifiedDataStore::addTriggers(
   const TriggerInfoList &triggerInfoList,
-  const ServerIdType &serverId)
+  DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
-	return cache.getMonitoring().syncTriggers(triggerInfoList, serverId);
+	return cache.getMonitoring().addTriggerInfoList(triggerInfoList, hooks);
+}
+
+HatoholError UnifiedDataStore::syncTriggers(
+  const TriggerInfoList &triggerInfoList,
+  const ServerIdType &serverId,
+  DBAgent::TransactionHooks *hooks)
+{
+	ThreadLocalDBCache cache;
+	return cache.getMonitoring().syncTriggers(triggerInfoList, serverId,
+	                                          hooks);
 }
 
 size_t UnifiedDataStore::getNumberOfGoodHosts(const TriggersQueryOption &option)

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -637,11 +637,12 @@ HatoholError UnifiedDataStore::addAction(ActionDef &actionDef,
 	return cache.getAction().addAction(actionDef, privilege);
 }
 
-void UnifiedDataStore::addEventList(EventInfoList &eventList)
+void UnifiedDataStore::addEventList(EventInfoList &eventList,
+                                    DBAgent::TransactionHooks *hooks)
 {
 	ThreadLocalDBCache cache;
 	ActionManager actionManager;
-	cache.getMonitoring().addEventInfoList(eventList);
+	cache.getMonitoring().addEventInfoList(eventList, hooks);
 	actionManager.checkEvents(eventList);
 }
 

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -166,9 +166,11 @@ public:
 	  DBAgent::TransactionHooks *hooks = NULL);
 	bool wasStoredHostsChanged(void);
 
-	HatoholError upsertHostgroups(const HostgroupVect &hostgroups);
+	HatoholError upsertHostgroups(const HostgroupVect &hostgroups,
+	                              DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError syncHostgroups(const HostgroupVect &hostgroups,
-	                            const ServerIdType &serverId);
+	                            const ServerIdType &serverId,
+	                            DBAgent::TransactionHooks *hooks = NULL);
 
 	HatoholError upsertHostgroupMembers(
 	  const HostgroupMemberVect &hostgroupMembers);

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -140,7 +140,7 @@ public:
 	                        HostIdType *hostId = NULL);
 
 	/**
-	 * Add hosts. If there's hosts already exist, they will be updated.
+	 * Add hosts. Already exisiting hosts are updated.
 	 *
 	 * See also DBTablesHost::upsert().
 	 *
@@ -148,19 +148,22 @@ public:
 	 * @param hostHostIdMapPtr
 	 * If this parameter is not NULL, the address of the ServerHostDef
 	 * and the corresponding host IDs are stored in it.
+	 * @param hook Transaction hook functions.
 	 *
 	 * @return The result of the call.
 	 */
 	HatoholError
 	  upsertHosts(const ServerHostDefVect &serverHostDefs,
-	              HostHostIdMap *hostHostIdMapPtr = NULL);
+	              HostHostIdMap *hostHostIdMapPtr = NULL,
+	              DBAgent::TransactionHooks *hooks = NULL);
 
 	/**
 	 * call upsertHosts for given hosts and update HostInfoCache.
 	 */
 	HatoholError syncHosts(
 	  const ServerHostDefVect &svHostDefs, const ServerIdType &serverId,
-	  HostInfoCache &hostInfoCache);
+	  HostInfoCache &hostInfoCache,
+	  DBAgent::TransactionHooks *hooks = NULL);
 	bool wasStoredHostsChanged(void);
 
 	HatoholError upsertHostgroups(const HostgroupVect &hostgroups);

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -173,9 +173,12 @@ public:
 	                            DBAgent::TransactionHooks *hooks = NULL);
 
 	HatoholError upsertHostgroupMembers(
-	  const HostgroupMemberVect &hostgroupMembers);
-	HatoholError syncHostgroupMembers(const HostgroupMemberVect &hostgroups,
-	                                  const ServerIdType &serverId);
+	  const HostgroupMemberVect &hostgroupMembers,
+	  DBAgent::TransactionHooks *hooks = NULL);
+	HatoholError syncHostgroupMembers(
+	  const HostgroupMemberVect &hostgroups,
+	  const ServerIdType &serverId,
+	  DBAgent::TransactionHooks *hooks = NULL);
 
 	HatoholError getHostgroupMembers(
 	  HostgroupMemberVect &hostgroupMembers,

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -199,8 +199,11 @@ public:
 	size_t getNumberOfBadTriggers(const TriggersQueryOption &option,
 				      TriggerSeverityType severity);
 	size_t getNumberOfTriggers(const TriggersQueryOption &option);
+	void addTriggers(const TriggerInfoList &triggerInfoList,
+	                 DBAgent::TransactionHooks *hooks = NULL);
 	HatoholError syncTriggers(const TriggerInfoList &triggerInfoList,
-	                          const ServerIdType &serverId);
+	                          const ServerIdType &serverId,
+	                          DBAgent::TransactionHooks *hooks = NULL);
 	size_t getNumberOfGoodHosts(const TriggersQueryOption &option);
 	size_t getNumberOfBadHosts(const TriggersQueryOption &option);
 	size_t getNumberOfItems(const ItemsQueryOption &option,

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -63,8 +63,10 @@ public:
 	 * Add events in the Hatohol DB and executes action if needed.
 	 *
 	 * @param eventList A list of EventInfo.
+	 * @param hooks     Transaction hook functions.
 	 */
-	void addEventList(EventInfoList &eventList);
+	void addEventList(EventInfoList &eventList,
+	                  DBAgent::TransactionHooks *hooks = NULL);
 
 	void addItemList(const ItemInfoList &itemList);
 


### PR DESCRIPTION
This PR fixes #1569 in which data body (e.g. events) and the associated lastInfo are not saved atomically.