### PR TITLE
[HatoholArmPluginGateHAPI2] Fix memory corruption due to rvalue reference variable lifetime

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -666,7 +666,7 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 	struct UpsertLastInfoHook : public DBAgent::TransactionHooks {
 		Impl &impl;
-		const LastInfoType &type;
+		const LastInfoType type;
 		string lastInfo;
 
 		UpsertLastInfoHook(Impl &_impl, const LastInfoType &_type)


### PR DESCRIPTION
Because `LAST_INFO_XXX` constants are rvalue(temporary value).
Thus, these constants will be destroyed after following constructor finished:

```cpp
Impl::UpsertLastInfoHook lastInfoUpserter(*m_impl, LAST_INFO_HOST);
```

Hence, lastInfoUpserter refers corrupted memory region and inserts wrong
`data_type` value.

We SHOULD store its copy into UpsertLastInfoHook member variable.

Related to https://github.com/project-hatohol/hatohol/issues/1769.