### PR TITLE
[hatohol-def-src-file-generator] Add uint64_t version of toString utility function

### DIFF
--- a/server/tools/hatohol-def-src-file-generator.cc
+++ b/server/tools/hatohol-def-src-file-generator.cc
@@ -93,6 +93,11 @@ static string toString(const int value)
 	return StringUtils::sprintf("%d", value);
 }
 
+static string toString(const uint64_t value)
+{
+	return StringUtils::sprintf("%lu", value);
+}
+
 static string toString(const string &value)
 {
 	return StringUtils::sprintf("'%s'", value.c_str());


### PR DESCRIPTION
`hatohol-db-initiator` should be able to treat over 32bit integer.
Otherwise, admin privileges wrongly disappears due to overflow. 