### PR TITLE
[test/setup.sql] Skip creating DB if existing.

### DIFF
--- a/data/test/setup.sql
+++ b/data/test/setup.sql
@@ -1,7 +1,7 @@
 GRANT all on ndoutils.* TO ndoutils@localhost IDENTIFIED BY 'admin';
-CREATE DATABASE hatohol_client;
+CREATE DATABASE IF NOT EXISTS hatohol_client;
 GRANT ALL PRIVILEGES ON hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';
-CREATE DATABASE test_hatohol_client;
+CREATE DATABASE IF NOT EXISTS test_hatohol_client;
 GRANT ALL PRIVILEGES ON test_hatohol_client.* TO hatohol@localhost IDENTIFIED BY 'hatohol';
 GRANT USAGE ON *.* TO ''@'localhost';
 GRANT ALL PRIVILEGES ON `test\_%`.* TO ''@'localhost';


### PR DESCRIPTION
In the development, there's already have some of the tables depending on the situation.
Even in that case, this patch makes the SQL run successfully.