### PR TITLE
[server][SessionManager] Address an invalid memory access after reset().

### DIFF
--- a/server/src/SessionManager.cc
+++ b/server/src/SessionManager.cc
@@ -115,6 +115,7 @@ size_t SessionManager::Impl::defaultTimeout = INITIAL_TIMEOUT;
 // ---------------------------------------------------------------------------
 void SessionManager::reset(void)
 {
+	getInstance()->m_impl->clearAllSessions();
 	delete Impl::instance;
 	Impl::instance = NULL;
 
@@ -131,8 +132,6 @@ void SessionManager::reset(void)
 		MLPL_INFO("Default session timeout: %zd (sec)\n",
 		          Impl::defaultTimeout);
 	}
-
-	getInstance()->m_impl->clearAllSessions();
 }
 
 SessionManager *SessionManager::getInstance(void)
@@ -191,6 +190,7 @@ bool SessionManager::remove(const string &sessionId)
 	m_impl->rwlock.unlock();
 	if (!session)
 		return false;
+	session->cancelTimer();
 	session->unref();
 	return true;
 }


### PR DESCRIPTION
Previously session timer is alive after reset(). And reset() also
recreates a SessonManager instance that is refered by the timer
handler. As a result, invalid memory access may happen.

This patch fixed the bug.
***

Note that  one of the test on TravisCI failed. However, no valgrind reported invalid memory access for all the test on my environment. So the cause of the failure doesn't seem to be related with the SessionManger.  