### PR TITLE
[hap2_zabbix_api] Reset zabbixapi object after error. (#1718)

### DIFF
--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -160,6 +160,11 @@ class Hap2ZabbixAPIPoller(haplib.BasePoller, ZabbixAPIConductor):
         self.update_triggers()
         self.update_events_poll()
 
+    # @override
+    def on_aborted_poll(self):
+        logger.error("Polling: aborted.")
+        super(ZabbixAPIConductor, self).reset()
+
 class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
     def __init__(self, *args, **kwargs):
         haplib.BaseMainPlugin.__init__(self)


### PR DESCRIPTION
When polling is aborted. this patch calls ZabbixAPIConductor's
reset(). It internally releases the ZabbixAPI object. As a
result, recreation of it is performed in the next polling
in which auth. token is obtained again too.