### PR TITLE
[RestResourceSummary] Correct wrong count of important events

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1225,8 +1225,8 @@ var EventsView = function(userProfile, options) {
   function setupStatictics() {
     // Assign/UnAssign events statistics
     var numOfImportantEvents = self.rawSummaryData["numOfImportantEvents"];
-    var numOfUnAssignedEvents = self.rawSummaryData["numOfUnAssignedImportantEvents"];
-    var numOfAssignedEvents = numOfImportantEvents - numOfUnAssignedEvents;
+    var numOfAssignedEvents = self.rawSummaryData["numOfAssignedImportantEvents"];
+    var numOfUnAssignedEvents = numOfImportantEvents - numOfAssignedEvents;
     $("#numOfUnAssignedEvents").text(numOfUnAssignedEvents);
     var unAssignedEventsPercentage = 0;
     if (numOfImportantEvents > 0)

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1235,7 +1235,7 @@ var EventsView = function(userProfile, options) {
     $("#unAssignedEventsPercentage").text(unAssignedEventsPercentage + "%");
     $("#unAssignedEventsPercentage").css("width", unAssignedEventsPercentage+"%");
 
-    // Important/NotImportant events statistics
+    // Important events statistics
     $("#numOfImportantEvents").text(numOfImportantEvents);
     var numOfImportantEventOccurredHosts =
           self.rawSummaryData["numOfImportantEventOccurredHosts"];

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -376,7 +376,7 @@ var EventsView = function(userProfile, options) {
     baseFilter = self.userConfig.getFilter(baseFilterId);
     $.extend(query, baseFilter);
 
-    return 'summary?' + $.param(query);
+    return 'summary/important-event?' + $.param(query);
   }
 
   function load(options) {

--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -100,10 +100,10 @@ void RestResourceSummary::handlerSummary(void)
 	}
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	EventsQueryOption option(m_dataQueryContextPtr);
+	EventsQueryOption userFilter(m_dataQueryContextPtr);
 	bool isCountOnly = false;
 	HatoholError err =
-	  RestResourceHostUtils::parseEventParameter(option, m_query, isCountOnly);
+	  RestResourceHostUtils::parseEventParameter(userFilter, m_query, isCountOnly);
 	if (err != HTERR_OK) {
 		replyError(err);
 		return;
@@ -112,7 +112,7 @@ void RestResourceSummary::handlerSummary(void)
 	std::set<TriggerSeverityType> importantSeveritySet;
 	getImportantSeveritySet(m_dataQueryContextPtr, importantSeveritySet);
 
-	EventsQueryOption importantEventOption(option);
+	EventsQueryOption importantEventOption(userFilter);
 	importantEventOption.setTriggerSeverities(importantSeveritySet);
 	int64_t numOfImportantEvents =
 	  dataStore->getNumberOfEvents(importantEventOption);
@@ -131,9 +131,9 @@ void RestResourceSummary::handlerSummary(void)
 	int64_t numOfAllHosts =
 	  dataStore->getNumberOfHosts(hostsOption);
 
-	EventsQueryOption assignedEventOption(option);
+	EventsQueryOption assignedEventOption(userFilter);
 	assignedEventOption.setTriggerSeverities(importantSeveritySet);
-	setAssignedIncidentStatusCondition(assignedEventOption, option);
+	setAssignedIncidentStatusCondition(assignedEventOption, userFilter);
 	int64_t numOfAssignedEvents =
 	  dataStore->getNumberOfEvents(assignedEventOption);
 

--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -27,14 +27,15 @@ using namespace std;
 typedef FaceRestResourceHandlerSimpleFactoryTemplate<RestResourceSummary>
   RestResourceSummaryFactory;
 
-const char *RestResourceSummary::pathForSummary = "/summary";
+const char *RestResourceSummary::pathForImportantEventSummary
+  = "/summary/important-event";
 
 void RestResourceSummary::registerFactories(FaceRest *faceRest)
 {
 	faceRest->addResourceHandlerFactory(
-	  pathForSummary,
+	  pathForImportantEventSummary,
 	  new RestResourceSummaryFactory(
-	        faceRest, &RestResourceSummary::handlerSummary));
+	        faceRest, &RestResourceSummary::handlerImportantEventSummary));
 }
 
 RestResourceSummary::RestResourceSummary(
@@ -116,7 +117,7 @@ static void setAssignedIncidentStatusCondition(
 	option.setIncidentStatuses(assignedStatusSet);
 }
 
-void RestResourceSummary::handlerSummary(void)
+void RestResourceSummary::handlerImportantEventSummary(void)
 {
 	if (!httpMethodIs("GET")) {
 		MLPL_ERR("Unknown method: %s\n", m_message->method);

--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -86,11 +86,9 @@ void RestResourceSummary::handlerSummary(void)
 	SeverityRankQueryOption severityRankOption(m_dataQueryContextPtr);
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	SeverityRankInfoVect importantSeverityRanks, notImportantSeverityRanks;
+	SeverityRankInfoVect importantSeverityRanks;
 	severityRankOption.setTargetAsImportant(static_cast<int>(true));
 	dataStore->getSeverityRanks(importantSeverityRanks, severityRankOption);
-	severityRankOption.setTargetAsImportant(static_cast<int>(false));
-	dataStore->getSeverityRanks(notImportantSeverityRanks, severityRankOption);
 	bool isCountOnly = false;
 	HatoholError err =
 	  RestResourceHostUtils::parseEventParameter(option, m_query, isCountOnly);
@@ -100,7 +98,7 @@ void RestResourceSummary::handlerSummary(void)
 	}
 
 	EventsQueryOption importantEventOption(option);
-	std::set<TriggerSeverityType> importantStatusSet, notImportantStatusSet;
+	std::set<TriggerSeverityType> importantStatusSet;
 	for (auto &severityRank : importantSeverityRanks) {
 		importantStatusSet.insert(static_cast<TriggerSeverityType>(severityRank.status));
 	}
@@ -118,13 +116,6 @@ void RestResourceSummary::handlerSummary(void)
 		return;
 	}
 
-	EventsQueryOption notImportantEventOption(option);
-	for (auto &severityRank : notImportantSeverityRanks) {
-		notImportantStatusSet.insert(static_cast<TriggerSeverityType>(severityRank.status));
-	}
-	notImportantEventOption.setTriggerSeverities(notImportantStatusSet);
-	int64_t numOfNotImportantEvents =
-	  dataStore->getNumberOfEvents(notImportantEventOption);
 	HostsQueryOption hostsOption(m_dataQueryContextPtr);
 	int64_t numOfAllHosts =
 	  dataStore->getNumberOfHosts(hostsOption);
@@ -140,7 +131,6 @@ void RestResourceSummary::handlerSummary(void)
 	reply.add("numOfImportantEvents", numOfImportantEvents);
 	reply.add("numOfImportantEventOccurredHosts",
 		  numOfImportantEventOccurredHosts);
-	reply.add("numOfNotImportantEvents", numOfNotImportantEvents);
 	reply.add("numOfAllHosts",
 		  numOfAllHosts);
 	reply.add("numOfAssignedImportantEvents", numOfAssignedEvents);

--- a/server/src/RestResourceSummary.h
+++ b/server/src/RestResourceSummary.h
@@ -27,12 +27,12 @@ struct RestResourceSummary : public RestResourceMemberHandler
 public:
 	typedef void (RestResourceSummary::*HandlerFunc)(void);
 
-	static const char *pathForSummary;
+	static const char *pathForImportantEventSummary;
 
 	static void registerFactories(FaceRest *faceRest);
 
 	RestResourceSummary(FaceRest *faceRest, HandlerFunc handler);
-	void handlerSummary(void);
+	void handlerImportantEventSummary(void);
 };
 
 #endif // RestResourceSummary_h

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -87,7 +87,7 @@ void test_summary(void)
 	};
 
 	startFaceRest();
-	RequestArg arg("/summary");
+	RequestArg arg("/summary/important-event");
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	unique_ptr<JSONParser> parserPtr(getResponseAsJSONParser(arg));
 	JSONParser *parser = parserPtr.get();

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -94,7 +94,6 @@ void test_summary(void)
 	assertErrorCode(parser);
 	assertValueInParser(parser, "numOfImportantEvents", 1);
 	assertValueInParser(parser, "numOfImportantEventOccurredHosts", 1);
-	assertValueInParser(parser, "numOfNotImportantEvents", 6);
 	assertValueInParser(parser, "numOfAllHosts", 16);
 	assertValueInParser(parser, "numOfAssignedImportantEvents", 0);
 	assertStartObject(parser, "statistics");

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -111,4 +111,27 @@ void test_summary(void)
 	parser->endObject();
 }
 
+void test_summaryWithSeveritiesFilter(void)
+{
+	loadTestDBSeverityRankInfo();
+	loadTestDBEvents();
+	loadTestDBIncidents();
+	loadTestDBIncidentTracker();
+	loadUnAssignedIncidentInfo();
+
+	startFaceRest();
+	RequestArg arg("/summary/important-event?severities=0%21");
+	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
+	unique_ptr<JSONParser> parserPtr(getResponseAsJSONParser(arg));
+	JSONParser *parser = parserPtr.get();
+	assertErrorCode(parser);
+	assertValueInParser(parser, "numOfImportantEvents", 0);
+	assertValueInParser(parser, "numOfImportantEventOccurredHosts", 0);
+	assertValueInParser(parser, "numOfAllHosts", 16);
+	assertValueInParser(parser, "numOfAssignedImportantEvents", 0);
+	assertStartObject(parser, "statistics");
+	cppcut_assert_equal(static_cast<unsigned int>(0), parser->countElements());
+	parser->endObject();
+}
+
 } // namespace testFaceRestSummary

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -120,7 +120,7 @@ void test_summaryWithSeveritiesFilter(void)
 	loadUnAssignedIncidentInfo();
 
 	startFaceRest();
-	RequestArg arg("/summary/important-event?severities=0%21");
+	RequestArg arg("/summary/important-event?severities=0%2C1");
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
 	unique_ptr<JSONParser> parserPtr(getResponseAsJSONParser(arg));
 	JSONParser *parser = parserPtr.get();

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -96,7 +96,7 @@ void test_summary(void)
 	assertValueInParser(parser, "numOfImportantEventOccurredHosts", 1);
 	assertValueInParser(parser, "numOfNotImportantEvents", 6);
 	assertValueInParser(parser, "numOfAllHosts", 16);
-	assertValueInParser(parser, "numOfUnAssignedImportantEvents", 1);
+	assertValueInParser(parser, "numOfAssignedImportantEvents", 0);
 	assertStartObject(parser, "statistics");
 	{
 		size_t i = 0;


### PR DESCRIPTION
* Replcae numOfUnAssignedImportantEvents with numOfAssignedImportantEvents
    * Because all unknown statuses should be treated as "UnAssigned"
* Apply "AND" condition against user filter & important severities
* Apply "AND" condition against user filter & "assigned" incident statuses
* Change the path of the REST resource to accentuate "important" condition
    * /summary -> /summary/important-events
* Remove unused property: numOfNotImportantEvents
