### PR TITLE
[EventsView] Try to conceal hatohol type incidents releated to information when hatohol incidents server is absent

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -320,10 +320,16 @@ var EventsView = function(userProfile, options) {
     if (hasIncidentTypeHatohol && !hasIncidentTypeOthers) {
       $("#select-incident-container").show();
       $("#change-incident-container").show();
+      $("#IncidentTypeHatoholNotAssignedEventLabel").show();
+      $("#IncidentTypeHatoholImportantEventLabel").show();
+      $("#IncidentTypeHatoholImportantEventProgress").show();
       fixupEventsTableHeight();
     } else {
       $("#select-incident-container").hide();
       $("#change-incident-container").hide();
+      $("#IncidentTypeHatoholNotAssignedEventLabel").hide();
+      $("#IncidentTypeHatoholImportantEventLabel").hide();
+      $("#IncidentTypeHatoholImportantEventProgress").hide();
       fixupEventsTableHeight();
     }
   }

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -39,7 +39,7 @@
   <div class="col-sm-3 col-md-2 sidebar" id="SummarySidebar" style="display: none;">
     <ul class="nav nav-sidebar">
       <li class="active"><a href="#" class="list-group-item list-group-item-warning">{% trans "Important event(s) index" %}<span class="sr-only">(current)</span></a></li>
-      <li>
+      <li id="IncidentTypeHatoholNotAssignedEventLabel" style="display: none;">
         <a href="#" color="black">
           {% trans "Total amount of non assigned important event(s)" %}<br><span class="badge progress-bar-info" id="numOfUnAssignedEvents">N/A</span><br>
         </a>
@@ -49,10 +49,10 @@
           {% trans "Total amount of important event(s)" %}<br><span class="badge progress-bar-warning" id="numOfImportantEvents">N/A</span><br>
         </a>
       </li>
-      <li>
+      <li id="IncidentTypeHatoholImportantEventLabel" style="display: none;">
         <a href="#">{% trans "A percentage not assigned in the important event(s)" %}</a>
       </li>
-      <li>
+      <li id="IncidentTypeHatoholImportantEventProgress" style="display: none;">
         <div class="progress">
           <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="0"
                aria-valuemin="0" aria-valuemax="100" style="width: 0%;"


### PR DESCRIPTION
When hatohol incidents server is absent, information which is related to hatohol type incidents server is needless to display.