### PR TITLE
Remove HAPI1 plugins from web dialog #1626

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,7 @@ if test "$with_qpid" = "yes"; then
   AC_DEFINE(WITH_QPID, [1], [Define to 1 if qpid is enabled.])
 fi
 AM_CONDITIONAL(WITH_QPID, test "$with_qpid" = "yes")
+AC_SUBST(with_qpid)
 
 AC_LANG_POP([C++])
 

--- a/server/data/Makefile.am
+++ b/server/data/Makefile.am
@@ -1,10 +1,16 @@
 sql_DATA = \
 	create-db.sql \
 	server-type-zabbix.sql \
-	server-type-nagios.sql \
+	server-type-nagios.sql
+
+if WITH_QPID
+sql_DATA += \
 	server-type-hapi-zabbix.sql \
 	server-type-hapi-json.sql \
-	server-type-ceilometer.sql \
+	server-type-ceilometer.sql
+endif
+
+sql_DATA += \
 	server-type-hap2-zabbix.sql \
 	server-type-hap2-nagios.sql \
 	server-type-hap2-ceilometer.sql \
@@ -21,9 +27,11 @@ server-type: $(HATOHOL_SERVER_TYPE_UTIL)
 
 server-type-zabbix.sql: server-type
 server-type-nagios.sql: server-type
+if WITH_QPID
 server-type-hapi-zabbix.sql: server-type
 server-type-hapi-json.sql: server-type
 server-type-ceilometer.sql: server-type
+endif
 
 HATOHOL_INIT_USER_GENERATOR = ../tools/hatohol-init-user-generator
 init-user.sql: $(HATOHOL_INIT_USER_GENERATOR)
@@ -40,9 +48,15 @@ EXTRA_DIST = \
 
 CLEANFILES = \
 	server-type-zabbix.sql \
-	server-type-nagios.sql \
+	server-type-nagios.sql
+
+if WITH_QPID
+CLEANFILES += \
 	server-type-hapi-zabbix.sql \
 	server-type-hapi-json.sql \
-	server-type-ceilometer.sql \
+	server-type-ceilometer.sql
+endif
+
+CLEANFILES += \
 	init-user.sql \
 	_tmp.*

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -24,6 +24,8 @@ import MySQLdb
 from ctypes import *
 import ConfigParser
 
+_use_hapi1_plugins = '@with_qpid@'
+
 sql_file_list = [
     {'table_name': 'users',
      'file_name': 'init-user.sql',
@@ -34,6 +36,10 @@ sql_file_list = [
     {'table_name': 'server_types',
      'file_name': 'server-type-nagios.sql',
      'target': 'nagios'},
+]
+
+if _use_hapi1_plugins == 'yes':
+    sql_file_list.extend([
     {'table_name': 'server_types',
      'file_name': 'server-type-hapi-zabbix.sql',
      'target': 'hapi-zabbix'},
@@ -43,6 +49,9 @@ sql_file_list = [
     {'table_name': 'server_types',
      'file_name': 'server-type-ceilometer.sql',
      'target': 'ceilometer'},
+    ])
+
+sql_file_list.extend([
     {'table_name': 'server_types',
      'file_name': 'server-type-hap2-ceilometer.sql',
      'target': 'hapi2-ceilometer'},
@@ -61,7 +70,7 @@ sql_file_list = [
     {'table_name': 'custom_incident_statuses',
      'file_name': 'custom-incident-statuses.sql',
      'target': 'custom-incident-statuses'},
-]
+])
 
 config_map = {
     'db_login_user': 'root',


### PR DESCRIPTION
These patches addresses the problem in which HAPI1 plugins
are shown in Web UI (servers) even HAPI1 cannot be used
due to the build without QPID development packages.