### PR TITLE
[Server] Accept user-defined incident statuses 

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1220,19 +1220,18 @@ var EventsView = function(userProfile, options) {
 
   function setupStatictics() {
     // Assign/UnAssign events statistics
-    var numOfUnAssignedEvents = self.rawSummaryData["numOfUnAssignedEvents"];
+    var numOfImportantEvents = self.rawSummaryData["numOfImportantEvents"];
+    var numOfUnAssignedEvents = self.rawSummaryData["numOfUnAssignedImportantEvents"];
+    var numOfAssignedEvents = numOfImportantEvents - numOfUnAssignedEvents;
     $("#numOfUnAssignedEvents").text(numOfUnAssignedEvents);
-    var numOfAssignedEvents = self.rawSummaryData["numOfAssignedEvents"];
-    var totalNumOfAssignEvents = numOfUnAssignedEvents + numOfAssignedEvents;
     var unAssignedEventsPercentage = 0;
-    if (totalNumOfAssignEvents > 0)
+    if (numOfImportantEvents > 0)
       unAssignedEventsPercentage =
-        (numOfUnAssignedEvents / totalNumOfAssignEvents * 100).toFixed(2);
+        (numOfUnAssignedEvents / numOfImportantEvents * 100).toFixed(2);
     $("#unAssignedEventsPercentage").text(unAssignedEventsPercentage + "%");
     $("#unAssignedEventsPercentage").css("width", unAssignedEventsPercentage+"%");
 
     // Important/NotImportant events statistics
-    var numOfImportantEvents = self.rawSummaryData["numOfImportantEvents"];
     $("#numOfImportantEvents").text(numOfImportantEvents);
     var numOfImportantEventOccurredHosts =
           self.rawSummaryData["numOfImportantEventOccurredHosts"];

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -217,27 +217,6 @@ typedef std::list<MonitoringServerStatus> MonitoringServerStatusList;
 typedef MonitoringServerStatusList::iterator MonitoringServerStatusListIterator;
 typedef MonitoringServerStatusList::const_iterator MonitoringServerStatusListConstIterator;
 
-enum class Status {
-	NONE,
-	HOLD,
-	IN_PROGRESS,
-	DONE,
-	USER_DEFINED_BEGIN
-};
-
-struct StatusDef {
-	Status status;
-	std::string indicator;
-	std::string label;
-};
-
-static const StatusDef definedStatuses[] = {
-	{ Status::NONE,        "",  "NONE" },
-	{ Status::HOLD,        "H", "HOLD" },
-	{ Status::IN_PROGRESS, "P", "IN PROGRESS" },
-	{ Status::DONE,        "*", "DONE" },
-};
-
 struct IncidentInfo {
 	typedef enum {
 		STATUS_UNKNOWN,

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -48,8 +48,8 @@ struct IncidentSenderHatohol::Impl
 
 	bool isKnownStatus(const string &status)
 	{
-		for (size_t i = 0; i < ARRAY_SIZE(systemDefinedStatuses); i++) {
-			if (status == systemDefinedStatuses[i])
+		for (auto &definedStatus: systemDefinedStatuses) {
+			if (status == definedStatus)
 				return true;
 		}
 

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -46,13 +46,17 @@ struct IncidentSenderHatohol::Impl
 	{
 	}
 
-	bool isKnownStatus(const string &status) {
+	bool isKnownStatus(const string &status)
+	{
 		for (size_t i = 0; i < ARRAY_SIZE(systemDefinedStatuses); i++) {
-			if (status == systemDefinedStatuses[i]) {
+			if (status == systemDefinedStatuses[i])
 				return true;
-			}
 		}
-		return false;
+
+		UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+		std::map<string, CustomIncidentStatus> customStatuses =
+		  dataStore->getCustomIncidentStatusesCache();
+		return customStatuses.find(status) != customStatuses.end();
 	}
 
 	HatoholError validate(const IncidentInfo &incident)

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -24,6 +24,18 @@
 using namespace std;
 using namespace mlpl;
 
+const string IncidentSenderHatohol::STATUS_NONE("NONE");
+const string IncidentSenderHatohol::STATUS_HOLD("HOLD");
+const string IncidentSenderHatohol::STATUS_IN_PROGRESS("IN PROGRESS");
+const string IncidentSenderHatohol::STATUS_DONE("DONE");
+
+static const string definedStatuses[] = {
+	IncidentSenderHatohol::STATUS_NONE,
+	IncidentSenderHatohol::STATUS_HOLD,
+	IncidentSenderHatohol::STATUS_IN_PROGRESS,
+	IncidentSenderHatohol::STATUS_DONE,
+};
+
 struct IncidentSenderHatohol::Impl
 {
 	Impl(IncidentSenderHatohol &sender)
@@ -36,7 +48,7 @@ struct IncidentSenderHatohol::Impl
 
 	bool isKnownStatus(const string &status) {
 		for (size_t i = 0; i < ARRAY_SIZE(definedStatuses); i++) {
-			if (status == definedStatuses[i].label) {
+			if (status == definedStatuses[i]) {
 				return true;
 			}
 		}
@@ -73,7 +85,7 @@ struct IncidentSenderHatohol::Impl
 		incidentInfo.triggerId = eventInfo.triggerId;
 		incidentInfo.identifier = StringUtils::toString(eventInfo.unifiedId);
 		incidentInfo.location = "";
-		incidentInfo.status = definedStatuses[0].label;
+		incidentInfo.status = STATUS_NONE;
 		incidentInfo.priority = "";
 		incidentInfo.assignee = "";
 		incidentInfo.doneRatio = 0;

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -29,7 +29,7 @@ const string IncidentSenderHatohol::STATUS_HOLD("HOLD");
 const string IncidentSenderHatohol::STATUS_IN_PROGRESS("IN PROGRESS");
 const string IncidentSenderHatohol::STATUS_DONE("DONE");
 
-static const string definedStatuses[] = {
+static const string systemDefinedStatuses[] = {
 	IncidentSenderHatohol::STATUS_NONE,
 	IncidentSenderHatohol::STATUS_HOLD,
 	IncidentSenderHatohol::STATUS_IN_PROGRESS,
@@ -47,8 +47,8 @@ struct IncidentSenderHatohol::Impl
 	}
 
 	bool isKnownStatus(const string &status) {
-		for (size_t i = 0; i < ARRAY_SIZE(definedStatuses); i++) {
-			if (status == definedStatuses[i]) {
+		for (size_t i = 0; i < ARRAY_SIZE(systemDefinedStatuses); i++) {
+			if (status == systemDefinedStatuses[i]) {
 				return true;
 			}
 		}

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -34,6 +34,15 @@ struct IncidentSenderHatohol::Impl
 	{
 	}
 
+	bool isKnownStatus(const string &status) {
+		for (size_t i = 0; i < ARRAY_SIZE(definedStatuses); i++) {
+			if (status == definedStatuses[i].label) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	HatoholError validate(const IncidentInfo &incident)
 	{
 		const IncidentTrackerInfo &tracker
@@ -45,14 +54,7 @@ struct IncidentSenderHatohol::Impl
 			return HatoholError(HTERR_INVALID_PARAMETER, message);
 		}
 
-		bool knownStatus = false;
-		for (size_t i = 0; i < ARRAY_SIZE(definedStatuses); i++) {
-			if (incident.status == definedStatuses[i].label) {
-				knownStatus = true;
-				break;
-			}
-		}
-		if (!knownStatus) {
+		if (!isKnownStatus(incident.status)) {
 			string message(StringUtils::sprintf(
 			  "Unknown status: %s", incident.status.c_str()));
 			return HatoholError(HTERR_INVALID_PARAMETER, message);

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -54,8 +54,8 @@ struct IncidentSenderHatohol::Impl
 		}
 
 		UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-		std::map<string, CustomIncidentStatus> customStatuses =
-		  dataStore->getCustomIncidentStatusesCache();
+		map<string, CustomIncidentStatus> customStatuses;
+		dataStore->getCustomIncidentStatusesCache(customStatuses);
 		return customStatuses.find(status) != customStatuses.end();
 	}
 

--- a/server/src/IncidentSenderHatohol.h
+++ b/server/src/IncidentSenderHatohol.h
@@ -25,6 +25,11 @@
 class IncidentSenderHatohol : public IncidentSender
 {
 public:
+	static const std::string STATUS_NONE;
+	static const std::string STATUS_HOLD;
+	static const std::string STATUS_IN_PROGRESS;
+	static const std::string STATUS_DONE;
+
 	IncidentSenderHatohol(const IncidentTrackerInfo &tracker);
 	virtual ~IncidentSenderHatohol();
 

--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -95,17 +95,11 @@ void RestResourceSummary::handlerSummary(void)
 	int64_t numOfAllHosts =
 	  dataStore->getNumberOfHosts(hostsOption);
 
-	EventsQueryOption assignedEventOption(option);
-	std::set<std::string> assignedStatusSet, unAssignedStatusSet;
-	assignedStatusSet.insert(IncidentSenderHatohol::STATUS_IN_PROGRESS.c_str());
-	assignedStatusSet.insert(IncidentSenderHatohol::STATUS_DONE.c_str());
-	assignedEventOption.setIncidentStatuses(assignedStatusSet);
-	int64_t numOfAssignedEvents =
-	  dataStore->getNumberOfEvents(assignedEventOption);
-
 	EventsQueryOption unAssignedEventOption(option);
+	std::set<std::string> unAssignedStatusSet;
 	unAssignedStatusSet.insert(IncidentSenderHatohol::STATUS_NONE.c_str());
 	unAssignedStatusSet.insert(IncidentSenderHatohol::STATUS_HOLD.c_str());
+	unAssignedEventOption.setTriggerSeverities(importantStatusSet);
 	unAssignedEventOption.setIncidentStatuses(unAssignedStatusSet);
 	int64_t numOfUnAssignedEvents =
 	  dataStore->getNumberOfEvents(unAssignedEventOption);
@@ -118,8 +112,7 @@ void RestResourceSummary::handlerSummary(void)
 	reply.add("numOfNotImportantEvents", numOfNotImportantEvents);
 	reply.add("numOfAllHosts",
 		  numOfAllHosts);
-	reply.add("numOfAssignedEvents", numOfAssignedEvents);
-	reply.add("numOfUnAssignedEvents", numOfUnAssignedEvents);
+	reply.add("numOfUnAssignedImportantEvents", numOfUnAssignedEvents);
 	reply.startArray("statistics");
 	for (auto &statistics : severityStatisticsVect) {
 		reply.startObject();

--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -20,6 +20,7 @@
 #include "RestResourceSummary.h"
 #include "RestResourceHostUtils.h"
 #include "UnifiedDataStore.h"
+#include "IncidentSenderHatohol.h"
 
 typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceSummary>
   RestResourceSummaryFactory;
@@ -96,15 +97,15 @@ void RestResourceSummary::handlerSummary(void)
 
 	EventsQueryOption assignedEventOption(option);
 	std::set<std::string> assignedStatusSet, unAssignedStatusSet;
-	assignedStatusSet.insert(definedStatuses[static_cast<int>(Status::IN_PROGRESS)].label.c_str());
-	assignedStatusSet.insert(definedStatuses[static_cast<int>(Status::DONE)].label.c_str());
+	assignedStatusSet.insert(IncidentSenderHatohol::STATUS_IN_PROGRESS.c_str());
+	assignedStatusSet.insert(IncidentSenderHatohol::STATUS_DONE.c_str());
 	assignedEventOption.setIncidentStatuses(assignedStatusSet);
 	int64_t numOfAssignedEvents =
 	  dataStore->getNumberOfEvents(assignedEventOption);
 
 	EventsQueryOption unAssignedEventOption(option);
-	unAssignedStatusSet.insert(definedStatuses[static_cast<int>(Status::NONE)].label.c_str());
-	unAssignedStatusSet.insert(definedStatuses[static_cast<int>(Status::HOLD)].label.c_str());
+	unAssignedStatusSet.insert(IncidentSenderHatohol::STATUS_NONE.c_str());
+	unAssignedStatusSet.insert(IncidentSenderHatohol::STATUS_HOLD.c_str());
 	unAssignedEventOption.setIncidentStatuses(unAssignedStatusSet);
 	int64_t numOfUnAssignedEvents =
 	  dataStore->getNumberOfEvents(unAssignedEventOption);

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -354,6 +354,7 @@ UnifiedDataStore::~UnifiedDataStore()
 void UnifiedDataStore::reset(void)
 {
 	stop();
+	m_impl->customIncidentStatusMap.clear();
 }
 
 UnifiedDataStore *UnifiedDataStore::getInstance(void)

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -325,13 +325,13 @@ struct UnifiedDataStore::Impl
 
 		CustomIncidentStatusesQueryOption option(USER_ID_SYSTEM);
 		UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-		std::vector<CustomIncidentStatus> customStatuses;
+		vector<CustomIncidentStatus> customStatuses;
 		dataStore->getCustomIncidentStatuses(customStatuses, option);
 		for (auto &customStatus: customStatuses)
 			customIncidentStatusMap[customStatus.code] = customStatus;
 	}
 
-	void getCustomIncidentStatusMap(map<std::string, CustomIncidentStatus> &map)
+	void getCustomIncidentStatusMap(map<string, CustomIncidentStatus> &map)
 	{
 		customIncidentStatusMapLock.readLock();
 		Reaper<ReadWriteLock> unlocker(&customIncidentStatusMapLock,
@@ -1090,7 +1090,7 @@ HatoholError UnifiedDataStore::updateCustomIncidentStatus(
 }
 
 HatoholError UnifiedDataStore::getCustomIncidentStatuses(
-  std::vector<CustomIncidentStatus> &customIncidentStatusVect,
+  vector<CustomIncidentStatus> &customIncidentStatusVect,
   const CustomIncidentStatusesQueryOption &option)
 {
 	ThreadLocalDBCache cache;

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -341,8 +341,8 @@ public:
 	HatoholError deleteCustomIncidentStatuses(
 	  std::list<CustomIncidentStatusIdType> &idList,
 	  const OperationPrivilege privilege);
-	std::map<std::string, CustomIncidentStatus> &
-	  getCustomIncidentStatusesCache(void);
+	void getCustomIncidentStatusesCache(
+	  std::map<std::string, CustomIncidentStatus> &customIncidentStatusMap);
 
 protected:
 	void fetchItems(const ServerIdType &targetServerId = ALL_SERVERS);

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -341,6 +341,8 @@ public:
 	HatoholError deleteCustomIncidentStatuses(
 	  std::list<CustomIncidentStatusIdType> &idList,
 	  const OperationPrivilege privilege);
+	std::map<std::string, CustomIncidentStatus> &
+	  getCustomIncidentStatusesCache(void);
 
 protected:
 	void fetchItems(const ServerIdType &targetServerId = ALL_SERVERS);

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -96,8 +96,7 @@ void test_summary(void)
 	assertValueInParser(parser, "numOfImportantEventOccurredHosts", 1);
 	assertValueInParser(parser, "numOfNotImportantEvents", 6);
 	assertValueInParser(parser, "numOfAllHosts", 16);
-	assertValueInParser(parser, "numOfAssignedEvents", 0);
-	assertValueInParser(parser, "numOfUnAssignedEvents", 1);
+	assertValueInParser(parser, "numOfUnAssignedImportantEvents", 1);
 	assertStartObject(parser, "statistics");
 	{
 		size_t i = 0;


### PR DESCRIPTION
Revise #1744.

Accept user-defined incident statuses at IncidentSenderHatohol.

In addition, this PR also modifies counting assigned/unassigned important events at RestResourceSummary
because they are also concerned with incident statuses.
