### PR TITLE
[client] Remove broken styles

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -40,16 +40,6 @@ div.hatohol-pager {
   text-align: center;
 }
 
-li {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-ul {
-  display: inline-block;
-  vertical-align: middle;
-}
-
 div.dialog {
   display: none;
 }


### PR DESCRIPTION
In the previous version following styles are applied to all ul &
li elements. It breaks the layout of navbar.

  display: inline-block;
  vertical-align: middle;

The above style is introduces at 29cac9bf to align "Latest events"
button and pager buttons. But it's not needed anymore because
"Latest events" button has been moved to other place.