### PR TITLE
[EventsView] Fix a bug that statuses of some problem events become green 

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -738,7 +738,6 @@ var EventsView = function(userProfile, options) {
 
   function renderTableDataEventSeverity(event, server) {
     var severity = event["severity"];
-    var statusClass = "status" + event["status"];
 
     return "<td class='" + getSeverityClass(event) + "'>" +
       severity_choices[Number(severity)] + "</td>";

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -730,7 +730,7 @@ var EventsView = function(userProfile, options) {
 
   function renderTableDataEventStatus(event, server) {
     var status = event["type"];
-    var statusClass = "status" + event["status"];
+    var statusClass = "status" + status;
 
     return "<td class='" + getSeverityClass(event) + " " + statusClass + "'>" +
       status_choices[Number(status)] + "</td>";


### PR DESCRIPTION
Because event["status"] is a status of a trigger, not a event.
We should use event["type"] instead of event["status"].
