### PR TITLE
[EventsView] Support toggle abbreviating event descriptions feature

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -318,6 +318,11 @@ h2.hatohol-graph {
     margin-bottom: -3px;
 }
 
+.abbreviate-checkbox {
+    margin-top: -3px !important;
+    margin-left: 15px !important;
+}
+
 .calendar-group {
     margin-top: -15px;
 }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -623,6 +623,7 @@ var EventsView = function(userProfile, options) {
       resetQuickFilter();
     });
 
+    $("#toggle-abbreviating-event-descriptions").attr("checked", false);
     $("#toggle-abbreviating-event-descriptions").change(function() {
       self.abbreviateDescription = $(this).is(":checked");
       load();

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -624,7 +624,7 @@ var EventsView = function(userProfile, options) {
     });
 
     $("#toggle-abbreviating-event-descriptions").change(function() {
-      self.abbreviateDescription = !self.abbreviateDescription;
+      self.abbreviateDescription = $(this).is(":checked");
       load();
     });
   }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -620,6 +620,9 @@ var EventsView = function(userProfile, options) {
       setupFilterValues();
       resetQuickFilter();
     });
+
+    $("#toggle-abbreviating-event-descriptions").change(function() {
+    });
   }
 
   function updateIncidentStatus() {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -46,7 +46,6 @@ var EventsView = function(userProfile, options) {
   self.lastQuickFilter = {};
   self.showToggleAutoRefreshButton();
   self.setupToggleAutoRefreshButtonHandler(load, self.reloadIntervalSeconds);
-  self.abbreviateDescription = false;
   self.abbreviateDescriptionLength = 30;
 
   setupEventsTable();
@@ -625,7 +624,6 @@ var EventsView = function(userProfile, options) {
 
     $("#toggle-abbreviating-event-descriptions").attr("checked", false);
     $("#toggle-abbreviating-event-descriptions").change(function() {
-      self.abbreviateDescription = $(this).is(":checked");
       load();
     });
   }
@@ -908,7 +906,7 @@ var EventsView = function(userProfile, options) {
     } catch(e) {
     }
 
-    if (self.abbreviateDescription) {
+    if ($("#toggle-abbreviating-event-descriptions").is(":checked")) {
       return name ? abbreviateDescription(name) : abbreviateDescription(event["brief"]);
     } else {
       return name ? name : event["brief"];

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -46,6 +46,8 @@ var EventsView = function(userProfile, options) {
   self.lastQuickFilter = {};
   self.showToggleAutoRefreshButton();
   self.setupToggleAutoRefreshButtonHandler(load, self.reloadIntervalSeconds);
+  self.abbreviateDescription = false;
+  self.abbreviateDescriptionLength = 30;
 
   setupEventsTable();
   setupToggleFilter();
@@ -622,6 +624,8 @@ var EventsView = function(userProfile, options) {
     });
 
     $("#toggle-abbreviating-event-descriptions").change(function() {
+      self.abbreviateDescription = !self.abbreviateDescription;
+      load();
     });
   }
 
@@ -887,6 +891,10 @@ var EventsView = function(userProfile, options) {
     return  hostId == "__SELF_MONITOR";
   }
 
+  function abbreviateDescription(description) {
+    return description.substr(0, self.abbreviateDescriptionLength) + " ...";
+  }
+
   function getEventDescription(event) {
     var extendedInfo, name;
 
@@ -895,8 +903,13 @@ var EventsView = function(userProfile, options) {
       name = extendedInfo["expandedDescription"];
     } catch(e) {
     }
-    return name ? name : event["brief"];
-  }
+    if (self.abbreviateDescription) {
+      return name ? abbreviateDescription(name) : abbreviateDescription(event["brief"]);
+    }
+    else {
+      return name ? name : event["brief"];
+    }
+  };
 
   function getIncident(event) {
     if (!self.rawData["haveIncident"])

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -906,10 +906,10 @@ var EventsView = function(userProfile, options) {
       name = extendedInfo["expandedDescription"];
     } catch(e) {
     }
+
     if (self.abbreviateDescription) {
       return name ? abbreviateDescription(name) : abbreviateDescription(event["brief"]);
-    }
-    else {
+    } else {
       return name ? name : event["brief"];
     }
   };

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -892,7 +892,10 @@ var EventsView = function(userProfile, options) {
   }
 
   function abbreviateDescription(description) {
-    return description.substr(0, self.abbreviateDescriptionLength) + " ...";
+    if (description.length > self.abbreviateDescriptionLength)
+      return description.substr(0, self.abbreviateDescriptionLength) + " ...";
+    else
+      return description;
   }
 
   function getEventDescription(event) {

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -199,8 +199,8 @@
               </select>
 	    </div>
 	    <div class="filter-element">
-              <p><label>{% trans "Abbreviate Event Descriptions:" %}</label></p>
-	      <input class="form-control" type="checkbox" id="toggle-abbreviating-event-descriptions"></input>
+	      <p><input class="form-control abbreviate-checkbox" type="checkbox" id="toggle-abbreviating-event-descriptions"></input>
+              <label>{% trans "Abbreviate Event Descriptions" %}</label></p>
 	    </div>
       	  </form>
 	</div>

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -198,6 +198,10 @@
 		<option value="HOLD">{% trans "HOLD" %}</option>
               </select>
 	    </div>
+	    <div class="filter-element">
+              <p><label>{% trans "Abbreviate Event Descriptions:" %}</label></p>
+	      <input class="form-control" type="checkbox" id="toggle-abbreviating-event-descriptions"></input>
+	    </div>
       	  </form>
 	</div>
       </div>


### PR DESCRIPTION
Default checkbox state is unchecked:

![screenshot from 2015-11-27 17 15 05](https://cloud.githubusercontent.com/assets/700876/11436697/70ebc47e-952a-11e5-8329-83925291f565.png)

When this checked, event descriptions are abbreviated like this:

![screenshot from 2015-11-27 17 17 23](https://cloud.githubusercontent.com/assets/700876/11436746/d24cd12c-952a-11e5-969c-b8b6decad2a9.png)


