### PR TITLE
[Operationprivilege][server] Expand privileges bit width

### DIFF
--- a/server/src/OperationPrivilege.cc
+++ b/server/src/OperationPrivilege.cc
@@ -93,7 +93,7 @@ void OperationPrivilege::setFlags(const OperationPrivilegeFlag &flags)
 OperationPrivilegeFlag OperationPrivilege::makeFlag(
   const OperationPrivilegeType &type)
 {
-	return (1 << type);
+	return (1ULL << type);
 }
 
 bool OperationPrivilege::has(const OperationPrivilegeType &type) const

--- a/server/test/testOperationPrivilege.cc
+++ b/server/test/testOperationPrivilege.cc
@@ -163,7 +163,7 @@ void test_makeFlag(void)
 		OperationPrivilegeType type =
 		  static_cast<OperationPrivilegeType>(i);
 		cppcut_assert_equal(
-		  (OperationPrivilegeFlag)(1 << i),
+		  (OperationPrivilegeFlag)(1ULL << i),
 		  OperationPrivilege::makeFlag(type));
 	}
 }


### PR DESCRIPTION
`1` is not `unit64_t` literal but `int32` literal.
It should use `1ULL` instead. 

Related to #1694.