### PR TITLE
[testFaceRestHost] Compare as JSON object.

### DIFF
--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -197,7 +197,7 @@ extern void _assertEqualJSONString(const string &expect, const string &actual)
 		set<string> expectMembers;
 		set<string> actualMembers;
 		expectParser.getMemberNames(expectMembers);
-		expectParser.getMemberNames(actualMembers);
+		actualParser.getMemberNames(actualMembers);
 		assertEqual(expectMembers, actualMembers);
 		for (auto name : expectMembers) {
 			auto expectType = expectParser.getValueType(name);

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1052,7 +1052,7 @@ void test_eventsWithIncidentStatusesFilter(void)
 
 	expected += getExpectedServers() + ",";
 	expected += getExpectedIncidentTrackers() + "}";
-	cppcut_assert_equal(expected, arg.response);
+	assertEqualJSONString(expected, arg.response);
 }
 
 static void incidentInfo2StringMap(


### PR DESCRIPTION
The order of elements in a JSON object is arbitrary. So the simple JSON strings comparision is sometimes inappropriate and causes false-positive.