### PR TITLE
[HatoholAddActionDialog] Enable to select trigger status on setting i…

### DIFF
--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -892,8 +892,6 @@ HatoholAddActionDialog.prototype.onAppendMainElement = function() {
     self.setupIncidentTrackersEditor();
     $("#selectTriggerStatus").val("TRIGGER_STATUS_PROBLEM");
     $("#selectTriggerSeverityCompType").val("CMP_EQ_GT");
-    $("label[for='selectTriggerStatus']").hide();
-    $("#selectTriggerStatus").hide();
   }
 };
 


### PR DESCRIPTION
…ncident sender

Because not only TRIGGER_STATUS_PROBLEM but also
TRIGGER_STATUS_OK should be confirmed by human in most sites.