### PR TITLE
[IncidentSenderHatohol] Permit user-defined incident statuses (USER01-USER06)

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -236,12 +236,12 @@ static const StatusDef definedStatuses[] = {
 	{ Status::HOLD,        "H", "HOLD" },
 	{ Status::IN_PROGRESS, "P", "IN PROGRESS" },
 	{ Status::DONE,        "*", "DONE" },
-	{ Status::USER_DEFINED, "",  "USER01" },
-	{ Status::USER_DEFINED, "",  "USER02" },
-	{ Status::USER_DEFINED, "",  "USER03" },
-	{ Status::USER_DEFINED, "",  "USER04" },
-	{ Status::USER_DEFINED, "",  "USER05" },
-	{ Status::USER_DEFINED, "",  "USER06" },
+	{ Status::USER_DEFINED, "", "USER01" },
+	{ Status::USER_DEFINED, "", "USER02" },
+	{ Status::USER_DEFINED, "", "USER03" },
+	{ Status::USER_DEFINED, "", "USER04" },
+	{ Status::USER_DEFINED, "", "USER05" },
+	{ Status::USER_DEFINED, "", "USER06" },
 };
 
 struct IncidentInfo {

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -222,7 +222,6 @@ enum class Status {
 	HOLD,
 	IN_PROGRESS,
 	DONE,
-	USER_DEFINED_BEGIN,
 	USER_DEFINED
 };
 

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -222,7 +222,8 @@ enum class Status {
 	HOLD,
 	IN_PROGRESS,
 	DONE,
-	USER_DEFINED_BEGIN
+	USER_DEFINED_BEGIN,
+	USER_DEFINED
 };
 
 struct StatusDef {
@@ -236,6 +237,12 @@ static const StatusDef definedStatuses[] = {
 	{ Status::HOLD,        "H", "HOLD" },
 	{ Status::IN_PROGRESS, "P", "IN PROGRESS" },
 	{ Status::DONE,        "*", "DONE" },
+	{ Status::USER_DEFINED, "",  "USER01" },
+	{ Status::USER_DEFINED, "",  "USER02" },
+	{ Status::USER_DEFINED, "",  "USER03" },
+	{ Status::USER_DEFINED, "",  "USER04" },
+	{ Status::USER_DEFINED, "",  "USER05" },
+	{ Status::USER_DEFINED, "",  "USER06" },
 };
 
 struct IncidentInfo {

--- a/server/test/testIncidentSenderHatohol.cc
+++ b/server/test/testIncidentSenderHatohol.cc
@@ -86,6 +86,24 @@ void data_updateStatus(void)
 	gcut_add_datum("DONE",
 	               "status", G_TYPE_STRING, "DONE",
 		       NULL);
+	gcut_add_datum("USER01",
+	               "status", G_TYPE_STRING, "USER01",
+		       NULL);
+	gcut_add_datum("USER02",
+	               "status", G_TYPE_STRING, "USER02",
+		       NULL);
+	gcut_add_datum("USER03",
+	               "status", G_TYPE_STRING, "USER03",
+		       NULL);
+	gcut_add_datum("USER04",
+	               "status", G_TYPE_STRING, "USER04",
+		       NULL);
+	gcut_add_datum("USER05",
+	               "status", G_TYPE_STRING, "USER05",
+		       NULL);
+	gcut_add_datum("USER06",
+	               "status", G_TYPE_STRING, "USER06",
+		       NULL);
 }
 
 void test_updateStatus(gconstpointer data)


### PR DESCRIPTION
IncidentSenderHatohol should permit from `USER01` to `USER06` statuses.
