### PR TITLE
[hap2] Fix the bug in which effective digit of time is dropped (#1704).

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -1147,17 +1147,20 @@ class Utils:
         return req_id
 
     @staticmethod
-    def translate_unix_time_to_hatohol_time(unix_time):
-        decimal = None
-        if isinstance(unix_time, float):
-            unix_time, decimal = str(unix_time).split(".")
-            unix_time = int(unix_time)
-        utc_time = time.gmtime(unix_time)
-        hatohol_time = time.strftime("%Y%m%d%H%M%S", utc_time)
-        if decimal is not None:
-            hatohol_time = hatohol_time + "." + decimal
+    def translate_unix_time_to_hatohol_time(unix_time, ns=0):
+        """
+        Translate unix_time into a time string of HAPI 2.0.
 
-        return hatohol_time
+        @param unix_time An unix time (integer or string).
+        @param ns A nanosecnd part of the time (integer or string).
+        @return A timestamp string in HAPI2.0
+        """
+        utc_time = time.gmtime(int(unix_time))
+        hatohol_time = time.strftime("%Y%m%d%H%M%S", utc_time)
+        ns_int = int(ns)
+        if ns_int > 1000000000 or ns_int < 0:
+            raise ValueError("Invalid 'ns': %s" % ns)
+        return hatohol_time + ".%09d" % ns_int
 
     @staticmethod
     def translate_hatohol_time_to_unix_time(hatohol_time):

--- a/server/hap2/hatohol/test/TestHaplib.py
+++ b/server/hap2/hatohol/test/TestHaplib.py
@@ -363,9 +363,32 @@ class Utils(unittest.TestCase):
 
     def test_translate_unix_time_to_hatohol_time(self):
         result = haplib.Utils.translate_unix_time_to_hatohol_time(0)
-        self.assertEquals(result, "19700101000000")
-        result = haplib.Utils.translate_unix_time_to_hatohol_time(0.123456)
-        self.assertEquals(result, "19700101000000.123456")
+        self.assertEquals(result, "19700101000000.000000000")
+        result = haplib.Utils.translate_unix_time_to_hatohol_time("0")
+        self.assertEquals(result, "19700101000000.000000000")
+        result = haplib.Utils.translate_unix_time_to_hatohol_time(0, 123456789)
+        self.assertEquals(result, "19700101000000.123456789")
+        result = haplib.Utils.translate_unix_time_to_hatohol_time(0, 123456)
+        self.assertEquals(result, "19700101000000.000123456")
+        result = haplib.Utils.translate_unix_time_to_hatohol_time("0", "123456789")
+        self.assertEquals(result, "19700101000000.123456789")
+
+        result = haplib.Utils.translate_unix_time_to_hatohol_time("0", "999999999")
+        self.assertEquals(result, "19700101000000.999999999")
+
+    def test_translate_unix_time_to_hatohol_time_with_errors(self):
+        self.assertRaises(
+            ValueError,
+            haplib.Utils.translate_unix_time_to_hatohol_time, 0, -1)
+
+        self.assertRaises(
+            ValueError,
+            haplib.Utils.translate_unix_time_to_hatohol_time, 0, 10000000000)
+
+        self.assertRaises(
+            ValueError,
+            haplib.Utils.translate_unix_time_to_hatohol_time, 0, "")
+
 
     def test_translate_hatohol_time_to_unix_time(self):
         result = haplib.Utils.translate_hatohol_time_to_unix_time("19700101000000.123456789")

--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -84,7 +84,8 @@ class TestZabbixApi(unittest.TestCase):
     def test_get_triggers(self):
         result = self.api.get_triggers()
         exact = [{"triggerId": u"1", "status": "OK", "severity": "ERROR",
-                  "lastChangeTime": "19700101000000", "hostId": u"1", "hostName": u"test_host",
+                  "lastChangeTime": "19700101000000.000000000",
+                  "hostId": u"1", "hostName": u"test_host",
                   "brief": u"test_description",
                   "extendedInfo": u"test_expand_description"}]
 

--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -77,15 +77,12 @@ class ZabbixAPI:
                 continue
             self.expand_item_brief(item)
 
-            if int(item["lastns"]) == 0:
-                ns = 0
-            else:
-                ns = Utils.translate_int_to_decimal(int(item["lastns"]))
-
+            time = Utils.translate_unix_time_to_hatohol_time(item["lastclock"],
+                                                             item["lastns"])
             items.append({"itemId": item["itemid"],
                           "hostId": item["hostid"],
                           "brief": item["name"],
-                          "lastValueTime": Utils.translate_unix_time_to_hatohol_time(int(item["lastclock"]) + ns),
+                          "lastValueTime": time,
                           "lastValue": item["lastvalue"],
                           "itemGroupName": get_item_groups(item["applications"]),
                           "unit": item["units"]})
@@ -117,13 +114,9 @@ class ZabbixAPI:
 
         histories = list()
         for history in res_dict["result"]:
-            if int(history["ns"]) == 0:
-                ns = 0
-            else:
-                ns = Utils.translate_int_to_decimal(int(history["ns"]))
-
-            histories.append({"value": history["value"],
-                              "time": Utils.translate_unix_time_to_hatohol_time(int(history["clock"]) + ns)})
+            time = Utils.translate_unix_time_to_hatohol_time(history["clock"],
+                                                             history["ns"])
+            histories.append({"value": history["value"], "time": time})
 
         return histories
 
@@ -202,10 +195,11 @@ class ZabbixAPI:
                 description = [ed["description"] for ed in
                                expanded_descriptions["result"]
                                if ed["triggerid"] == trigger["triggerid"]][0]
+                time = Utils.translate_unix_time_to_hatohol_time(trigger["lastchange"])
                 triggers.append({"triggerId": trigger["triggerid"],
                                  "status": TRIGGER_STATUS[trigger["state"]],
                                  "severity": TRIGGER_SEVERITY[trigger["priority"]],
-                                 "lastChangeTime": Utils.translate_unix_time_to_hatohol_time(int(trigger["lastchange"])),
+                                 "lastChangeTime": time,
                                  "hostId": trigger["hosts"][0]["hostid"],
                                  "hostName": trigger["hosts"][0]["name"],
                                  "brief": trigger["description"],
@@ -259,14 +253,11 @@ class ZabbixAPI:
         events = list()
         for event in res_dict["result"]:
             try:
-                if int(event["ns"]) == 0:
-                    ns = 0
-                else:
-                    ns = Utils.translate_int_to_decimal(int(event["ns"]))
-
                 trigger = self.get_select_trigger(event["objectid"])
+                time = Utils.translate_unix_time_to_hatohol_time(event["clock"],
+                                                                 event["ns"])
                 events.append({"eventId": event["eventid"],
-                               "time": Utils.translate_unix_time_to_hatohol_time(int(event["clock"]) + ns),
+                               "time": time,
                                "type": EVENT_TYPE[event["value"]],
                                "triggerId": trigger["triggerid"],
                                "status": TRIGGER_STATUS[trigger["state"]],


### PR DESCRIPTION
Presently, the accuracy of time form the Zabbix server is dropped in hap2_zabbix_api.py.
This patch address the problem by handling unix time and nanoseconds separately.