### PR TITLE
[hap2][zabbixapi] Remove unused enumerate().

### DIFF
--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -197,7 +197,7 @@ class ZabbixAPI:
             return
 
         triggers = list()
-        for num, trigger in enumerate(res_dict["result"]):
+        for trigger in res_dict["result"]:
             try:
                 description = [ed["description"] for ed in
                                expanded_descriptions["result"]


### PR DESCRIPTION
enumerate() is not necessary. So this patch removes it.