### PR TITLE
[EventsView] Move "Latest events" button next to "Apply filter" button

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -340,6 +340,8 @@ var EventsView = function(userProfile, options) {
     });
 
     $('button.latest-button').click(function() {
+      $("#end-time").val("");
+      $("#end-time").next(".clear-button").hide();
       load();
     });
 
@@ -526,8 +528,7 @@ var EventsView = function(userProfile, options) {
       $("#select-server").attr("disabled", "disabled");
       $("#select-host").attr("disabled", "disabled");
       $("#select-filter").attr("disabled", "disabled");
-      $("#latest-events-button1").attr("disabled", "disabled");
-      $("#latest-events-button2").attr("disabled", "disabled");
+      $(".latest-button").attr("disabled", "disabled");
     } else {
       $("#begin-time").removeAttr("disabled");
       $("#end-time").removeAttr("disabled");
@@ -538,8 +539,7 @@ var EventsView = function(userProfile, options) {
       if ($("#select-host option").length > 1)
         $("#select-host").removeAttr("disabled");
       $("#select-filter").removeAttr("disabled");
-      $("#latest-events-button1").removeAttr("disabled");
-      $("#latest-events-button2").removeAttr("disabled");
+      $(".latest-button").removeAttr("disabled");
     }
   }
 

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -120,6 +120,10 @@
 	      <button id="apply-all-filter" type="button" class="btn btn-info btn-apply-all-filter">
 		{% trans "Apply filter(s)" %} <span class="glyphicon glyphicon-ok-circle" id="sidebar-left-glyph"></span>
 	      </button>
+              <button type="button" class="btn btn-info latest-button">
+                <span class="glyphicon glyphicon-refresh"></span>
+                {% trans "Latest events" %}
+              </button>
 	    </div>
 	  </div>
 	  <br><br>
@@ -206,10 +210,6 @@
       </div>
 
       <form id="events-pager" class="form-inline" style="text-align: center;">
-	<button id="latest-events-button2" type="button" class="btn btn-info latest-button">
-	  <span class="glyphicon glyphicon-refresh"></span>
-	  {% trans "Latest events" %}
-	</button>
 	<ul class="pagination">
 	</ul>
       </form>


### PR DESCRIPTION
In addition, clear "End time" field when "Latest events" is
clicked.

![move-latest-button](https://cloud.githubusercontent.com/assets/135104/10811384/ca8aa420-7e4e-11e5-82d0-41904061e525.png)
