### PR TITLE
Dont read config file on conf manager test

### DIFF
--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Project Hatohol
+ * Copyright (C) 2013-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -33,6 +33,14 @@ namespace testConfigManager {
 void cut_setup(void)
 {
 	hatoholInit();
+
+	// In hatoholInit(), ConfigManager::reset() is invoked with
+	// loadConfigFile = true. This makes the test results depend on
+	// contents of the configuration file.
+	// Here, we call reset() with loadConfigFile = false in order to
+	// eliminate the dependency and makes sure the same conditions.
+	const bool loadConfigFile = false;
+	ConfigManager::reset(NULL, loadConfigFile);
 }
 
 // ---------------------------------------------------------------------------

--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -284,8 +284,7 @@ void test_parseFaceRestNumWorkers(gconstpointer data)
 	cmds.activate();
 
 	cppcut_assert_equal(
-		ConfigManager::getInstance()->getFaceRestNumWorkers(),
-		expect);
+	  expect, ConfigManager::getInstance()->getFaceRestNumWorkers());
 }
 
 void test_setFaceRestNumWorkers(void)


### PR DESCRIPTION
In hatoholInit(), ConfigManager::reset() is invoked with loadConfigFile = true. This makes the test results depend on contents of the configuration file.
Here, we call reset() with loadConfigFile = false in order to eliminate the dependency and makes sure the same conditions.
