### PR TITLE
[EventsView][WebUI] Set up custom incident status label

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -32,6 +32,7 @@ var EventsView = function(userProfile, options) {
   self.severityRanksMap = {};
   self.rawCustomIncidentStatusData = {};
   self.customIncidentStatusesMap = {};
+  self.defaultIncidentStatusesMap = {};
   self.durations = {};
   self.baseQuery = {
     limit:            50,
@@ -82,6 +83,7 @@ var EventsView = function(userProfile, options) {
       { value: "5", label: gettext("Disaster") },
     ],
   };
+  setupDefaultIncidentStatusMap();
 
   var columnDefinitions = {
     "monitoringServerName": {
@@ -745,6 +747,19 @@ var EventsView = function(userProfile, options) {
     });
   }
 
+  function setupDefaultIncidentStatusMap() {
+    var i, defaultIncidentStatuses;
+    self.defaultIncidentStatusesMap = {};
+    defaultIncidentStatuses =
+      eventPropertyChoices.incident;
+    if (defaultIncidentStatuses) {
+      for (i = 0; i < defaultIncidentStatuses.length; i++) {
+        self.defaultIncidentStatusesMap[defaultIncidentStatuses[i].value] =
+          defaultIncidentStatuses[i];
+      }
+    }
+  }
+
   function setLoading(loading) {
     if (loading) {
       $("#begin-time").attr("disabled", "disabled");
@@ -958,6 +973,16 @@ var EventsView = function(userProfile, options) {
     return self.severityRanksMap[severity].label;
   }
 
+  function getCustomIncidentStatusLabel(event) {
+    var incident = event["incident"];
+    var defaultLabel = "";
+    if (!self.customIncidentStatusesMap || !self.customIncidentStatusesMap[incident.status])
+      return defaultLabel;
+    if (self.defaultIncidentStatusesMap[incident.status].label && !self.customIncidentStatusesMap[incident.status].label)
+      return self.defaultIncidentStatusesMap[incident.status].label;
+    return self.customIncidentStatusesMap[incident.status].label;
+  }
+
   function renderTableDataEventSeverity(event, server) {
     var severity = event["severity"];
 
@@ -987,11 +1012,11 @@ var EventsView = function(userProfile, options) {
       return html + "</td>";
 
     if (!incident.localtion)
-      return html + pgettext("Incident", escapeHTML(incident.status)) + "</td>";
+      return html + getCustomIncidentStatusLabel(event) + "</td>";
 
     html += "<a href='" + escapeHTML(incident.location)
       + "' target='_blank'>";
-    html += pgettext("Incident", escapeHTML(incident.status)) + "</a>";
+    html += getCustomIncidentStatusLabel(event) + "</a>";
     html += "</td>";
 
     return html;

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -30,6 +30,7 @@ var EventsView = function(userProfile, options) {
   self.rawSummaryData = {};
   self.rawSeverityRankData = {};
   self.severityRanksMap = {};
+  self.rawCustomIncidentStatusData = {};
   self.durations = {};
   self.baseQuery = {
     limit:            50,
@@ -146,7 +147,7 @@ var EventsView = function(userProfile, options) {
   // Private functions
   //
   function start() {
-    $.when(loadUserConfig(), loadSeverityRank()).done(function() {
+    $.when(loadUserConfig(), loadSeverityRank(), loadCustomIncidentStatus()).done(function() {
       load();
     }).fail(function() {
       hatoholInfoMsgBox(gettext("Failed to get the configuration!"));
@@ -189,6 +190,25 @@ var EventsView = function(userProfile, options) {
             self.severityRanksMap[severityRanks[i].status] = severityRanks[i];
           }
         }
+        deferred.resolve();
+      },
+      parseErrorCallback: function() {
+        deferred.reject();
+      },
+      connectErrorCallback: function() {
+        deferred.reject();
+      },
+    });
+    return deferred.promise();
+  }
+
+  function loadCustomIncidentStatus() {
+    var deferred = new $.Deferred;
+    new HatoholConnector({
+      url: "/custom-incident-status",
+      request: "GET",
+      replyCallback: function(reply, parser) {
+        self.rawCustomIncidentStatusData = reply;
         deferred.resolve();
       },
       parseErrorCallback: function() {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -477,6 +477,7 @@ var EventsView = function(userProfile, options) {
   }
 
   function setIncidentStatusFilter(selector, addEmptyItem) {
+    var defaultCandidates = self.defaultIncidentStatusesMap;
     var candidates = self.customIncidentStatusesMap;
     var option;
     var x;
@@ -494,10 +495,17 @@ var EventsView = function(userProfile, options) {
 
     $.map(candidates, function(aCandidate) {
       var option;
+      var label = null;
+
+      if (aCandidate.label !== "") {
+        label = aCandidate.label;
+      } else if ( aCandidate.label == "" && defaultCandidates[aCandidate.code]) {
+        label = defaultCandidates[aCandidate.code].label;
+      }
 
       if (aCandidate) {
         option = $("<option/>", {
-          text: aCandidate.code,
+          text: label ? label : aCandidate.code,
           value: aCandidate.code
         }).appendTo(selector);
       }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -503,9 +503,9 @@ var EventsView = function(userProfile, options) {
         label = defaultCandidates[aCandidate.code].label;
       }
 
-      if (aCandidate) {
+      if (label && aCandidate) {
         option = $("<option/>", {
-          text: label ? label : aCandidate.code,
+          text: label,
           value: aCandidate.code
         }).appendTo(selector);
       }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -476,6 +476,36 @@ var EventsView = function(userProfile, options) {
     $("#select-" + type).val(currentId);
   }
 
+  function setIncidentStatusFilter(selector, addEmptyItem) {
+    var candidates = self.customIncidentStatusesMap;
+    var option;
+    var x;
+    var selectedCandidates = {};
+    var currentId = $(selector).val();
+
+    $(selector).empty();
+
+    if (addEmptyItem) {
+      option = $("<option/>", {
+        text: "--------------------",
+        value: "",
+      }).appendTo(selector);
+    }
+
+    $.map(candidates, function(aCandidate) {
+      var option;
+
+      if (aCandidate) {
+        option = $("<option/>", {
+          text: aCandidate.code,
+          value: aCandidate.code
+        }).appendTo(selector);
+      }
+    });
+
+    $(selector).val(currentId);
+  }
+
   function setupFilterValues(servers, query) {
     var serverId = $("#select-server").val();
     var filterId = $("#select-filter").val();
@@ -490,9 +520,11 @@ var EventsView = function(userProfile, options) {
 
     self.setupHostFilters(servers, query);
 
-    resetEventPropertyFilter(filterConfig, "incident", true);
     resetEventPropertyFilter(filterConfig, "type", true);
     resetEventPropertyFilter(filterConfig, "severity", false);
+    setIncidentStatusFilter("#select-incident", true);
+    setIncidentStatusFilter("#change-incident", true);
+    setupChangeIncidentMenu();
 
     removeUnselectableFilterCandidates(filterConfig, "server");
     if (serverId) {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -476,7 +476,7 @@ var EventsView = function(userProfile, options) {
     $("#select-" + type).val(currentId);
   }
 
-  function setIncidentStatusFilter(selector, addEmptyItem) {
+  function setupIncidentStatusSelectCandidates(selector, addEmptyItem) {
     var defaultCandidates = self.defaultIncidentStatusesMap;
     var candidates = self.customIncidentStatusesMap;
     var option;
@@ -530,8 +530,8 @@ var EventsView = function(userProfile, options) {
 
     resetEventPropertyFilter(filterConfig, "type", true);
     resetEventPropertyFilter(filterConfig, "severity", false);
-    setIncidentStatusFilter("#select-incident", true);
-    setIncidentStatusFilter("#change-incident", true);
+    setupIncidentStatusSelectCandidates("#select-incident", true);
+    setupIncidentStatusSelectCandidates("#change-incident", true);
     setupChangeIncidentMenu();
 
     removeUnselectableFilterCandidates(filterConfig, "server");

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -31,6 +31,7 @@ var EventsView = function(userProfile, options) {
   self.rawSeverityRankData = {};
   self.severityRanksMap = {};
   self.rawCustomIncidentStatusData = {};
+  self.customIncidentStatusesMap = {};
   self.durations = {};
   self.baseQuery = {
     limit:            50,
@@ -208,7 +209,17 @@ var EventsView = function(userProfile, options) {
       url: "/custom-incident-status",
       request: "GET",
       replyCallback: function(reply, parser) {
+        var i, customIncidentStatuses;
         self.rawCustomIncidentStatusData = reply;
+        self.customIncidentStatusesMap = {};
+        customIncidentStatuses =
+          self.rawCustomIncidentStatusData["CustomIncidentStatuses"];
+        if (customIncidentStatuses) {
+          for (i = 0; i < customIncidentStatuses.length; i++) {
+            self.customIncidentStatusesMap[customIncidentStatuses[i].code] =
+              customIncidentStatuses[i];
+          }
+        }
         deferred.resolve();
       },
       parseErrorCallback: function() {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -488,7 +488,7 @@ var EventsView = function(userProfile, options) {
 
     if (addEmptyItem) {
       option = $("<option/>", {
-        text: "--------------------",
+        text: "---------",
         value: "",
       }).appendTo(selector);
     }

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -42,6 +42,32 @@ describe('EventsView', function() {
     "apiVersion":4,
     "errorCode":0
   }
+  var dummyIncidentStatuses = {
+    "apiVersion": 4,
+    "errorCode": 0,
+    "CustomIncidentStatuses": [
+      {
+        "id": 1,
+        "code": "NONE",
+        "label": ""
+      },
+      {
+        "id": 2,
+        "code": "IN PROGRESS",
+        "label": ""
+      },
+      {
+        "id": 3,
+        "code": "HOLD",
+        "label": ""
+      },
+      {
+        "id": 4,
+        "code": "DONE",
+        "label": ""
+      },
+    ]
+  };
   var testOptions = {
     disableTimeRangeFilter: true,
   };
@@ -125,11 +151,18 @@ describe('EventsView', function() {
                     summaryJson);
   }
 
+  function respondIncidentStatuses(incidentStatusesJson) {
+    var request = this.requests[5];
+    request.respond(200, { "Content-Type": "application/json" },
+                    incidentStatusesJson);
+  }
+
   function respond(eventsJson, configJson) {
     respondUserConfig(configJson);
     respondSeverityRank();
     respondEvents(eventsJson);
     respondSummary(JSON.stringify(dummySummary));
+    respondIncidentStatuses(JSON.stringify(dummyIncidentStatuses));
   }
 
   function getDummyServerInfo(type){

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -139,30 +139,30 @@ describe('EventsView', function() {
                     severityRanksJson());
   }
 
-  function respondEvents(eventsJson) {
+  function respondIncidentStatuses(incidentStatusesJson) {
     var request = this.requests[3];
+    request.respond(200, { "Content-Type": "application/json" },
+                    incidentStatusesJson);
+  }
+
+  function respondEvents(eventsJson) {
+    var request = this.requests[4];
     request.respond(200, { "Content-Type": "application/json" },
                     eventsJson);
   }
 
   function respondSummary(summaryJson) {
-    var request = this.requests[4];
-    request.respond(200, { "Content-Type": "application/json" },
-                    summaryJson);
-  }
-
-  function respondIncidentStatuses(incidentStatusesJson) {
     var request = this.requests[5];
     request.respond(200, { "Content-Type": "application/json" },
-                    incidentStatusesJson);
+                    summaryJson);
   }
 
   function respond(eventsJson, configJson) {
     respondUserConfig(configJson);
     respondSeverityRank();
+    respondIncidentStatuses(JSON.stringify(dummyIncidentStatuses));
     respondEvents(eventsJson);
     respondSummary(JSON.stringify(dummySummary));
-    respondIncidentStatuses(JSON.stringify(dummyIncidentStatuses));
   }
 
   function getDummyServerInfo(type){


### PR DESCRIPTION
If users set up custom incident labels like this...:

![screenshot from 2015-11-19 15 23 58](https://cloud.githubusercontent.com/assets/700876/11263820/b450a860-8ed1-11e5-8b01-ea0d65603837.png)

In events view, these values are used in tables and select box like these:

![screenshot from 2015-11-19 15 25 20](https://cloud.githubusercontent.com/assets/700876/11263840/ea6313e8-8ed1-11e5-93af-455896f42cbb.png)

![screenshot from 2015-11-19 15 26 40](https://cloud.githubusercontent.com/assets/700876/11263856/0a489124-8ed2-11e5-9543-1831981cca65.png)


### NOTE

* from NONE to DONE are always shown and be able to use
* from USER01 to USER06 are only shown when label is defined