### PR TITLE
[EventsView] Distiguish the properties "type" and "status" of events correctly in internal code

### DIFF
--- a/client/static/css/zabbix.css
+++ b/client/static/css/zabbix.css
@@ -20,6 +20,9 @@
 td.status1   { color: #AA0000; }
 td.status0   { color: #00AA00; }
 
+td.event-type1   { color: #AA0000; }
+td.event-type0   { color: #00AA00; }
+
 td.severity5 { background-color: #FF0000; }
 td.severity4 { background-color: #FF8888; }
 td.severity3 { background-color: #DDAAAA; }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -53,8 +53,9 @@ var EventsView = function(userProfile, options) {
     setupTimeRangeFilter();
   }
 
-  var status_choices = [gettext('OK'), gettext('Problem'), gettext('Unknown'),
-                        gettext('Notification')];
+  var status_choices = [gettext('OK'), gettext('Problem')];
+  var type_choices = [gettext('OK'), gettext('Problem'), gettext('Unknown'),
+                      gettext('Notification')];
   var severity_choices = [
     gettext('Not classified'), gettext('Information'), gettext('Warning'),
     gettext('Average'), gettext('High'), gettext('Disaster')];
@@ -76,9 +77,13 @@ var EventsView = function(userProfile, options) {
       header: gettext("Event ID"),
       body: renderTableDataEventId,
     },
-    "status": {
+    "type": {
       header: gettext("Status"),
-      body: renderTableDataEventStatus,
+      body: renderTableDataEventType,
+    },
+    "status": {
+      header: gettext("Current trigger status"),
+      body: renderTableDataTriggerStatus,
     },
     "severity": {
       header: gettext("Severity"),
@@ -212,8 +217,8 @@ var EventsView = function(userProfile, options) {
     if ($("#select-incident").val())
       query.incidentStatuses = $("#select-incident").val();
 
-    if ($("#select-status").val())
-      query.type = $("#select-status").val();
+    if ($("#select-type").val())
+      query.type = $("#select-type").val();
 
     if ($("#select-severity").val())
       query.minimumSeverity =  $("#select-severity").val();
@@ -309,8 +314,8 @@ var EventsView = function(userProfile, options) {
 
     if ("minimumSeverity" in query)
       $("#select-severity").val(query.minimumSeverity);
-    if ("status" in query)
-      $("#select-status").val(query.status);
+    if ("type" in query)
+      $("#select-type").val(query.type);
   }
 
   function setupTreatmentMenu() {
@@ -551,7 +556,7 @@ var EventsView = function(userProfile, options) {
       $("#end-time").attr("disabled", "disabled");
       $("#select-incident").attr("disabled", "disabled");
       $("#select-severity").attr("disabled", "disabled");
-      $("#select-status").attr("disabled", "disabled");
+      $("#select-type").attr("disabled", "disabled");
       $("#select-server").attr("disabled", "disabled");
       $("#select-host").attr("disabled", "disabled");
       $("#select-filter").attr("disabled", "disabled");
@@ -561,7 +566,7 @@ var EventsView = function(userProfile, options) {
       $("#end-time").removeAttr("disabled");
       $("#select-incident").removeAttr("disabled");
       $("#select-severity").removeAttr("disabled");
-      $("#select-status").removeAttr("disabled");
+      $("#select-type").removeAttr("disabled");
       $("#select-server").removeAttr("disabled");
       if ($("#select-host option").length > 1)
         $("#select-host").removeAttr("disabled");
@@ -645,11 +650,11 @@ var EventsView = function(userProfile, options) {
   }
 
   function getSeverityClass(event) {
-    var status = event["type"];
+    var type = event["type"];
     var severity = event["severity"];
     var severityClass = "severity";
 
-    if (status == hatohol.EVENT_TYPE_BAD)
+    if (type == hatohol.EVENT_TYPE_BAD)
       return "severity" + escapeHTML(severity);
     else
       return "";
@@ -732,8 +737,16 @@ var EventsView = function(userProfile, options) {
       escapeHTML(description) + "</td>";
   }
 
-  function renderTableDataEventStatus(event, server) {
-    var status = event["type"];
+  function renderTableDataEventType(event, server) {
+    var type = event["type"];
+    var typeClass = "event-type" + type;
+
+    return "<td class='" + getSeverityClass(event) + " " + typeClass + "'>" +
+      type_choices[Number(type)] + "</td>";
+  }
+
+  function renderTableDataTriggerStatus(event, server) {
+    var status = event["status"];
     var statusClass = "status" + status;
 
     return "<td class='" + getSeverityClass(event) + " " + statusClass + "'>" +

--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -415,7 +415,7 @@ HatoholEventsViewConfig.prototype.getDefaultConfig = function() {
     'events.auto-reload.interval': "60",
     'events.num-rows-per-page': "300",
     'events.columns':
-      "incidentStatus,status,severity,time," +
+      "incidentStatus,type,severity,time," +
       "monitoringServerName,hostName,description",
     'events.sort.type': "time",
     'events.sort.order': "" + hatohol.DATA_QUERY_OPTION_SORT_DESCENDING,

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -156,7 +156,7 @@ describe('EventsView', function() {
     var view = new EventsView(getOperator(), testOptions);
     var expected = "";
 
-    expected += '<td class="severity1 status1">Problem</td>';
+    expected += '<td class="severity1 event-type1">Problem</td>';
     expected += '<td class="severity1">Information</td>';
 
     if (params) {
@@ -199,7 +199,7 @@ describe('EventsView', function() {
     var view = new EventsView(getOperator(), testOptions);
     var expected = "";
 
-    expected += '<td class="severity1 status1">Problem</td>';
+    expected += '<td class="severity1 event-type1">Problem</td>';
     expected += '<td class="severity1">Information</td>';
     if (params) {
       expected += '<td class="severity1"><a href="' + escapeHTML(params.eventURL) +
@@ -309,7 +309,7 @@ describe('EventsView', function() {
     var eventURL =
       "http://192.168.1.100/zabbix/tr_events.php?&triggerid=13569&eventid=12332";
     var expected =
-      '<td class=" status0">OK</td>' +
+      '<td class=" event-type0">OK</td>' +
       '<td class="">Information</td>' +
       '<td class=""><a href="' + escapeHTML(eventURL) +
       '" target="_blank">' + escapeHTML(formatDate(1415749496)) +
@@ -342,7 +342,7 @@ describe('EventsView', function() {
   it('Customize columns', function() {
     var view = new EventsView(getOperator(), testOptions);
     var configJson =
-      '{"events.columns":"duration,severity,status,description,' +
+      '{"events.columns":"duration,severity,type,description,' +
       'hostName,time,monitoringServerName"}';
     respond(eventsJson(dummyEventInfo, getDummyServerInfo(0)),
 	    configJson);

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -140,7 +140,7 @@
 	    </div>
 	    <div class="filter-element">
 	      <p><label>{% trans "Status:" %}</label></p>
-	      <select id="select-status" class="form-control">
+	      <select id="select-type" class="form-control">
 		<option value="-1">---------</option>
 		<option value="0">{% trans "OK" %}</option>
 		<option value="1">{% trans "Problem" %}</option>


### PR DESCRIPTION
* status: The current trigger status which is concerned with the
          event.
* type:   The event state.

In usual cases we should use the later one for events, but the
former one was often used in the previous code.

This commit fixes this issue to avoid confusion.

Please clear your config value of "event.columns" to reset the
default setting.