### PR TITLE
[hap2_zabbix_api] Fix a bug of calculating event_from for Zabbix API.

### DIFF
--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -111,6 +111,8 @@ class ZabbixAPIConductor:
 
         event_id_from = None
         if direction == "ASC":
+            if isinstance(last_info, unicode) or isinstance(last_info, str):
+                last_info = int(last_info)
             if isinstance(last_info, int):
                 event_id_from = last_info + 1
             event_id_till = None


### PR DESCRIPTION
last_info in haplib is hold as a type: unicode because the input
type of event id is it. However, the code n hap2_zabbix_api excepts
an integer type. As a result, right event_form parameter is not
calculated.