### PR TITLE
Add "types" filter for events

### DIFF
--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -47,7 +47,7 @@ var HatoholEventsViewConfig = function(options) {
   self.config = self.getDefaultConfig();
   self.servers = null;
   self.multiselectFilterTypes = [
-    "incident", "status", "severity", "server", "hostgroup", "host"
+    "incident", "type", "severity", "server", "hostgroup", "host"
   ];
   self.filterList = [self.getDefaultFilterConfig()];
   self.resetEditingFilterList();
@@ -510,7 +510,7 @@ HatoholEventsViewConfig.prototype.setCurrentFilterConfig = function(filter) {
       { value: "IN PROGRESS", label: gettext("IN PROGRESS") },
       { value: "DONE",        label: pgettext("Incident", "DONE") },
     ],
-    status: [
+    type: [
       { value: "0", label: gettext("OK") },
       { value: "1", label: gettext("Problem") },
       { value: "2", label: gettext("Unknown") },
@@ -638,7 +638,7 @@ HatoholEventsViewConfig.prototype.getDefaultFilterConfig = function() {
       enable: false,
       selected: []
     },
-    status: {
+    type: {
       enable: false,
       selected: []
     },
@@ -721,8 +721,8 @@ HatoholEventsViewConfig.prototype.createFilter = function(filterConfig) {
   if (conf.incident.enable && conf.incident.selected.length > 0)
     filter["incidentStatuses"] = conf.incident.selected.join(",");
 
-  if (conf.status.enable && conf.status.selected.length > 0)
-    filter["statuses"] = conf.status.selected.join(",");
+  if (conf.type.enable && conf.type.selected.length > 0)
+    filter["types"] = conf.type.selected.join(",");
 
   if (conf.severity.enable && conf.severity.selected.length > 0)
     filter["severities"] = conf.severity.selected.join(",");

--- a/client/test/browser/test_hatohol_events_view_config.js
+++ b/client/test/browser/test_hatohol_events_view_config.js
@@ -169,7 +169,7 @@ describe('EventsViewConfig', function() {
         enable: false,
         selected: []
       },
-      status: {
+      type: {
         enable: false,
         selected: []
       },
@@ -206,7 +206,7 @@ describe('EventsViewConfig', function() {
         enable: true,
         selected: ["NONE", "IN PROGRESS"]
       },
-      status: {
+      type: {
         enable: true,
         selected: ["0", "1"]
       },
@@ -246,7 +246,7 @@ describe('EventsViewConfig', function() {
         enable: true,
         selected: ["NONE", "IN PROGRESS", "DONE"]
       },
-      status: {
+      type: {
         enable: true,
         selected: ["0", "1"]
       },
@@ -272,7 +272,7 @@ describe('EventsViewConfig', function() {
     };
     var expected = {
       incidentStatuses: "NONE,IN PROGRESS,DONE",
-      statuses: "0,1",
+      types: "0,1",
       severities: "2,3",
       selectHosts: [
         { serverId: "1", },

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -389,42 +389,42 @@
 		  </div>
 		</div>
 
-		<!-- Status filter config -->
+		<!-- Type filter config -->
 		<div class="panel panel-default">
-		  <div class="panel-heading" role="tab" id="status-filter-pane">
+		  <div class="panel-heading" role="tab" id="type-filter-pane">
 		    <h4 class="panel-title">
 		      <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion"
-			 href="#collapse-status-filter" aria-expanded="false" aria-controls="collapse-status-filter">
+			 href="#collapse-type-filter" aria-expanded="false" aria-controls="collapse-type-filter">
 			{% trans "Status" %}
 		      </a>
 		    </h4>
 		  </div>
-		  <div id="collapse-status-filter" class="panel-collapse collapse" role="tabpanel" aria-labelledby="status-filter-pane">
+		  <div id="collapse-type-filter" class="panel-collapse collapse" role="tabpanel" aria-labelledby="type-filter-pane">
 		    <div class="panel-body">
 		      <p>
-			<input type="checkbox" id="enable-status-filter-selector">
-			<label for="enable-status-filter-selector">{% trans 'Include "Status" to the filter condition' %}</label>
+			<input type="checkbox" id="enable-type-filter-selector">
+			<label for="enable-type-filter-selector">{% trans 'Include "Status" to the filter condition' %}</label>
 		      </p>
 		      <div class="row">
 			<div class="col-xs-5">
-			  <p><label for="status-filter-selector">{% trans "Candidates" %}<label></p>
-			  <select name="from[]" id="status-filter-selector"
+			  <p><label for="type-filter-selector">{% trans "Candidates" %}<label></p>
+			  <select name="from[]" id="type-filter-selector"
 				  class="form-control" size="4" multiple="multiple">
 			  </select>
 			</div>
 
-			<div class="status-filter-selector-buttons col-xs-2" style="margin-top: 46px;">
-			  <button type="button" id="status-filter-selector_rightSelected" class="btn btn-block">
+			<div class="type-filter-selector-buttons col-xs-2" style="margin-top: 46px;">
+			  <button type="button" id="type-filter-selector_rightSelected" class="btn btn-block">
 			    <i class="glyphicon glyphicon-chevron-right"></i>
 			  </button>
-			  <button type="button" id="status-filter-selector_leftSelected" class="btn btn-block">
+			  <button type="button" id="type-filter-selector_leftSelected" class="btn btn-block">
 			    <i class="glyphicon glyphicon-chevron-left"></i>
 			  </button>
 			</div>
 
 			<div class="col-xs-5">
-			  <p><label for="status-filter-selector-selected">{% trans "Selected" %}<label></p>
-			  <select name="to[]" id="status-filter-selector-selected"
+			  <p><label for="type-filter-selector-selected">{% trans "Selected" %}<label></p>
+			  <select name="to[]" id="type-filter-selector-selected"
 				  class="form-control" size="4" multiple="multiple">
 			  </select>
 			</div>

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -848,6 +848,7 @@ struct EventsQueryOption::Impl {
 	TriggerIdType triggerId;
 	timespec beginTime;
 	timespec endTime;
+	set<EventType> eventTypes;
 	set<TriggerSeverityType> triggerSeverities;
 	set<TriggerStatusType> triggerStatuses;
 	set<string> incidentStatuses;
@@ -971,6 +972,20 @@ string EventsQueryOption::getCondition(void) const
 			getColumnName(IDX_EVENTS_TIME_NS).c_str(),
 			m_impl->endTime.tv_nsec);
 	}
+
+	string typeCondition;
+	for (const auto &type: m_impl->eventTypes) {
+		addCondition(
+		  typeCondition,
+		  StringUtils::sprintf(
+		    "%s=%d",
+		    getColumnName(IDX_EVENTS_EVENT_TYPE).c_str(),
+		    type),
+		  ADD_TYPE_OR);
+	}
+	if (m_impl->eventTypes.size() > 1)
+		typeCondition = string("(") + typeCondition + string(")");
+	addCondition(condition, typeCondition);
 
 	string severityCondition;
 	for (const auto &severity: m_impl->triggerSeverities) {
@@ -1156,6 +1171,16 @@ void EventsQueryOption::setEndTime(const timespec &_endTime)
 const timespec &EventsQueryOption::getEndTime(void)
 {
 	return m_impl->endTime;
+}
+
+void EventsQueryOption::setEventTypes(const std::set<EventType> &types)
+{
+	m_impl->eventTypes = types;
+}
+
+const std::set<EventType> &EventsQueryOption::getEventTypes(void) const
+{
+	return m_impl->eventTypes;
 }
 
 void EventsQueryOption::setTriggerSeverities(

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -70,6 +70,8 @@ public:
 	void setEndTime(const timespec &endTime);
 	const timespec &getEndTime(void);
 
+	void setEventTypes(const std::set<EventType> &types);
+	const std::set<EventType> &getEventTypes(void) const;
 	void setTriggerSeverities(const std::set<TriggerSeverityType> &severities);
 	const std::set<TriggerSeverityType> &getTriggerSeverities(void) const;
 	void setTriggerStatuses(const std::set<TriggerStatusType> &statuses);

--- a/server/src/RestResourceHostUtils.cc
+++ b/server/src/RestResourceHostUtils.cc
@@ -374,8 +374,22 @@ HatoholError RestResourceHostUtils::parseEventParameter(
 		return err;
 	option.setEndTime(endTime);
 
-	// severities
+	// types
 	const gchar *value = static_cast<const gchar*>(
+	  g_hash_table_lookup(query, "types"));
+	if (value && *value) {
+		StringVector values;
+		StringUtils::split(values, value, ',');
+		std::set<EventType> types;
+		for (auto &type: values) {
+			uint64_t v = StringUtils::toUint64(type);
+			types.insert(static_cast<EventType>(v));
+		}
+		option.setEventTypes(types);
+	}
+
+	// severities
+	value = static_cast<const gchar*>(
 	  g_hash_table_lookup(query, "severities"));
 	if (value && *value) {
 		StringVector values;
@@ -402,7 +416,7 @@ HatoholError RestResourceHostUtils::parseEventParameter(
 		option.setTriggerStatuses(statuses);
 	}
 
-	// statuses
+	// incident statuses
 	value = static_cast<const gchar*>(
 	  g_hash_table_lookup(query, "incidentStatuses"));
 	if (value && *value) {

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1739,6 +1739,33 @@ void test_getEventsExcludeByHostgroup(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getEventsSelectByTypes(void)
+{
+	loadTestDBServerHostDef();
+	loadTestDBHostgroup();
+	loadTestDBHostgroupMember();
+	loadTestDBEvents();
+	loadTestDBIncidents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+
+	EventsQueryOption option(USER_ID_SYSTEM);
+	set<EventType> types;
+	types.insert(EVENT_TYPE_BAD);
+	types.insert(EVENT_TYPE_UNKNOWN);
+	option.setEventTypes(types);
+
+	EventInfoList events;
+	dbMonitoring.getEventInfoList(events, option, NULL);
+	string actual = sortedJoin(events);
+	string expected(
+	   "3|3|1390000000|123456789|1|2|1|2|35|10001|hostZ1|TEST Trigger 2|"
+	     "{\"expandedDescription\":\"Test Trigger on hostZ1\"}\n"
+	   "3|4|1390000100|123456789|2|4|2|4|41|10002|hostZ2|"
+	     "Status:Unknown, Severity:Critical|\n");
+	cppcut_assert_equal(expected, actual);
+}
+
 void test_getEventsSelectByIncidentStatuses(void)
 {
 	loadTestDBServerHostDef();

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -878,6 +878,60 @@ void test_eventsWithHostsFilter(void)
 	assertEqualJSONString(expected, arg.response);
 }
 
+void test_eventsWithTypesFilter(void)
+{
+	loadTestDBArmPlugin();
+	loadTestDBTriggers();
+	loadTestDBEvents();
+	loadTestDBServerHostDef();
+	startFaceRest();
+
+	RequestArg arg("/event?types=1%2C2");
+	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
+	getServerResponse(arg);
+	string expected(
+	  "{"
+	  "\"apiVersion\":4,"
+	  "\"errorCode\":0,"
+	  "\"lastUnifiedEventId\":7,"
+	  "\"haveIncident\":false,"
+	  "\"events\":"
+	  "["
+	  "{"
+	  "\"unifiedId\":7,"
+	  "\"serverId\":3,"
+	  "\"time\":1390000100,"
+	  "\"type\":2,"
+	  "\"triggerId\":\"4\","
+	  "\"eventId\":\"4\","
+	  "\"status\":2,"
+	  "\"severity\":4,"
+	  "\"hostId\":\"10002\","
+	  "\"brief\":\"Status:Unknown, Severity:Critical\","
+	  "\"extendedInfo\":\"\""
+	  "},"
+	  "{"
+	  "\"unifiedId\":6,"
+	  "\"serverId\":3,"
+	  "\"time\":1390000000,"
+	  "\"type\":1,"
+	  "\"triggerId\":\"2\","
+	  "\"eventId\":\"3\","
+	  "\"status\":1,"
+	  "\"severity\":2,"
+	  "\"hostId\":\"10001\","
+	  "\"brief\":\"TEST Trigger 2\","
+	  "\"extendedInfo\":"
+	  "\"{\\\"expandedDescription\\\":\\\"Test Trigger on hostZ1\\\"}\""
+	  "}"
+	  "],"
+	  "\"numberOfEvents\":2,");
+
+	expected += getExpectedServers() + ",";
+	expected += getExpectedIncidentTrackers() + "}";
+	assertEqualJSONString(expected, arg.response);
+}
+
 void test_eventsWithSeveritiesFilter(void)
 {
 	loadTestDBArmPlugin();

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -540,6 +540,24 @@ void test_eventQueryOptionGetEndTime(void)
 	cppcut_assert_equal(expected.tv_nsec, actual.tv_nsec);
 }
 
+void data_eventQueryOptionWithTypes(void)
+{
+	prepareTestDataExcludeDefunctServers();
+}
+
+void test_eventQueryOptionWithTypes(gconstpointer data)
+{
+	EventsQueryOption option(USER_ID_SYSTEM);
+	set<EventType> types;
+	types.insert(EVENT_TYPE_BAD);
+	types.insert(EVENT_TYPE_UNKNOWN);
+	option.setEventTypes(types);
+
+	string expected = "(event_value=1 OR event_value=2)";
+	fixupForFilteringDefunctServer(data, expected, option);
+	cppcut_assert_equal(expected, option.getCondition());
+}
+
 void data_eventQueryOptionWithSeverities(void)
 {
 	prepareTestDataExcludeDefunctServers();


### PR DESCRIPTION
Currently "statuses" filter is used for selecting events with certain states.
But "statuses" filter is inappropriate in most case because it means "Trigger statuses", not "Event statuses".
We should use "types" filter for selecting event states.
