### PR TITLE
[hap2] Show line breaks in traceback.

### DIFF
--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -88,8 +88,8 @@ def handle_exception(raises=(SystemExit,)):
     if exctype in raises:
         raise
     if exctype is not Signal:
-        logger.error("Unexpected error: %s, %s, %s" % \
-                      (exctype, value, traceback.format_tb(tb)))
+        logger.error("Unexpected error: %s, %s\n%s" % \
+                      (exctype, value, traceback.format_exc()))
     elif value.critical:
         logger.critical("Got critical signal.")
         raise


### PR DESCRIPTION
Currently the traceback of the exception is logged without
linebreaks. It is hard to recognize the content.

This patch improve the visibility by inserting line breaks
into the messages.

Example:

[currently]

2015-11-05 12:45:33,541    ERROR [21870] hatohol.hap:92:  Unexpected error: <type 'exceptions.ValueError'>, No JSON object could be decoded, ['  File "/home/kyamato/hatohol/server/hap2/hatohol/haplib.py", line 976, in __poll_in_try_block\n    self.poll()\n', '  File "hatohol/hap2_zabbix_api.py", line 138, in poll\n    self.make_sure_token()\n', '  File "hatohol/hap2_zabbix_api.py", line 57, in make_sure_token\n    self.__api = zabbixapi.ZabbixAPI(ms_info)\n', '  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 39, in __init__\n    monitoring_server_info.password)\n', '  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 44, in get_auth_token\n    res_dict = self.get_response_dict("user.authenticate", params)\n', '  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 292, in get_response_dict\n    return json.loads(res_str)\n', '  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads\n    return _default_decoder.decode(s)\n', '  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n', '  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode\n    raise ValueError("No JSON object could be decoded")\n']

[with this patch]

2015-11-05 12:53:42,731    ERROR [22211] hatohol.hap:92:  Unexpected error: <type 'exceptions.ValueError'>, No JSON object could be decoded
Traceback (most recent call last):
  File "/home/kyamato/hatohol/server/hap2/hatohol/haplib.py", line 976, in __poll_in_try_block
    self.poll()
  File "hatohol/hap2_zabbix_api.py", line 138, in poll
    self.make_sure_token()
  File "hatohol/hap2_zabbix_api.py", line 57, in make_sure_token
    self.__api = zabbixapi.ZabbixAPI(ms_info)
  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 39, in __init__
    monitoring_server_info.password)
  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 44, in get_auth_token
    res_dict = self.get_response_dict("user.authenticate", params)
  File "/home/kyamato/hatohol/server/hap2/hatohol/zabbixapi.py", line 292, in get_response_dict
    return json.loads(res_str)
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded