### PR TITLE
[HatoholArmPluginGateHAPI2] Handle array of itemGroupName.

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1118,6 +1118,35 @@ static bool parseItemParams(JSONParser &parser, ItemInfoList &itemInfoList,
 			    const HostInfoCache &hostInfoCache,
 			    JSONRPCError &errObj)
 {
+	/**
+	 * Get olny the first element from itemGroupName array.
+	 *
+	 * NOTE: This is tentative implementation. We will have to handle
+	 *       all of the given item group names.
+	 *
+	 * @param name
+	 * The first item gropu name. If the array is empty, an empty string
+	 * is assigned.
+	 * @return true if successful. Otherwise false.
+	 */
+	auto getItemGroupName = [&](string &name) {
+		CHECK_MANDATORY_ARRAY_EXISTENCE("itemGroupName", errObj);
+		parser.startObject("itemGroupName");
+		size_t num = parser.countElements();
+		if (num == 0)
+			name.clear();
+		else
+			parser.read(0, name);
+		// TODO: Don't ignore 2nd and the later itemGroupName.
+		if (num > 1) {
+			MLPL_WARN("Ignore 2nd and later itemGroups. This is "
+			          "a limitation of the current version of "
+			          "Hatohol (#1721).");
+		}
+		parser.endObject();
+		return true;
+	};
+
 	CHECK_MANDATORY_ARRAY_EXISTENCE("items", errObj);
 	parser.startObject("items");
 	size_t num = parser.countElements();
@@ -1138,7 +1167,8 @@ static bool parseItemParams(JSONParser &parser, ItemInfoList &itemInfoList,
 		PARSE_AS_MANDATORY("brief", itemInfo.brief, errObj);
 		parseTimeStamp(parser, "lastValueTime", itemInfo.lastValueTime, errObj);
 		PARSE_AS_MANDATORY("lastValue", itemInfo.lastValue, errObj);
-		PARSE_AS_MANDATORY("itemGroupName", itemInfo.itemGroupName, errObj);
+		if (!getItemGroupName(itemInfo.itemGroupName))
+			return false;
 		PARSE_AS_MANDATORY("unit", itemInfo.unit, errObj);
 		parser.endElement();
 		HostInfoCache::Element cacheElem;

--- a/server/test/testHatoholArmPluginGateHAPI2.cc
+++ b/server/test/testHatoholArmPluginGateHAPI2.cc
@@ -388,14 +388,24 @@ void test_procedureHandlerPutItems(void)
 	  new HatoholArmPluginGateHAPI2(monitoringServerInfo, false), false);
 	string json =
 		"{\"jsonrpc\":\"2.0\",\"method\":\"putItems\","
-		" \"params\":{\"items\":[{\"itemId\":\"1\", \"hostId\":\"1\","
+		" \"params\":{\"items\":["
+		// 1st item
+		"{\"itemId\":\"1\", \"hostId\":\"1\","
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175523\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"},"
+		" \"itemGroupName\":[\"example name\"], \"unit\":\"example unit\"},"
+		// 2nd item
 		" {\"itemId\":\"2\", \"hostId\":\"1\","
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175531\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"}],"
+		" \"itemGroupName\":[\"example name\", \"example2\"], \"unit\":\"example unit\"},"
+		// 3rd item
+		" {\"itemId\":\"3\", \"hostId\":\"1\","
+		" \"brief\":\"example wiht empty itemGroupName array\","
+		" \"lastValueTime\":\"20151117095531\","
+		" \"lastValue\":\"Alpha Beta Gamma\","
+		" \"itemGroupName\":[], \"unit\":\"Kelvin\"}],"
+		// others
 		" \"fetchId\":\"1\"}, \"id\":83241245}";
 	JSONParser parser(json);
 	gate->setEstablished(true);
@@ -411,7 +421,7 @@ void test_procedureHandlerPutItems(void)
 	option.setTargetServerId(monitoringServerInfo.id);
 	dbMonitoring.getItemInfoList(itemInfoList, option);
 	ItemInfoList expectedItemInfoList;
-	ItemInfo item1, item2;
+	ItemInfo item1, item2, item3;
 	timespec timeStamp;
 	string lastValueTime;
 
@@ -445,6 +455,21 @@ void test_procedureHandlerPutItems(void)
 	item2.unit           = "example unit";
 	expectedItemInfoList.push_back(item2);
 
+	lastValueTime = "20151117095531";
+	HatoholArmPluginGateHAPI2::parseTimeStamp(lastValueTime, timeStamp);
+	item3.serverId       = 302;
+	item3.id             = "3";
+	item3.globalHostId   = 10;
+	item3.hostIdInServer = "1";
+	item3.brief          = "example wiht empty itemGroupName array";
+	item3.lastValueTime  = timeStamp;
+	item3.lastValue      = "Alpha Beta Gamma";
+	item3.itemGroupName  = "";
+	item3.valueType      = ITEM_INFO_VALUE_TYPE_UNKNOWN;
+	item3.delay          = 0;
+	item3.unit           = "Kelvin";
+	expectedItemInfoList.push_back(item3);
+
 	string actualOutput;
 	for (auto itemInfo : itemInfoList) {
 		actualOutput += makeItemOutput(itemInfo);
@@ -466,11 +491,11 @@ void test_procedureHandlerPutItemsInvalidJSON(void)
 		" \"params\":{\"items\":[{\"itemId\":\"1\", "
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175523\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"},"
+		" \"itemGroupName\":[\"example name\"], \"unit\":\"example unit\"},"
 		" {\"itemId\":\"2\", \"hostId\":\"1\","
 		" \"lastValueTime\":\"20150410175531\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"}],"
+		" \"itemGroupName\":[\"example name\"], \"unit\":\"example unit\"}],"
 		" \"fetchId\":\"1\"}, \"id\":83241245}";
 	JSONParser parser(json);
 	gate->setEstablished(true);
@@ -1617,11 +1642,11 @@ void test_fetchItemsCallback(void)
 		" \"params\":{\"items\":[{\"itemId\":\"1\", \"hostId\":\"1\","
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175523\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"},"
+		" \"itemGroupName\":[\"example name\"], \"unit\":\"example unit\"},"
 		" {\"itemId\":\"2\", \"hostId\":\"1\","
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175531\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":\"example name\", \"unit\":\"example unit\"}],"
+		" \"itemGroupName\":[\"example name\", \"example2\"], \"unit\":\"example unit\"}],"
 		" \"fetchId\":\"%s\"}, \"id\":%" PRId64 "}",
 		fetchId.c_str(), id);
 	sendMessage(putItemsJSON);


### PR DESCRIPTION
HAPI2.0 spec. defines the type of itemGroupName as an array of
strings. However, the implementation has handled it as a single
string. This patch addresses the problem.

****
This PR is a fixed version of #1735. 