### PR TITLE
[test][DBAgent] Fix the access to unitialized variable.

### DIFF
--- a/server/test/testDBAgent.cc
+++ b/server/test/testDBAgent.cc
@@ -28,8 +28,25 @@ using namespace mlpl;
 
 namespace testDBAgent {
 
+static void initColumnDef(ColumnDef &colDef)
+{
+	colDef.columnName = NULL;
+	colDef.type = SQL_COLUMN_TYPE_INT,
+	colDef.columnLength = 11;
+	colDef.decFracLength = 0;
+	colDef.canBeNull = false;
+	colDef.keyType = SQL_KEY_NONE;
+	colDef.flags = 0;
+	colDef.defaultValue = "0";
+}
+
 class TestDBAgent : public DBAgent {
 public:
+	TestDBAgent(void)
+	{
+		for (auto &colDef : m_testColumnDefs)
+			initColumnDef(colDef);
+	}
 
 	void assertCreateTableProfile(void)
 	{


### PR DESCRIPTION
Without this patch, Valgrind reports the problem like

==18336== Conditional jump or move depends on uninitialised value(s)
==18336==    at 0x794E8B4: DBAgent::TableProfile::TableProfile(char const*, ColumnDef const*, unsigned long const&, DBAgent::IndexDef const*) (DBAgent.cc:93)
==18336==    by 0xB0D887C: void testDBAgent::TestDBAgent::assertUpdateArgAdd<long, int>(long const*, unsigned long const&) (testDBAgent.cc:277)
==18336==    by 0xB0CAC0D: testDBAgent::test_updateArgAddTime_t() (testDBAgent.cc:594)
==18336==    by 0x4E7E26C: ??? (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7449F: ??? (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7455D: cut_test_case_run_with_filter (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7C2F4: ??? (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7C818: ??? (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7CBAA: cut_test_suite_run_with_filter (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E7C0B0: ??? (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E6BB5B: cut_runner_run (in /usr/lib/libcutter.so.0.1.0)
==18336==    by 0x4E6B2B0: cut_run_context_start (in /usr/lib/libcutter.so.0.1.0)