### PR TITLE
[RestResourceSummary] Fix the number of assigned events

### DIFF
--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -96,6 +96,7 @@ void RestResourceSummary::handlerSummary(void)
 	EventsQueryOption assignedEventOption(option);
 	std::set<std::string> assignedStatusSet, unAssignedStatusSet;
 	assignedStatusSet.insert(definedStatuses[static_cast<int>(Status::IN_PROGRESS)].label.c_str());
+	assignedStatusSet.insert(definedStatuses[static_cast<int>(Status::DONE)].label.c_str());
 	assignedEventOption.setIncidentStatuses(assignedStatusSet);
 	int64_t numOfAssignedEvents =
 	  dataStore->getNumberOfEvents(assignedEventOption);


### PR DESCRIPTION
Status::DONE should be treated as assigned events.
(Souldn't be treated as unassigned events.)