### PR TITLE
Make code in a transaction simple.

### DIFF
--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014-2015 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -103,5 +103,42 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
+
+template <typename T, typename SEQ_TYPE>
+struct SeqTransactionProc : public DBAgent::TransactionProc {
+	DBTables *dbTables;
+	const SEQ_TYPE *seq;
+
+	SeqTransactionProc(void)
+	: dbTables(NULL),
+	  seq(NULL)
+	{
+	}
+
+	void init(DBTables *_dbTables, const SEQ_TYPE *_seq)
+	{
+		dbTables = _dbTables;
+		seq = _seq;
+	}
+
+	virtual void operator ()(DBAgent &dbAgent) override
+	{
+		HATOHOL_ASSERT(seq, "Sequence is NULL");
+		typename SEQ_TYPE::const_iterator itr = seq->begin();
+		for (; itr != seq->end(); ++itr)
+			foreach(dbAgent, *itr);
+	}
+
+	virtual void foreach(DBAgent &dbAgent, const T &elem)
+	{
+	}
+
+	template <typename U>
+	U &get(void)
+	{
+		return *dynamic_cast<U *>(dbTables);
+	}
+};
+
 
 #endif // DB_h

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -123,14 +123,18 @@ struct MutableSeqTransactionProc : public DBAgent::TransactionProc {
 
 	virtual void operator ()(DBAgent &dbAgent) override
 	{
-		HATOHOL_ASSERT(seq, "Sequence is NULL");
-		auto itr = seq->begin();
-		for (; itr != seq->end(); ++itr)
-			foreach(dbAgent, *itr);
+		runBaseFunctor(dbAgent);
 	}
 
 	virtual void foreach(DBAgent &dbAgent, T &elem)
 	{
+	}
+
+	void runBaseFunctor(DBAgent &dbAgent)
+	{
+		HATOHOL_ASSERT(seq, "Sequence is NULL");
+		for (auto itr = seq->begin(); itr != seq->end(); ++itr)
+			foreach(dbAgent, *itr);
 	}
 
 	template <typename U>

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -105,17 +105,17 @@ private:
 };
 
 template <typename T, typename SEQ_TYPE>
-struct SeqTransactionProc : public DBAgent::TransactionProc {
+struct MutableSeqTransactionProc : public DBAgent::TransactionProc {
 	DBTables *dbTables;
-	const SEQ_TYPE *seq;
+	SEQ_TYPE *seq;
 
-	SeqTransactionProc(void)
+	MutableSeqTransactionProc(void)
 	: dbTables(NULL),
 	  seq(NULL)
 	{
 	}
 
-	void init(DBTables *_dbTables, const SEQ_TYPE *_seq)
+	void init(DBTables *_dbTables, SEQ_TYPE *_seq)
 	{
 		dbTables = _dbTables;
 		seq = _seq;
@@ -124,12 +124,12 @@ struct SeqTransactionProc : public DBAgent::TransactionProc {
 	virtual void operator ()(DBAgent &dbAgent) override
 	{
 		HATOHOL_ASSERT(seq, "Sequence is NULL");
-		typename SEQ_TYPE::const_iterator itr = seq->begin();
+		auto itr = seq->begin();
 		for (; itr != seq->end(); ++itr)
 			foreach(dbAgent, *itr);
 	}
 
-	virtual void foreach(DBAgent &dbAgent, const T &elem)
+	virtual void foreach(DBAgent &dbAgent, T &elem)
 	{
 	}
 
@@ -140,5 +140,9 @@ struct SeqTransactionProc : public DBAgent::TransactionProc {
 	}
 };
 
+template <typename T, typename SEQ_TYPE>
+struct SeqTransactionProc :
+  public MutableSeqTransactionProc<const T, const SEQ_TYPE> {
+};
 
 #endif // DB_h

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -385,36 +385,6 @@ static bool updateDB(
 	return true;
 }
 
-template <typename T, typename SEQ_TYPE>
-struct SeqTransactionProc : public DBAgent::TransactionProc {
-	DBTablesHost *dbHost;
-	const SEQ_TYPE *seq;
-
-	SeqTransactionProc(void)
-	: dbHost(NULL),
-	  seq(NULL)
-	{
-	}
-
-	void init(DBTablesHost *_dbHost, const SEQ_TYPE *_seq)
-	{
-		dbHost = _dbHost;
-		seq = _seq;
-	}
-
-	virtual void operator ()(DBAgent &dbAgent) override
-	{
-		HATOHOL_ASSERT(seq, "Sequence is NULL");
-		typename SEQ_TYPE::const_iterator itr = seq->begin();
-		for (; itr != seq->end(); ++itr)
-			foreach(dbAgent, *itr);
-	}
-
-	virtual void foreach(DBAgent &dbAgent, const T &elem)
-	{
-	}
-};
-
 // ---------------------------------------------------------------------------
 // HostsQueryOption
 // ---------------------------------------------------------------------------
@@ -873,7 +843,7 @@ void DBTablesHost::upsertVMInfoVect(const VMInfoVect &vmInfoVect,
 	struct : public SeqTransactionProc<VMInfo, VMInfoVect> {
 		void foreach(DBAgent &dbAgent, const VMInfo &vminfo) override
 		{
-			dbHost->upsertVMInfo(vminfo, false);
+			get<DBTablesHost>().upsertVMInfo(vminfo, false);
 		}
 	} proc;
 	proc.init(this, &vmInfoVect);


### PR DESCRIPTION
Some methods in DBTables's subclasses insert multiple records in a transaction.
Each of them ran for-loop with the similar pattern. These patches add a template
method that is commonly used and use it to make code simple.