### PR TITLE
[HatoholArmPluginGateHAPI2] Suppress a build warning. 

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1896,6 +1896,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHostParents(
 
 	string updateType;
 	bool checkInvalidHostParents = parseUpdateType(parser, updateType, errObj);
+	MLPL_BUG("Take into account the result: checkInvalidHostParents: %d.",
+	         checkInvalidHostParents);
 	if (parser.isMember("lastInfo")) {
 		parser.read("lastInfo", lastInfo);
 	}


### PR DESCRIPTION
The variable that is now not used, but we will use future, causes a build warning.
Instead of the warning, we show the message as a reminder using the variable.
