### PR TITLE
[DBAgent] Add "GROUP BY" statement

### DIFF
--- a/server/src/DBAgent.cc
+++ b/server/src/DBAgent.cc
@@ -534,6 +534,10 @@ string DBAgent::makeSelectStatement(const SelectExArg &selectExArg)
 		sql += " WHERE ";
 		sql += selectExArg.condition;
 	}
+	if (!selectExArg.groupBy.empty()) {
+		sql += " GROUP BY ";
+		sql += selectExArg.groupBy;
+	}
 	if (!selectExArg.orderBy.empty()) {
 		sql += " ORDER BY ";
 		sql += selectExArg.orderBy;

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -162,6 +162,7 @@ public:
 		std::vector<SQLColumnType> columnTypes;
 		std::string                condition;
 		std::string                orderBy;
+		std::string                groupBy;
 		size_t                     limit;
 		size_t                     offset;
 		std::string                appName;

--- a/server/test/testDBAgent.cc
+++ b/server/test/testDBAgent.cc
@@ -94,6 +94,7 @@ public:
 		cppcut_assert_equal(true, arg.statements.empty());
 		cppcut_assert_equal(true, arg.columnTypes.empty());
 		cppcut_assert_equal(true, arg.condition.empty());
+		cppcut_assert_equal(true, arg.groupBy.empty());
 		cppcut_assert_equal(true, arg.orderBy.empty());
 		cppcut_assert_equal((size_t)0, arg.limit);
 		cppcut_assert_equal((size_t)0, arg.offset);


### PR DESCRIPTION
Because this statement is needed by summary SQL query like this:

```
mysql> select severity, count(severity) from incidents left join events on
events.unified_id = incidents.unified_event_id where severity in
(3,4,5) group by severity;
```

And "GROUP BY" clause place is between "WHERE" and "ORDER BY" clauses.
This clause is also omittable same as "WHERE" and "ORDER BY" etc.

Strictly speaking, "HAVING" clause can put into between "GROUP BY"
clause and "ORDER BY" clauses. But now, this clause does not implement
yet.