### PR TITLE
[client] Rebranding mechanism

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/django.po
+++ b/client/conf/locale/ja/LC_MESSAGES/django.po
@@ -186,8 +186,8 @@ msgid "Total"
 msgstr "合計"
 
 #: viewer/events_ajax.html:24 viewer/events_ajax.html.py:36
-msgid "Hatohol Event Console"
-msgstr "Hatohol イベントコンソール"
+msgid "Event Console"
+msgstr "イベントコンソール"
 
 #: viewer/events_ajax.html:32
 msgid "Config"

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -228,3 +228,6 @@ ENABLED_PAGES = (
     #"http://www.hatohol.org/docs"
     #"#version"
 )
+
+BRAND_NAME = "Hatohol"
+VENDOR_NAME = "Project Hatohol"

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -230,4 +230,10 @@ ENABLED_PAGES = (
 )
 
 BRAND_NAME = "Hatohol"
+
 VENDOR_NAME = "Project Hatohol"
+
+# The file name of your logo file.
+# Put it under "{{ STATIC_URL }}/images/" to show it onto navbar.
+# When the value is empty, BRAND_NAME will be shown instead.
+BRAND_LOGO_FILE = ""

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -19,6 +19,7 @@
 # Django settings for hatohol project.
 import os
 import logging
+from branding_settings import *
 
 PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -228,12 +229,3 @@ ENABLED_PAGES = (
     #"http://www.hatohol.org/docs"
     #"#version"
 )
-
-BRAND_NAME = "Hatohol"
-
-VENDOR_NAME = "Project Hatohol"
-
-# The file name of your logo file.
-# Put it under "{{ STATIC_URL }}/images/" to show it onto navbar.
-# When the value is empty, BRAND_NAME will be shown instead.
-BRAND_LOGO_FILE = ""

--- a/client/hatohol/branding_settings.py
+++ b/client/hatohol/branding_settings.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2015 Project Hatohol
+#
+# This file is part of Hatohol.
+#
+# Hatohol is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License, version 3
+# as published by the Free Software Foundation.
+#
+# Hatohol is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Hatohol. If not, see
+# <http://www.gnu.org/licenses/>.
+
+BRAND_NAME = "Hatohol"
+
+VENDOR_NAME = "Project Hatohol"
+
+# The file name of your logo image.
+# Put the file under "{{ STATIC_URL }}/images/" to show it onto navbar.
+# When the value is empty, BRAND_NAME will be shown instead.
+BRAND_LOGO_FILE = ""

--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -20,6 +20,19 @@
 /* Override jQuery's default values to overcome bootstrap's style */
 .ui-front { z-index: 2000 !important }
 
+/* Brand on navigation bar */
+.navbar-brand {
+  float: left;
+  height: 32px;
+  padding: 8px 15px;
+  font-size: 30px;
+  line-height: 32px;
+}
+
+.navbar-brand img {
+  height: 32px;
+}
+
 div.copyright {
     text-align: center;
     margin-top: 2em;

--- a/client/static/js/hatohol_navi.js
+++ b/client/static/js/hatohol_navi.js
@@ -112,7 +112,7 @@ var HatoholNavi = function(userProfile, currentPage) {
           href: "http://www.hatohol.org/docs"
         },
         {
-          title: gettext("Hatohol version: ") + HATOHOL_VERSION,
+          title: hatohol.brandName + " " + gettext("version: ") + HATOHOL_VERSION,
           href: "#version"
         },
       ]

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -402,6 +402,8 @@ function hasFlags(flags, flagNumbers) {
   }
 
   var hatohol = Namespace("hatohol");
+  hatohol.brandName = "Hatohol";
+  hatohol.vendorName = "Project Hatohol";
   hatohol.addNamespace = Namespace;
   hatohol.isIPv4 = isIPv4;
   hatohol.escapeHTML = escapeHTML;

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -44,7 +44,11 @@
   <body style="padding-top: 60px">
 
     <div class="navbar navbar-inverse navbar-fixed-top">
-      <a class="navbar-brand">&nbsp;<i>{{ brand_name }}</i>&nbsp;</a>
+      {% if brand_logo_file %}
+        <a class="navbar-brand"><img alt="{{ brand_name }}" src="{{ STATIC_URL }}images/{{ brand_logo_file }}"></a>
+      {% else %}
+        <a class="navbar-brand">&nbsp;<i>{{ brand_name }}</i>&nbsp;</a>
+      {% endif %}
       <ul class="nav navbar-nav">
       </ul>
 
@@ -132,6 +136,7 @@
 
       hatohol.brandName = "{{ brand_name }}";
       hatohol.vendorName = "{{ vendor_name }}";
+      hatohol.brandLogoPath = "{{ brand_logo_path }}";
       hatohol.enabledPages = {
         {% for page in enabled_pages %}
           "{{ page }}": true,

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -37,14 +37,14 @@
     <link href="{{ STATIC_URL }}css.external/spectrum.css" rel="stylesheet" media="screen">
 
     <title>
-      {% block title %}{% endblock %} - {% trans "Hatohol" %}
+      {% block title %}{% endblock %} - {{ brand_name }}
     </title>
   </head>
 
   <body style="padding-top: 60px">
 
     <div class="navbar navbar-inverse navbar-fixed-top">
-      <a class="navbar-brand">&nbsp;<i>{% trans "Hatohol" %}</i>&nbsp;</a>
+      <a class="navbar-brand">&nbsp;<i>{{ brand_name }}</i>&nbsp;</a>
       <ul class="nav navbar-nav">
       </ul>
 
@@ -130,6 +130,8 @@
       var userProfile;
       var params = deparam();
 
+      hatohol.brandName = "{{ brand_name }}";
+      hatohol.vendorName = "{{ vendor_name }}";
       hatohol.enabledPages = {
         {% for page in enabled_pages %}
           "{{ page }}": true,
@@ -154,7 +156,5 @@
 
 {% block logic %}
 {% endblock %}
-
-    <div class="copyright">Copyright &copy; 2013-2015 Project Hatohol</div>
   </body>
 </html>

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -21,7 +21,7 @@
 {% endcomment %}
 
 {% block title %}
-{% trans "Hatohol Event Console" %}
+{{ brand_name }} {% trans "Event Console" %}
 {% endblock %}
 
 {% block main %}
@@ -33,7 +33,7 @@
     </button>
   </div>
 
-  <h2 style="margin-left: 20px;">{% trans "Hatohol Event Console" %}</h2>
+  <h2 style="margin-left: 20px;">{{ brand_name }} {% trans "Event Console" %}</h2>
 
   <hr>
   <div class="col-sm-3 col-md-2 sidebar" id="SummarySidebar" style="display: none;">

--- a/client/viewer/views.py
+++ b/client/viewer/views.py
@@ -14,8 +14,10 @@ class HatoholView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HatoholView, self).get_context_data(**kwargs)
         context.update({
+            'brand_name' : settings.BRAND_NAME,
+            'vendor_name' : settings.VENDOR_NAME,
+            'enabled_pages': settings.ENABLED_PAGES,
             'plugin_js_files': self.plugin_js_files,
             'project_top_path': self.request.META.get("SCRIPT_NAME", ""),
-            'enabled_pages': settings.ENABLED_PAGES,
         })
         return context

--- a/client/viewer/views.py
+++ b/client/viewer/views.py
@@ -16,6 +16,7 @@ class HatoholView(TemplateView):
         context.update({
             'brand_name' : settings.BRAND_NAME,
             'vendor_name' : settings.VENDOR_NAME,
+            'brand_logo_file' : settings.BRAND_LOGO_FILE,
             'enabled_pages': settings.ENABLED_PAGES,
             'plugin_js_files': self.plugin_js_files,
             'project_top_path': self.request.META.get("SCRIPT_NAME", ""),


### PR DESCRIPTION
This modification makes easy to replace the brand name & logo.

If you want to use your own brand name & logo, modify client/hatohol/branding_settings.py
then put your logo image to /static/images in your site.
