### PR TITLE
[simple_server] Send an empty string in accordance with HAPI-2.0 Spec.

### DIFF
--- a/server/hap2/hatohol/simple_server.py
+++ b/server/hap2/hatohol/simple_server.py
@@ -52,7 +52,7 @@ class SimpleServer:
         self.__rpc_queue = hap.MultiprocessingJoinableQueue()
         self.__dispatcher = haplib.Dispatcher(self.__rpc_queue)
         self.__dispatcher.daemonize()
-        self.__last_info = {"event": None, "trigger": None}
+        self.__last_info = {"event": "", "trigger": ""}
 
         self.__handler_map = {
             "exchangeProfile": self.__rpc_exchange_profile,


### PR DESCRIPTION
Previously a null object is returned. This behavior violates the HAPI-2.0 Spec.