### PR TITLE
[RestResourceServer] Clear plugin path when HAPI2 passiveMode

### DIFF
--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -489,6 +489,9 @@ static HatoholError parseServerParameter(
 			  HatoholArmPluginGate::PassivePluginQuasiPath;
 #endif
 		}
+		if (passiveMode && svInfo.type == MONITORING_SYSTEM_HAPI2) {
+			armPluginInfo.path.clear();
+		}
 	}
 
 	// brokerUrl


### PR DESCRIPTION
When using HAPI2 and selected `passive mode`, it should clear `armPluginInfo.path`.
Otherwise, detect code for HAPI2 passive mode, such as `path.empty()`, is meaningless.

Related to #1733.

With this patch, hatohol server can recognize HAP2 passive mode like these:

![screenshot from 2015-11-20 15 53 09](https://cloud.githubusercontent.com/assets/700876/11293633/1381eb96-8f9f-11e5-83a9-e5874ff89acf.png)

![screenshot from 2015-11-20 15 53 55](https://cloud.githubusercontent.com/assets/700876/11293635/16f34856-8f9f-11e5-9ab3-f6d5fae7ee6f.png)
