### PR TITLE
[EventsView] Use the default candidates for the drop down menu of inc…

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -486,6 +486,9 @@ var EventsView = function(userProfile, options) {
 
     $(selector).empty();
 
+    if (Object.keys(candidates).length == 0)
+      candidates = defaultCandidates;
+
     if (addEmptyItem) {
       option = $("<option/>", {
         text: "---------",


### PR DESCRIPTION
…ident statuses when the user-defined status list is empty

It's a rare case because initial user-defined statuses are inserted
by hatohol-db-initiator and they never be removed, though.