### PR TITLE
[test][Helpers] Add a new magic column for checking the content.

### DIFF
--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -730,6 +730,8 @@ static void assertDBContentForComponets(const string &expect,
 	for (size_t i = 0; i < wordsExpect.size(); i++) {
 		if (wordsExpect[i] == DBCONTENT_MAGIC_CURR_DATETIME) {
 			assertCurrDatetime(wordsActual[i]);
+		} else if (wordsExpect[i] == DBCONTENT_MAGIC_CURR_TIME) {
+			assertCurrDatetime(atoi(wordsActual[i].c_str()));
 		} else if(wordsExpect[i] == DBCONTENT_MAGIC_ANY) {
 			// just pass
 		} else if(wordsExpect[i] == DBCONTENT_MAGIC_NULL) {

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -35,6 +35,7 @@
 #include "ArmStatus.h"
 
 #define DBCONTENT_MAGIC_CURR_DATETIME "#CURR_DATETIME#"
+#define DBCONTENT_MAGIC_CURR_TIME     "#CURR_TIME#"
 #define DBCONTENT_MAGIC_NULL          "#NULL#"
 #define DBCONTENT_MAGIC_ANY           "#ANY#"
 


### PR DESCRIPTION
A newly added magic column: DBCONTENT_MAGIC_CURR_TIME enables
a unix time to be tested.