### PR TITLE
[hap2] Remove the explict declaration of argument just passed.

### DIFF
--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -130,10 +130,8 @@ class StandardHap:
             logger.info("Rerun after %d sec" % self.__error_sleep_time)
             time.sleep(self.__error_sleep_time)
 
-    def __create_poller(self, sender, dispatcher, status_log_interval, **kwargs):
-        poller = self.create_poller(sender=sender,
-                                    process_id="Poller",
-                                    status_log_interval=status_log_interval,
+    def __create_poller(self, sender, dispatcher, **kwargs):
+        poller = self.create_poller(sender=sender, process_id="Poller",
                                     **kwargs)
         if poller is None:
             return
@@ -179,11 +177,14 @@ class StandardHap:
         if args.disable_poller:
             logger.info("Disabled: poller plugin.")
         else:
+            kwargs = {
+                "status_log_interval": args.status_log_interval,
+                "polling_targets": args.polling_targets,
+            }
             self.__poller = self.__create_poller(
                                 self.__main_plugin.get_sender(),
                                 self.__main_plugin.get_dispatcher(),
-                                args.status_log_interval,
-                                polling_targets=args.polling_targets)
+                                **kwargs)
 
         self.__main_plugin.start_dispatcher()
         logger.info("started dispatcher process.")


### PR DESCRIPTION
An argument: status_log_interval is just passed to the constructor
of BasePoller. So there's no needed to be declared explicitly.
And this way make it easy to pass parameters that are added in
the future.