### PR TITLE
[EventsView] Apply severity ranks color settings

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -28,6 +28,7 @@ var EventsView = function(userProfile, options) {
   self.limitOfUnifiedId = 0;
   self.rawData = {};
   self.rawSummaryData = {};
+  self.rawSeverityRankData = {};
   self.durations = {};
   self.baseQuery = {
     limit:            50,
@@ -925,6 +926,25 @@ var EventsView = function(userProfile, options) {
      $("#importantEventOccurredHostsPercentage").css("width", importantEventOccurredHostsPercentage+"%");
   }
 
+  function setupSeverityRank() {
+    var deferred = new $.Deferred;
+    new HatoholConnector({
+      url: "/severity-rank",
+      request: "GET",
+      replyCallback: function(reply, parser) {
+        self.rawSeverityRankData = reply;
+        deferred.resolve();
+      },
+      parseErrorCallback: function() {
+        deferred.reject();
+      },
+      connectErrorCallback: function() {
+        deferred.reject();
+      },
+    });
+    return deferred.promise();
+  }
+
   function setupPieChart() {
     var item, severity, times, severityStatMap = {}, pieChartDataMap = {};
     var preDefinedSeverityArray = [
@@ -997,6 +1017,11 @@ var EventsView = function(userProfile, options) {
 
     setupStatictics();
     setupPieChart();
+    $.when(setupSeverityRank())
+      .done(function() {
+      }).fail(function() {
+        hatoholInfoMsgBox(gettext("Failed to get severity rank!"));
+      });
   }
 
   function updateCore(reply) {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -945,6 +945,13 @@ var EventsView = function(userProfile, options) {
     return deferred.promise();
   }
 
+  function setupTableColor() {
+    var severityRanks = self.rawSeverityRankData["SeverityRanks"];
+    for (var x = 0; x < severityRanks.length; ++x) {
+      $('td.severity'+x).css("background-color", severityRanks[x].color);
+    }
+  }
+
   function setupPieChart() {
     var item, severity, times, severityStatMap = {}, pieChartDataMap = {};
     var preDefinedSeverityArray = [
@@ -963,29 +970,34 @@ var EventsView = function(userProfile, options) {
 
       severityStatMap[severity] = times;
     }
-
+    var severityRanks = self.rawSeverityRankData["SeverityRanks"];
+    var severityRankColorMap = {};
+    for (var ix = 0; ix < severityRanks.length; ++ix) {
+      severityRankColorMap[Number(severityRanks[ix].status)] =
+        severityRanks[ix].color;
+    }
     for (var idx = 0; idx < preDefinedSeverityArray.length; ++idx) {
       pieChartDataMap[idx] = severityStatMap[idx] ? severityStatMap[idx] : 0;
     }
     var dataSet = [
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_EMERGENCY)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_EMERGENCY],
-        color: "#FF0000" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_EMERGENCY] },
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_CRITICAL)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_CRITIAL],
-        color: "#FF9900" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_CRITICAL] },
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_ERROR)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_ERROR],
-        color: "#FFFF00" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_ERROR] },
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_WARNING)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_WARNING],
-        color: "#FDFD96" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_WARNING] },
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_INFO)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_INFO],
-        color: "#CCE2CC" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_INFO] },
       { label: severity_choices[Number(hatohol.TRIGGER_SEVERITY_UNKNOWN)],
         data: pieChartDataMap[hatohol.TRIGGER_SEVERITY_UNKNOWN],
-        color: "#BCBCBC" },
+        color: severityRankColorMap[hatohol.TRIGGER_SEVERITY_UNKNOWN] },
     ];
 
     var options = {
@@ -1016,9 +1028,10 @@ var EventsView = function(userProfile, options) {
       self.rawSummaryData = reply;
 
     setupStatictics();
-    setupPieChart();
     $.when(setupSeverityRank())
       .done(function() {
+        setupTableColor();
+        setupPieChart();
       }).fail(function() {
         hatoholInfoMsgBox(gettext("Failed to get severity rank!"));
       });


### PR DESCRIPTION
* Apply severity ranks color settings to pieChart and table

Note that this feature is too honest implementation.
This feature works as below:

![screenshot from 2015-10-29 15 41 51](https://cloud.githubusercontent.com/assets/700876/10811864/edba63fe-7e53-11e5-9851-355e91e84aa2.png)
