### PR TITLE
[hap2_zabbix_api] Fix update events function

### DIFF
--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -30,6 +30,8 @@ from hatohol import haplib
 from hatohol import zabbixapi
 from hatohol import standardhap
 
+logger = haplib.logger
+MAX_NUMBER_OF_EVENTS_FROM_ZABBIX = 1000
 
 class PreviousHostsInfo:
     def __init__(self):
@@ -104,26 +106,48 @@ class ZabbixAPIConductor:
                           last_info=self.__trigger_last_info,
                           fetch_id=fetch_id)
 
-    def update_events(self, last_info=None, count=None, direction="ASC",
-                      fetch_id=None):
-        if last_info is None:
-            last_info = self.get_cached_event_last_info()
+    def update_events_poll(self):
+        last_event_id = self.__api.get_end_id(False)
+        event_ids = list()
+        last_info = self.get_cached_event_last_info()
+        if len(last_info):
+            last_info = int(last_info)
+        # If Hatohol server does not have last_info, set 0 to last_info.
+        elif isinstance(last_info, str) or isinstance(last_info, unicode):
+            last_info = 0
 
-        event_id_from = None
+        while True:
+            event_id_from = last_info + 1
+            event_id_till = last_info + MAX_NUMBER_OF_EVENTS_FROM_ZABBIX
+            event_ids.append([event_id_from, event_id_till])
+            if event_id_till >= last_event_id: break
+            last_info = event_id_till
+
+        events = list()
+        for event_from_id, event_till_id in event_ids:
+            events = events + self.__api.get_events(event_from_id,
+                                                    event_till_id)
+
+        if len(events) == 0:
+            return
+
+        self.put_events(events)
+
+    def update_events_fetch(self, last_info, count, direction, fetch_id):
+        if count > MAX_NUMBER_OF_EVENTS_FROM_ZABBIX:
+            logger.error("Received a bad request which wants to get number or \
+                          events that burdening the Zabbix API.")
+            raise
+
         if direction == "ASC":
-            if isinstance(last_info, unicode) or isinstance(last_info, str):
-                last_info = int(last_info)
-            if isinstance(last_info, int):
-                event_id_from = last_info + 1
-            event_id_till = None
-            if count is not None:
-                event_id_till = event_id_from + count
-        # The following elif sentence is used from only fetchEvents
+            event_id_from = last_info + 1
+            event_id_till = last_info + count
         elif direction == "DESC":
+            event_id_from = last_info - count + 1
             event_id_till = last_info
-            event_id_from = event_id_till - count
 
         events = self.__api.get_events(event_id_from, event_id_till)
+
         if len(events) == 0:
             return
 
@@ -141,7 +165,7 @@ class Hap2ZabbixAPIPoller(haplib.BasePoller, ZabbixAPIConductor):
         self.update_hosts_and_host_group_membership()
         self.update_host_groups()
         self.update_triggers()
-        self.update_events()
+        self.update_events_poll()
 
 class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
     def __init__(self, *args, **kwargs):
@@ -167,8 +191,8 @@ class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
     def hap_fetch_events(self, params, request_id):
         self.make_sure_token()
         self.get_sender().response("SUCCESS", request_id)
-        self.update_events(int(params["lastInfo"]), params["count"],
-                           params["direction"], params["fetchId"])
+        self.update_events_fetch(int(params["lastInfo"]), params["count"],
+                                 params["direction"], params["fetchId"])
 
 
 class Hap2ZabbixAPI(standardhap.StandardHap):

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -32,7 +32,7 @@ from hatohol import standardhap
 
 logger = haplib.logger
 MAX_NUMBER_OF_EVENTS_FROM_ZABBIX = 1000
-MAX_NUMBER_OF_EVENTS_FROM_HAPI2 = 1000
+MAX_NUMBER_OF_EVENTS_OF_HAPI2 = 1000
 
 class PreviousHostsInfo:
     def __init__(self):
@@ -185,15 +185,16 @@ class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
         self.update_triggers(params.get("hostIds"), params["fetchId"])
 
     def hap_fetch_events(self, params, request_id):
-        if params["count"] > MAX_NUMBER_OF_EVENTS_FROM_HAPI2:
-            error_msg = "Count exceeds the limit of the HAPI2.0 specification."
+        count = params["count"]
+        if count > MAX_NUMBER_OF_EVENTS_OF_HAPI2:
+            error_msg = "%d count exceeds the limit of the HAPI2.0 specification." % count
             logger.error(error_msg)
             self.hap_return_error(error_msg, request_id)
             return
 
         self.make_sure_token()
         self.get_sender().response("SUCCESS", request_id)
-        self.update_events_fetch(int(params["lastInfo"]), params["count"],
+        self.update_events_fetch(int(params["lastInfo"]), count,
                                  params["direction"], params["fetchId"])
 
 

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -32,6 +32,7 @@ from hatohol import standardhap
 
 logger = haplib.logger
 MAX_NUMBER_OF_EVENTS_FROM_ZABBIX = 1000
+MAX_NUMBER_OF_EVENTS_FROM_HAPI2 = 1000
 
 class PreviousHostsInfo:
     def __init__(self):
@@ -134,11 +135,6 @@ class ZabbixAPIConductor:
         self.put_events(events)
 
     def update_events_fetch(self, last_info, count, direction, fetch_id):
-        if count > MAX_NUMBER_OF_EVENTS_FROM_ZABBIX:
-            logger.error("Received a bad request which wants to get number or \
-                          events that burdening the Zabbix API.")
-            raise
-
         if direction == "ASC":
             event_id_from = last_info + 1
             event_id_till = last_info + count
@@ -189,6 +185,12 @@ class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
         self.update_triggers(params.get("hostIds"), params["fetchId"])
 
     def hap_fetch_events(self, params, request_id):
+        if params["count"] > MAX_NUMBER_OF_EVENTS_FROM_HAPI2:
+            error_msg = "Count exceeds the limit of the HAPI2.0 specification."
+            logger.error(error_msg)
+            self.hap_return_error(error_msg, request_id)
+            return
+
         self.make_sure_token()
         self.get_sender().response("SUCCESS", request_id)
         self.update_events_fetch(int(params["lastInfo"]), params["count"],

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -119,7 +119,7 @@ class ZabbixAPIConductor:
         while True:
             event_id_from = last_info + 1
             event_id_till = last_info + MAX_NUMBER_OF_EVENTS_FROM_ZABBIX
-            event_ids.append([event_id_from, event_id_till])
+            event_ids.append((event_id_from, event_id_till))
             if event_id_till >= last_event_id: break
             last_info = event_id_till
 

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -114,7 +114,7 @@ class ZabbixAPIConductor:
         if len(last_info):
             last_info = int(last_info)
         # If Hatohol server does not have last_info, set 0 to last_info.
-        elif isinstance(last_info, str) or isinstance(last_info, unicode):
+        else:
             last_info = 0
 
         while True:

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -108,7 +108,7 @@ class ZabbixAPIConductor:
                           fetch_id=fetch_id)
 
     def update_events_poll(self):
-        last_event_id = self.__api.get_end_id(False)
+        last_event_id = self.__api.get_event_end_id()
         event_ids = list()
         last_info = self.get_cached_event_last_info()
         if len(last_info):

--- a/server/hap2/hatohol/test/TestHap2ZabbixApi.py
+++ b/server/hap2/hatohol/test/TestHap2ZabbixApi.py
@@ -255,7 +255,7 @@ class APIForTest:
 
         return test_events
 
-    def get_end_id(self, is_first):
+    def get_event_end_id(self, is_first):
         test_event_id = 1
 
         return test_event_id

--- a/server/hap2/hatohol/test/TestHap2ZabbixApi.py
+++ b/server/hap2/hatohol/test/TestHap2ZabbixApi.py
@@ -174,12 +174,15 @@ class Hap2ZabbixAPIPoller(unittest.TestCase):
         cls.poller._ZabbixAPIConductor__api =  APIForTest()
         def null_func(self, *args, **kwargs):
             pass
+        def return_empty_string(*args, **kwargs):
+            return ""
         cls.poller.put_hosts = null_func
         cls.poller.put_host_groups =  null_func
         cls.poller.put_host_group_membership = null_func
         cls.poller.put_triggers = null_func
         cls.poller.put_events = null_func
         cls.poller.get_last_info = null_func
+        cls.poller.get_cached_event_last_info = return_empty_string
 
     def test_poll(self):
         testutils.assertNotRaises(self.poller.poll)

--- a/server/hap2/hatohol/test/TestHap2ZabbixApi.py
+++ b/server/hap2/hatohol/test/TestHap2ZabbixApi.py
@@ -36,6 +36,8 @@ class ZabbixAPIConductor(unittest.TestCase):
     def setUpClass(cls):
         def null_func(*args, **kwargs):
             pass
+        def return_empty_string(*args, **kwargs):
+            return ""
         hap2_zabbix_api.ZabbixAPIConductor.get_component_code = null_func
         hap2_zabbix_api.ZabbixAPIConductor.get_sender = null_func
         cls.conductor = hap2_zabbix_api.ZabbixAPIConductor()
@@ -49,7 +51,7 @@ class ZabbixAPIConductor(unittest.TestCase):
         cls.conductor.put_triggers = null_func
         cls.conductor.put_events = null_func
         cls.conductor.get_last_info = null_func
-        cls.conductor.get_cached_event_last_info = null_func
+        cls.conductor.get_cached_event_last_info = return_empty_string
 
     def test_reset(self):
         self.conductor.reset()
@@ -108,11 +110,16 @@ class ZabbixAPIConductor(unittest.TestCase):
         testutils.assertNotRaises(self.conductor.update_triggers,
                                "test_ids", "test_id")
 
-    def test_update_events(self):
-        testutils.assertNotRaises(self.conductor.update_events)
+    def test_update_events_poll(self):
+        testutils.assertNotRaises(self.conductor.update_events_poll)
 
-    def test_update_events_request(self):
-        testutils.assertNotRaises(self.conductor.update_events, last_info=1)
+    def test_update_events_fetch_asc(self):
+        testutils.assertNotRaises(self.conductor.update_events_fetch,
+                                  last_info=1, count=1, direction="ASC", fetch_id=1)
+
+    def test_update_events_fetch_desc(self):
+        testutils.assertNotRaises(self.conductor.update_events_fetch,
+                                  last_info=1, count=1, direction="DESC", fetch_id=1)
 
     def test_update_hosts_and_host_group_membership(self):
         testutils.assertNotRaises(self.conductor.update_hosts_and_host_group_membership)
@@ -244,3 +251,8 @@ class APIForTest:
                         "hostName": "exampleName"}]
 
         return test_events
+
+    def get_end_id(self, is_first):
+        test_event_id = 1
+
+        return test_event_id

--- a/server/hap2/hatohol/test/TestHap2ZabbixApi.py
+++ b/server/hap2/hatohol/test/TestHap2ZabbixApi.py
@@ -255,7 +255,7 @@ class APIForTest:
 
         return test_events
 
-    def get_event_end_id(self, is_first):
+    def get_event_end_id(self, is_first=False):
         test_event_id = 1
 
         return test_event_id

--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -129,8 +129,8 @@ class TestZabbixApi(unittest.TestCase):
 
         self.assertEquals(exact, result)
 
-    def test_get_end_id(self):
-        result = self.api.get_end_id(False)
+    def test_get_event_end_id(self):
+        result = self.api.get_event_end_id(False)
         exact = 1
 
         self.assertEquals(exact, result)

--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -129,6 +129,12 @@ class TestZabbixApi(unittest.TestCase):
 
         self.assertEquals(exact, result)
 
+    def test_get_end_id(self):
+        result = self.api.get_end_id(False)
+        exact = 1
+
+        self.assertEquals(exact, result)
+
     def test_check_response(self):
         res_dict = {"error": None}
         self.assertFalse(zabbixapi.check_response(res_dict))

--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -36,104 +36,104 @@ class TestZabbixApi(unittest.TestCase):
 
     def test_get_auth_token(self):
         result = self.api.get_auth_token("user", "password")
-        exact = "test_auth_token"
+        expected = "test_auth_token"
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_api_version(self):
         result = self.api.get_api_version()
-        exact = "2.2.7"
+        expected = "2.2.7"
 
     def test_get_items(self):
         result = self.api.get_items()
-        exact = [{"itemId": u"1","hostId": u"1", "brief": u"test_name",
+        expected = [{"itemId": u"1","hostId": u"1", "brief": u"test_name",
                   "unit": u"B", "itemGroupName": [u"test_name"],
                   "lastValueTime": "19700101000003.111111111", "lastValue": u"100"}]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_history(self):
         result = self.api.get_history("test_id", "19700101000000.111",
                                                  "19700101000000.222")
-        exact = [{"value": u"1","time": "19700101000000.111111111"},
+        expected = [{"value": u"1","time": "19700101000000.111111111"},
                  {"value": u"2","time": "19700101000001.222222222"}]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_item_value_type(self):
         result = self.api.get_item_value_type("test_id")
-        exact = "3"
+        expected = "3"
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_host(self):
         result_hosts, result_host_group_membership = self.api.get_hosts()
-        exact_hosts = [{"hostId": u"1", "hostName": u"test_host"}]
-        exact_host_group_membership = [{"hostId": u"1", "groupIds":[u"1"]}]
+        expected_hosts = [{"hostId": u"1", "hostName": u"test_host"}]
+        expected_host_group_membership = [{"hostId": u"1", "groupIds":[u"1"]}]
 
 
-        self.assertEquals(exact_hosts, result_hosts)
-        self.assertEquals(exact_host_group_membership, result_host_group_membership)
+        self.assertEquals(expected_hosts, result_hosts)
+        self.assertEquals(expected_host_group_membership, result_host_group_membership)
 
     def test_host_groups(self):
         result = self.api.get_host_groups()
-        exact = [{"groupId": "1", "groupName": "test_name"}]
+        expected = [{"groupId": "1", "groupName": "test_name"}]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_triggers(self):
         result = self.api.get_triggers()
-        exact = [{"triggerId": u"1", "status": "OK", "severity": "ERROR",
+        expected = [{"triggerId": u"1", "status": "OK", "severity": "ERROR",
                   "lastChangeTime": "19700101000000", "hostId": u"1", "hostName": u"test_host",
                   "brief": u"test_description",
                   "extendedInfo": u"test_expand_description"}]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_trigger_expand_description(self):
         result = self.api.get_trigger_expand_description()
-        exact = {u"result": [{u"triggerid": u"1",
+        expected = {u"result": [{u"triggerid": u"1",
                  u"description": u"test_expand_description",
                  u"state": u"0", u"priority": u"3"}]}
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_select_trigger(self):
         result = self.api.get_select_trigger("test_id")
-        exact = {u"triggerid": u"1", u"priority": u"3", u"state": u"0",
+        expected = {u"triggerid": u"1", u"priority": u"3", u"state": u"0",
                  u"description": u"test_expand_description"}
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_events(self):
         result = self.api.get_events("test_from")
-        exact = [{"eventId": u"1", "time": u"19700101000000.111111111", "type": "GOOD",
+        expected = [{"eventId": u"1", "time": u"19700101000000.111111111", "type": "GOOD",
                   "triggerId": u"1", "status": "OK", "severity": "ERROR",
                   "hostId": u"1", "hostName": u"test_host",
                   "brief": u"test_expand_description",
                   "extendedInfo": ""}]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_response_dict(self):
         result = self.api.get_response_dict("user.authenticate", "test_param",
                                             "test_header")
-        exact = {u'result': u'test_auth_token'}
+        expected = {u'result': u'test_auth_token'}
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_item_groups(self):
         applications = [{"name": "test1"},{"name": "test2"}]
         result = zabbixapi.get_item_groups(applications)
-        exact = ["test1", "test2"]
+        expected = ["test1", "test2"]
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_get_event_end_id(self):
         result = self.api.get_event_end_id(False)
-        exact = 1
+        expected = 1
 
-        self.assertEquals(exact, result)
+        self.assertEquals(expected, result)
 
     def test_check_response(self):
         res_dict = {"error": None}

--- a/server/hap2/hatohol/test/test_urllib2.py
+++ b/server/hap2/hatohol/test/test_urllib2.py
@@ -40,7 +40,8 @@ RESULTS = {
                            "state": "0"}],
     "event.get": [{"eventid":"1", "objectid":"1",
                    "clock":"0","value":"0", "ns":"111111111",
-                   "hosts":[{"hostid":"1","name":"test_host"}]}]
+                   "hosts":[{"hostid":"1","name":"test_host"}]}],
+    "event.get.expand": [{"eventid":"1"}]
 }
 
 class urllib2:
@@ -49,6 +50,9 @@ class urllib2:
         self.method = request["method"]
         if str(request["method"]) == "trigger.get":
             if request["params"].get(u"expandDescription"):
+                self.method += ".expand"
+        if str(request["method"]) == "event.get":
+            if request["params"].get(u"limit"):
                 self.method += ".expand"
         return
 

--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -282,7 +282,7 @@ class ZabbixAPI:
         return events
 
 
-    def get_end_id(self, is_first):
+    def get_event_end_id(self, is_first=False):
         params = {"output": "shorten", "sortfield": "eventid", "limit": 1}
         if is_first:
             params["sortorder"] = "ASC"

--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -281,6 +281,23 @@ class ZabbixAPI:
 
         return events
 
+
+    def get_end_id(self, is_first):
+        params = {"output": "shorten", "sortfield": "eventid", "limit": 1}
+        if is_first:
+            params["sortorder"] = "ASC"
+        else:
+            params["sortorder"] = "DESC"
+
+        res_dict = self.get_response_dict("event.get", params, self.auth_token)["result"]
+
+        self.result = check_response(res_dict)
+        if not self.result:
+            return
+
+        return int(res_dict[0]["eventid"])
+
+
     def get_response_dict(self, method_name, params, auth_token=None):
         HEADER = {"Content-Type": "application/json-rpc"}
         post = json.dumps({"jsonrpc": "2.0", "method": method_name,


### PR DESCRIPTION
[hap2_zabbix_api] Fix update_events function
- Separate update_event to incase of polling and fetch
- Define MAX_NUMBER_OF_EVENTS_FROM_ZABBIX
- Split a requset that sent to Zabbix API

[zabbixapi] Implement get_end_id

Related: #1668