### PR TITLE
[EventsView] Show default filter's begin time

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -245,6 +245,11 @@ var EventsView = function(userProfile, options) {
       limitOfUnifiedId: self.limitOfUnifiedId,
     });
 
+    // TODO: Should set it by caller
+    var beginTime = new Date(baseFilter.beginTime * 1000);
+    var beginTimeString = formatDateTimeWithZeroSecond(beginTime);
+    $("#begin-time").attr("placeholder", beginTimeString);
+
     return 'events?' + $.param(query);
   };
 


### PR DESCRIPTION
Set the begin time of the default filter as the placeholder of
"Begin time" entry.