### PR TITLE
[client] Suppress UnicodeWarning of Django

### DIFF
--- a/client/test/python/TestEventFiltersView.py
+++ b/client/test/python/TestEventFiltersView.py
@@ -38,6 +38,7 @@ class TestEventFiltersView(unittest.TestCase):
     def _request(self, method, id=None, body=None, POST=None, PUT=None):
         request = HttpRequest()
         request.method = method
+        request.encoding = "UTF-8"
         self._setSessionId(request)
         if PUT:
             request.META['CONTENT_TYPE'] = "application/json"

--- a/client/test/python/TestGraphsView.py
+++ b/client/test/python/TestGraphsView.py
@@ -38,6 +38,7 @@ class TestGraphsView(unittest.TestCase):
     def _request(self, method, id=None, body=None, POST=None, PUT=None):
         request = HttpRequest()
         request.method = method
+        request.encoding = "UTF-8"
         self._setSessionId(request)
         if PUT:
             request.META['CONTENT_TYPE'] = "application/json"


### PR DESCRIPTION
In the previous version, Django reports the following warning
message when a user save a new filter which includes UTF-8 string.
This modification fixes this issue by converting a bytestring to
an unicode string.

/usr/lib/python2.7/dist-packages/django/db/models/fields/__init__.py:245: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if not self.blank and value in self.empty_values:

/usr/lib/python2.7/dist-packages/django/db/models/fields/__init__.py:202: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if value in self.empty_values:

Fix #1751