### PR TITLE
[zabbixapi] Correspond to the zabbix3.0

### DIFF
--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -117,7 +117,7 @@ class TestZabbixApi(unittest.TestCase):
         self.assertEquals(expected, result)
 
     def test_get_response_dict(self):
-        result = self.api.get_response_dict("user.authenticate", "test_param",
+        result = self.api.get_response_dict("user.login", "test_param",
                                             "test_header")
         expected = {u'result': u'test_auth_token'}
 

--- a/server/hap2/hatohol/test/test_urllib2.py
+++ b/server/hap2/hatohol/test/test_urllib2.py
@@ -22,7 +22,7 @@
 import json
 
 RESULTS = {
-    "user.authenticate": "test_auth_token",
+    "user.login": "test_auth_token",
     "apiinfo.version": "2.2.7",
     "item.get": [{"itemid": "1", "hostid": "1",
         "name": "test_name","units": "B","value_type":"3",

--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -50,7 +50,7 @@ class ZabbixAPI:
 
     def get_auth_token(self, user_name, user_passwd):
         params = {'user': user_name, 'password': user_passwd}
-        res_dict = self.get_response_dict("user.authenticate", params)
+        res_dict = self.get_response_dict("user.login", params)
 
         self.result = check_response(res_dict)
         if not self.result:


### PR DESCRIPTION
auth token取得に使用するメソッド以外で2系から3系への変更点は見当たらなかった。
組み込み，HAPI2.0ともに動作を確認。
user.loginメソッドはzabbix２系，3系共通のメソッドのため，これに変更することで両verに対応できる。