### PR TITLE
[server][SelfMonitor] Add a new class to monitor Hatohol internals (＃1745)

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -31,6 +31,7 @@ enum TriggerStatusType {
 	TRIGGER_STATUS_OK,
 	TRIGGER_STATUS_PROBLEM,
 	TRIGGER_STATUS_UNKNOWN,
+	NUM_TRIGGER_STATUS,
 };
 
 enum TriggerSeverityType {
@@ -104,6 +105,7 @@ typedef TriggerIdInfoMap::const_iterator       TriggerIdInfoMapConstIterator;
 typedef std::list<TriggerIdType> TriggerIdList;
 
 enum EventType {
+	EVENT_TYPE_AUTO = -2,
 	EVENT_TYPE_ALL = -1,
 	EVENT_TYPE_GOOD,
 	EVENT_TYPE_BAD,
@@ -138,6 +140,7 @@ typedef std::list<EventInfo>          EventInfoList;
 typedef EventInfoList::iterator       EventInfoListIterator;
 typedef EventInfoList::const_iterator EventInfoListConstIterator;
 
+// TODO: Remove after the new SelfMonitoring replaces the old ArmUtils' one.
 static const EventIdType DISCONNECT_SERVER_EVENT_ID = "";
 
 enum ItemInfoValueType {

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -74,6 +74,7 @@ libhatohol_la_SOURCES = \
 	RestResourceSeverityRank.cc RestResourceSeverityRank.h \
 	RestResourceSummary.cc RestResourceSummary.h \
 	RestResourceUser.cc RestResourceUser.h \
+	SelfMonitor.cc SelfMonitor.h \
 	SessionManager.cc SessionManager.h \
 	SQLProcessorTypes.h \
 	SQLUtils.cc SQLUtils.h \

--- a/server/src/SelfMonitor.cc
+++ b/server/src/SelfMonitor.cc
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <SmartTime.h>
+#include <algorithm>
+#include <mutex>
+#include <Reaper.h>
+#include "SelfMonitor.h"
+#include "ThreadLocalDBCache.h"
+#include "UnifiedDataStore.h"
+using namespace std;
+using namespace mlpl;
+
+struct SelfMonitor::Impl
+{
+	TriggerInfo        triggerInfo;
+
+	/**
+	 * The last status other than TRIGGER_STATUS_UNKNOWN.
+	 * I.e. TRIGGER_STATUS_OK or TRIGGER_STATUS_PROBLEM.
+	 */
+	TriggerStatusType  lastKnownStatus;
+
+	/**
+	 * The last status set by update(). This can be updated even when
+	 * isWorkable() is false, althogh the visible status is
+	 * TRIGGER_STATUS_PROBLEM.
+	 */
+	TriggerStatusType  actualStatus;
+
+	SelfMonitorWeakPtrList listeners;
+	EventGenerator eventGenerators[NUM_TRIGGER_STATUS][NUM_TRIGGER_STATUS];
+	NotificationHandler notificationHandler;
+	bool                inUpdating;
+	bool                workable;
+	bool                inSetWorkableCall;
+
+	Impl(const ServerIdType &serverId,
+	     const TriggerIdType &triggerId,
+	     const string &brief,
+	     const TriggerSeverityType &severity)
+	: lastKnownStatus(TRIGGER_STATUS_UNKNOWN),
+	  actualStatus(TRIGGER_STATUS_UNKNOWN),
+	  notificationHandler([](
+	    SelfMonitor &, const SelfMonitor &,
+	    const TriggerStatusType &, const TriggerStatusType &){}),
+	  inUpdating(false),
+	  workable(true),
+	  inSetWorkableCall(false)
+	{
+		initEventGenerators();
+		setupTriggerInfo(serverId, triggerId, brief, severity);
+	}
+
+	bool hasTriggerId(void)
+	{
+		return !triggerInfo.id.empty();
+	}
+
+	TriggerStatusType unworkableVisibleStatus(void)
+	{
+		// We use NUM_TRIGGER_STATUS for the meaning.
+		return TRIGGER_STATUS_UNKNOWN;
+	}
+
+	void setupTriggerInfo(const ServerIdType &serverId,
+	                      const TriggerIdType &triggerId,
+	                      const string &brief,
+	                      const TriggerSeverityType &severity)
+	{
+		triggerInfo.serverId = serverId;
+		triggerInfo.id = triggerId;
+		triggerInfo.status = TRIGGER_STATUS_UNKNOWN;
+		triggerInfo.severity = severity;
+		triggerInfo.lastChangeTime =
+		  SmartTime::getCurrTime().getAsTimespec();
+		triggerInfo.globalHostId = INAPPLICABLE_HOST_ID;
+		triggerInfo.hostIdInServer = MONITORING_SELF_LOCAL_HOST_ID;
+		triggerInfo.hostName = "(SELF MONITOR)";
+
+		triggerInfo.brief = brief;
+		triggerInfo.extendedInfo.clear();
+		triggerInfo.validity = TRIGGER_VALID_SELF_MONITORING;
+
+		ThreadLocalDBCache cache;
+		cache.getMonitoring().addTriggerInfo(&triggerInfo);
+	}
+
+	void initEventGenerators(void)
+	{
+		auto nullFunc = [](SelfMonitor &monitor,
+		                   const TriggerStatusType &prevStatus,
+		                   const TriggerStatusType &newStatus) {};
+
+		for (auto &generatorArray : eventGenerators) {
+			for (auto &generator : generatorArray)
+				generator = nullFunc;
+		}
+	}
+
+	EventType calcEventType(const TriggerStatusType &trigStatus)
+	{
+		EventType evtType = EVENT_TYPE_UNKNOWN;
+		if (trigStatus == TRIGGER_STATUS_OK)
+			evtType = EVENT_TYPE_GOOD;
+		else
+			evtType = EVENT_TYPE_BAD;
+		return evtType;
+	}
+};
+
+// TODO: This is easy implementation that uses big lock.
+//       We want to replace it with a more efficient way.
+static recursive_mutex updateLock;
+
+// ---------------------------------------------------------------------------
+// Public methods
+// ---------------------------------------------------------------------------
+SelfMonitor::SelfMonitor(
+  const ServerIdType &serverId,
+  const TriggerIdType &triggerId,
+  const string &brief,
+  const TriggerSeverityType &severity)
+: m_impl(new Impl(serverId, triggerId, brief, severity))
+{
+}
+
+SelfMonitor::~SelfMonitor()
+{
+}
+
+void SelfMonitor::setEventGenerator(
+  const TriggerStatusType &prevStatus, const TriggerStatusType &newStatus,
+  SelfMonitor::EventGenerator generator)
+{
+	auto setupRange = [](const TriggerStatusType &st,
+	                     TriggerStatusType &begin, TriggerStatusType &end)
+	{
+		if (st == TRIGGER_STATUS_ALL) {
+			begin = static_cast<TriggerStatusType>(0);
+			end = NUM_TRIGGER_STATUS;
+		} else {
+			begin = st;
+			end = static_cast<TriggerStatusType>(st + 1);
+		}
+	};
+
+	TriggerStatusType prevBegin, prevEnd, newBegin, newEnd;
+	setupRange(prevStatus, prevBegin, prevEnd);
+	setupRange(newStatus, newBegin, newEnd);
+
+	for (int pst = prevBegin; pst != prevEnd; ++pst) {
+		for (int nst = newBegin; nst != newEnd; ++nst)
+			m_impl->eventGenerators[pst][nst] = generator;
+	}
+}
+
+void SelfMonitor::setNotificationHandler(NotificationHandler handler)
+{
+	m_impl->notificationHandler = handler;
+}
+
+void SelfMonitor::update(const TriggerStatusType &_status)
+{
+	// Prevent other threads from running this method concurrently
+	lock_guard<recursive_mutex> lock(updateLock);
+
+	HATOHOL_ASSERT(!m_impl->inUpdating, "Detetec a circular listening.");
+	Reaper<bool> eraser(&m_impl->inUpdating, [](bool *bp){*bp = false;});
+	m_impl->inUpdating = true;
+
+	TriggerStatusType status = _status;
+	if (!m_impl->inSetWorkableCall)
+		m_impl->actualStatus = status;
+	if (!m_impl->workable)
+		status = m_impl->unworkableVisibleStatus();
+
+	if (status != TRIGGER_STATUS_UNKNOWN)
+		m_impl->lastKnownStatus = status;
+
+	TriggerStatusType prevStatus = m_impl->triggerInfo.status;
+	m_impl->triggerInfo.status = status;
+	onUpdated(status, prevStatus);
+
+	if (m_impl->hasTriggerId()) {
+		ThreadLocalDBCache cache;
+		cache.getMonitoring().addTriggerInfo(&m_impl->triggerInfo);
+	}
+
+	generateEvent(prevStatus, status);
+
+	SelfMonitorWeakPtrList::iterator listenerIt = m_impl->listeners.begin();
+	while (listenerIt != m_impl->listeners.end()) {
+		auto listener = listenerIt->lock();
+		if (listener) {
+			listener->onNotified(*this, prevStatus, status);
+			++listenerIt;
+		} else {
+			// Delete a deleleted listener.
+			listenerIt = m_impl->listeners.erase(listenerIt);
+		}
+	}
+}
+
+TriggerStatusType SelfMonitor::getLastKnownStatus(void) const
+{
+	return m_impl->lastKnownStatus;
+}
+
+void SelfMonitor::saveEvent(const string &brief, const EventType &eventType)
+{
+	// TODO: Set once for members that never change
+	EventInfoList eventList;
+	eventList.push_back(EventInfo());
+	EventInfo &eventInfo = eventList.back();
+	initEventInfo(eventInfo);
+
+	const TriggerInfo &triggerInfo = m_impl->triggerInfo;
+	eventInfo.serverId = triggerInfo.serverId;
+	eventInfo.id = "";
+	eventInfo.time =
+	  SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
+
+	if (eventType != EVENT_TYPE_AUTO)
+		eventInfo.type = eventType;
+	else
+		eventInfo.type = m_impl->calcEventType(triggerInfo.status);
+
+	eventInfo.triggerId = triggerInfo.id;
+
+	eventInfo.status = triggerInfo.status;
+	eventInfo.severity = triggerInfo.severity;
+	eventInfo.globalHostId = triggerInfo.globalHostId;
+	eventInfo.hostIdInServer = triggerInfo.hostIdInServer;
+	eventInfo.hostName = triggerInfo.hostName;
+	if (!brief.empty())
+		eventInfo.brief = brief;
+	else
+		eventInfo.brief = triggerInfo.brief;
+	eventInfo.extendedInfo = triggerInfo.extendedInfo;
+
+	// We have to use UnifiedDataStore::addEventList
+	// (not DBTablesMonitoring method directly) to work
+	// Action mechanism. Therefore, we use EventInfoList
+	// although we save only one event.
+	UnifiedDataStore::getInstance()->addEventList(eventList);
+}
+
+void SelfMonitor::setWorkable(const bool &workable)
+{
+	Reaper<bool> clean(&m_impl->inSetWorkableCall,
+	                   [](bool *b){ *b = false;});
+	m_impl->inSetWorkableCall = true;
+	m_impl->workable = workable;
+	if (workable)
+		update(m_impl->actualStatus);
+	else
+		update(m_impl->unworkableVisibleStatus());
+}
+
+void SelfMonitor::addNotificationListener(SelfMonitorPtr monitor)
+{
+	m_impl->listeners.push_back(monitor);
+}
+
+void SelfMonitor::generateEvent(const TriggerStatusType &prevStatus,
+                                const TriggerStatusType &newStatus)
+{
+	auto generator = m_impl->eventGenerators[prevStatus][newStatus];
+	generator(*this, prevStatus, newStatus);
+}
+
+void SelfMonitor::onUpdated(const TriggerStatusType &prevStatus,
+                            const TriggerStatusType &newStatus)
+{
+}
+
+void SelfMonitor::onNotified(const SelfMonitor &srcMonitor,
+                             const TriggerStatusType &prevStatus,
+                             const TriggerStatusType &newStatus)
+{
+	auto handler = m_impl->notificationHandler;
+	handler(*this, srcMonitor, prevStatus, newStatus);
+}

--- a/server/src/SelfMonitor.h
+++ b/server/src/SelfMonitor.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SelfMonitor_h
+#define SelfMonitor_h
+
+#include <list>
+#include <memory>
+#include <UsedCountable.h>
+#include <Monitoring.h>
+
+class SelfMonitor;
+typedef std::shared_ptr<SelfMonitor> SelfMonitorPtr;
+typedef std::weak_ptr<SelfMonitor> SelfMonitorWeakPtr;
+
+class SelfMonitor {
+public:
+	typedef std::function<void (
+	          SelfMonitor &monitor,
+	          const TriggerStatusType &prevStatus,
+	          const TriggerStatusType &newStatus)
+	> EventGenerator;
+
+	typedef std::function<void (
+	          SelfMonitor &monitor, const SelfMonitor &srcMonitor,
+	          const TriggerStatusType &prevStatus,
+	          const TriggerStatusType &newStatus)
+	> NotificationHandler;
+
+	SelfMonitor(
+	  const ServerIdType &serverId,
+	  const TriggerIdType &triggerId,
+	  const std::string &brief,
+	  const TriggerSeverityType &severity = TRIGGER_SEVERITY_UNKNOWN);
+	virtual ~SelfMonitor();
+
+	void setEventGenerator(const TriggerStatusType &prevStatus,
+	                       const TriggerStatusType &newStatus,
+	                       EventGenerator generator);
+	void setNotificationHandler(NotificationHandler handler);
+
+	void update(const TriggerStatusType &status);
+	TriggerStatusType getLastKnownStatus(void) const;
+	void saveEvent(const std::string &brief = "",
+	               const EventType &eventType = EVENT_TYPE_AUTO);
+
+	/**
+	 * Set the workable status.
+	 * This feature is typically used, for example, when the propagation
+	 * path has an error and the target status beyond the path cannot be
+	 * obtained.
+	 *
+	 * @param workable
+	 * When true is given, the instance works normally. This is default
+	 * status. Once false is set, the trigger status becomes
+	 * TRIGGER_STATUS_UNKNOWN. Then true is set, the trigger status
+	 * changes to the status given by the last update().
+	 * Note that these changes invokes the processings and callbacks
+	 * similary to the call of update().
+	 *
+	 */
+	void setWorkable(const bool &workable);
+
+	/**
+	 * Add a SelfMonitor instance. The given monitor instance here can be
+	 * deleted while this instance is alive without any operation to this
+	 * instance.
+	 *
+	 * @param monitor A shared_pointer of SelfMonitor instance.
+	 * When update() of this instance is called, the given monitor's
+	 * onNotified is invoked().
+	 */
+	void addNotificationListener(SelfMonitorPtr monitor);
+
+	/**
+	 * Called in update(). The default behavior is calling the
+	 * registered handler set by setEventGenerator().
+	 * If this method is overridden, the behavior doesn't naturally.
+	 */
+	virtual void generateEvent(const TriggerStatusType &prevStatus,
+	                           const TriggerStatusType &newStatus);
+
+	virtual void onUpdated(const TriggerStatusType &prevStatus,
+	                       const TriggerStatusType &newStatus);
+
+	/**
+	 * This method is called back when the status of the SelfMonitor
+	 * instance of which this instance has called addNotificationLister()
+	 * is updated.
+	 *
+	 * The default behavior is calling a handler registered by
+	 * setNotificaitionHandler(). Don't override this method,
+	 * if the mechanism is used.
+	 *
+	 * @param srcMonitor A SelfMonitor instance of the the status chagned
+	 * @param prevStatus A previous status.
+	 * @param newStatus  A new status.
+	 */
+	virtual void onNotified(const SelfMonitor &srcMonitor,
+	                        const TriggerStatusType &prevStatus,
+	                        const TriggerStatusType &newStatus);
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
+typedef std::list<SelfMonitorWeakPtr> SelfMonitorWeakPtrList;
+
+#endif // SelfMonitor_h

--- a/server/test/Makefile.am
+++ b/server/test/Makefile.am
@@ -81,6 +81,7 @@ testHatohol_la_SOURCES = \
 	testJSONParser.cc testJSONBuilder.cc testUtils.cc \
 	testJSONParserPositionStack.cc \
 	testNamedPipe.cc \
+	testSelfMonitor.cc \
 	testArmUtils.cc testArmBase.cc \
 	testArmZabbixAPI.cc testArmNagiosNDOUtils.cc testArmRedmine.cc \
 	testArmStatus.cc testStatisticsCounter.cc \

--- a/server/test/testSelfMonitor.cc
+++ b/server/test/testSelfMonitor.cc
@@ -1,0 +1,430 @@
+/*
+ * Copyright (C) 2015 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <cppcutter.h>
+#include <StringUtils.h>
+#include "Helpers.h"
+#include "Hatohol.h"
+#include "DBTablesTest.h"
+#include "SelfMonitor.h"
+#include "ThreadLocalDBCache.h"
+
+using namespace std;
+using namespace mlpl;
+
+namespace testSelfMonitor {
+
+static string expectedTriggerDBContent(
+  const ServerIdType &serverId, const TriggerIdType &triggerId,
+  const string &brief,
+  const TriggerStatusType &expectedStatus = TRIGGER_STATUS_UNKNOWN)
+{
+	string expect;
+	expect += StringUtils::sprintf(
+	            "%" FMT_SERVER_ID "|%" FMT_TRIGGER_ID,
+	            serverId, triggerId.c_str());
+	expect += StringUtils::sprintf(
+	            "|%d|%d|%s|%s|%" FMT_HOST_ID,
+	            expectedStatus, TRIGGER_SEVERITY_UNKNOWN,
+	            DBCONTENT_MAGIC_CURR_TIME,
+	            DBCONTENT_MAGIC_ANY, // ns
+	            INAPPLICABLE_HOST_ID);
+	expect += StringUtils::sprintf(
+	            "|__SELF_MONITOR|(SELF MONITOR)|%s||%d\n",
+	            brief.c_str(), TRIGGER_VALID_SELF_MONITORING);
+	return expect;
+}
+
+static void trigerStatusForeach(function<void(const TriggerStatusType &)> f)
+{
+	for (int st = 0; st < NUM_TRIGGER_STATUS; st++)
+		f(static_cast<TriggerStatusType>(st));
+}
+
+static void trigerStatusDoubleForeach(
+  function<void(const TriggerStatusType &, const TriggerStatusType &)> f)
+{
+	trigerStatusForeach([&](const TriggerStatusType &s) {
+		for (int t = 0; t < NUM_TRIGGER_STATUS; t++) {
+			f(static_cast<TriggerStatusType>(s),
+			  static_cast<TriggerStatusType>(t));
+		}
+	});
+}
+
+static void trigerStatusUpdateDoubleForeach(
+  SelfMonitor &monitor,
+  function<void(const TriggerStatusType &, const TriggerStatusType &)> func1,
+  function<void(const TriggerStatusType &, const TriggerStatusType &)> func2)
+{
+	trigerStatusDoubleForeach([&](const TriggerStatusType &prev,
+	                              const TriggerStatusType &curr) {
+		monitor.update(prev);
+		func1(prev, curr);
+		monitor.update(curr);
+		func2(prev, curr);
+	});
+}
+
+static void _assertTriggerDB(const string &expect)
+{
+	ThreadLocalDBCache cache;
+	string statement = "select * from ";
+	statement += DBTablesMonitoring::TABLE_NAME_TRIGGERS;
+	statement += " ORDER BY last_change_time_sec ASC, last_change_time_ns ASC";
+	assertDBContent(&cache.getMonitoring().getDBAgent(), statement, expect);
+}
+
+#define assertTriggerDB(E,...) \
+cut_trace(_assertTriggerDB(E,##__VA_ARGS__))
+
+
+void cut_setup(void)
+{
+	hatoholInit();
+	setupTestDB();
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+void test_constructor(void)
+{
+	const ServerIdType serverId = 100;
+	const TriggerIdType triggerId = "TEST_TRIGGER_ID";
+	const string brief = "Test trigger for self monitoring.";
+	SelfMonitor monitor(serverId, triggerId, brief);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief));
+}
+
+void test_constructor_define_same_multiple()
+{
+	test_constructor();
+	test_constructor();
+}
+
+void test_constructor_define_different_multiple()
+{
+	struct {
+		ServerIdType  serverId;
+		TriggerIdType triggerId;
+		string        brief;
+	} const dataArray[] = {
+		{100, "TEST_TRIGGER_ID", "Test trigger for self monitoring."},
+		{100, "Cat cafe", "I'm  a cat."},
+		{99, "Tree", "Time and tide wait for no man."},
+	};
+
+	string expected;
+	for (auto &d: dataArray) {
+		SelfMonitor monitor(d.serverId, d.triggerId, d.brief);
+		expected += expectedTriggerDBContent(d.serverId, d.triggerId,
+		                                     d. brief);
+	}
+	assertTriggerDB(expected);
+}
+
+void test_setEventGenerator(void)
+{
+	const ServerIdType serverId = 5;
+	const TriggerIdType triggerId = "TEST_TRIGGER_ID";
+	const string brief = "Test trigger for setEventGenerator.";
+	SelfMonitor monitor(serverId, triggerId, brief);
+
+	bool called = false;
+	monitor.setEventGenerator(TRIGGER_STATUS_OK, TRIGGER_STATUS_PROBLEM,
+	  [&](SelfMonitor &m, ...) {
+		cppcut_assert_equal(&monitor, &m);
+		called = true;
+	});
+
+	trigerStatusUpdateDoubleForeach(monitor,
+	  [&](...) { called = false; },
+	  [&](const TriggerStatusType prev, const TriggerStatusType curr) {
+		const bool condP = (prev == TRIGGER_STATUS_OK);
+		const bool condC = (curr == TRIGGER_STATUS_PROBLEM);
+		cppcut_assert_equal(condP && condC, called,
+		  cut_message("prev: %d, curr: %d", prev, curr));
+	});
+}
+
+void test_setEventGeneratorWithAllTriggerStatusPrev(void)
+{
+	bool called = false;
+	SelfMonitor monitor(3, "TriggerId", "Brief");
+	monitor.setEventGenerator(TRIGGER_STATUS_ALL, TRIGGER_STATUS_PROBLEM,
+	  [&](SelfMonitor &m, ...) { called = true; });
+
+	trigerStatusUpdateDoubleForeach(monitor,
+	  [&](...) { called = false; },
+	  [&](const TriggerStatusType prev, const TriggerStatusType curr) {
+		cppcut_assert_equal(curr == TRIGGER_STATUS_PROBLEM, called);
+	});
+}
+
+void test_setEventGeneratorWithAllTriggerStatusNew(void)
+{
+	bool called = false;
+	SelfMonitor monitor(4, "TriggerId", "Brief");
+	monitor.setEventGenerator(TRIGGER_STATUS_OK, TRIGGER_STATUS_ALL,
+	  [&](SelfMonitor &m, ...) { called = true; });
+
+	trigerStatusUpdateDoubleForeach(monitor,
+	  [&](...) { called = false; },
+	  [&](const TriggerStatusType prev, const TriggerStatusType curr) {
+		cppcut_assert_equal(prev == TRIGGER_STATUS_OK, called);
+	});
+}
+
+void test_setEventGeneratorWithAllTriggerStatusBoth(void)
+{
+	bool called = false;
+	SelfMonitor monitor(4, "TriggerId", "Brief");
+	monitor.setEventGenerator(TRIGGER_STATUS_ALL, TRIGGER_STATUS_ALL,
+	  [&](SelfMonitor &m, ...) { called = true; });
+
+	trigerStatusUpdateDoubleForeach(monitor,
+	  [&](...) { called = false; },
+	  [&](const TriggerStatusType prev, const TriggerStatusType curr) {
+		cppcut_assert_equal(true, called);
+	});
+}
+
+void test_setWorkable(void)
+{
+	const ServerIdType serverId = 5;
+	const TriggerIdType triggerId = "TRIGGER !!!";
+	const string brief = "Brieeeeeeeeeeeeeeeeef";
+	SelfMonitor monitor(serverId, triggerId, brief);
+	monitor.update(TRIGGER_STATUS_OK);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_OK));
+	monitor.setWorkable(false);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_UNKNOWN));
+	monitor.setWorkable(true);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_OK));
+}
+
+void test_setWorkableChangeStatusInUnworkable(void)
+{
+	const ServerIdType serverId = 5;
+	const TriggerIdType triggerId = "TRIGGER !!!";
+	const string brief = "Brieeeeeeeeeeeeeeeeef";
+	SelfMonitor monitor(serverId, triggerId, brief);
+	monitor.update(TRIGGER_STATUS_OK);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_OK));
+	monitor.setWorkable(false);
+	monitor.update(TRIGGER_STATUS_PROBLEM);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_UNKNOWN));
+	monitor.setWorkable(true);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_PROBLEM));
+	monitor.setWorkable(false);
+	monitor.update(TRIGGER_STATUS_OK);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_UNKNOWN));
+	monitor.setWorkable(true);
+	assertTriggerDB(expectedTriggerDBContent(serverId, triggerId, brief,
+	                                         TRIGGER_STATUS_OK));
+}
+
+void test_addNotificationListener(void)
+{
+	struct RcvMonitor : public SelfMonitor {
+		SelfMonitor srcMonitor;
+		bool called;
+
+		RcvMonitor()
+		: SelfMonitor(2, "TRIG2", "Receiver"),
+		  srcMonitor(1, "TRIG1", "Source"),
+		  called(false)
+		{
+		}
+
+		void onNotified(const SelfMonitor &src,
+		                const TriggerStatusType &prevStatus,
+		                const TriggerStatusType &newStatus) override
+		{
+			cppcut_assert_equal(&srcMonitor, &src);
+			cppcut_assert_equal(TRIGGER_STATUS_UNKNOWN, prevStatus);
+			cppcut_assert_equal(TRIGGER_STATUS_OK, newStatus);
+			called = true;
+		}
+	};
+	shared_ptr<RcvMonitor> rcvMonitorPtr(new RcvMonitor());
+	SelfMonitor &srcMonitor = rcvMonitorPtr->srcMonitor;
+	srcMonitor.addNotificationListener(rcvMonitorPtr);
+	srcMonitor.update(TRIGGER_STATUS_OK);
+	cppcut_assert_equal(true, rcvMonitorPtr->called);
+}
+
+void test_setNotificationHandler(void)
+{
+	SelfMonitor srcMonitor(1, "TRIG1", "Source");
+	SelfMonitorPtr rcvMonitorPtr(new SelfMonitor(2, "TRIG2", "Receiver"));
+
+	bool called = false;
+	auto handler = [&](SelfMonitor &m, const SelfMonitor &src,
+	                   const TriggerStatusType &prevStatus,
+	                   const TriggerStatusType &newStatus)
+	{
+		cppcut_assert_equal(&srcMonitor, &src);
+		cppcut_assert_equal(rcvMonitorPtr.get(), &m);
+		cppcut_assert_equal(TRIGGER_STATUS_UNKNOWN, prevStatus);
+		cppcut_assert_equal(TRIGGER_STATUS_OK, newStatus);
+		called = true;
+	};
+	srcMonitor.addNotificationListener(rcvMonitorPtr);
+	rcvMonitorPtr->setNotificationHandler(handler);
+	srcMonitor.update(TRIGGER_STATUS_OK);
+	cppcut_assert_equal(true, called);
+}
+
+void test_eraseDeletedListener(void)
+{
+	struct RcvMonitor : public SelfMonitor {
+		bool called;
+
+		RcvMonitor(const TriggerIdType &triggerId)
+		: SelfMonitor(1, triggerId, "Receiver"),
+		  called(false)
+		{
+		}
+
+		void onNotified(const SelfMonitor &,
+		  const TriggerStatusType &, const TriggerStatusType &) override
+		{
+			called = true;
+		}
+	};
+
+	SelfMonitor srcMonitor(1, "TRIG1", "Source");
+	shared_ptr<RcvMonitor> rcvMonitor1Ptr(new RcvMonitor("R1"));
+	{
+		shared_ptr<RcvMonitor> rcvMonitor2Ptr(new RcvMonitor("R2"));
+		srcMonitor.addNotificationListener(rcvMonitor2Ptr);
+		srcMonitor.addNotificationListener(rcvMonitor1Ptr);
+
+		srcMonitor.update(TRIGGER_STATUS_OK);
+		cppcut_assert_equal(true, rcvMonitor1Ptr->called);
+		cppcut_assert_equal(true, rcvMonitor2Ptr->called);
+	}
+	rcvMonitor1Ptr->called = false;
+	srcMonitor.update(TRIGGER_STATUS_PROBLEM);
+	cppcut_assert_equal(true, rcvMonitor1Ptr->called);
+}
+
+void test_getLastKnownStatus(void)
+{
+	SelfMonitor m(1, "TRIG1", "Monitor");
+	cppcut_assert_equal(TRIGGER_STATUS_UNKNOWN, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_OK);
+	cppcut_assert_equal(TRIGGER_STATUS_OK, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_UNKNOWN);
+	cppcut_assert_equal(TRIGGER_STATUS_OK, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_PROBLEM);
+	cppcut_assert_equal(TRIGGER_STATUS_PROBLEM, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_UNKNOWN);
+	cppcut_assert_equal(TRIGGER_STATUS_PROBLEM, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_OK);
+	cppcut_assert_equal(TRIGGER_STATUS_OK, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_PROBLEM);
+	cppcut_assert_equal(TRIGGER_STATUS_PROBLEM, m.getLastKnownStatus());
+
+	m.update(TRIGGER_STATUS_OK);
+	cppcut_assert_equal(TRIGGER_STATUS_OK, m.getLastKnownStatus());
+}
+
+void test_saveEvent(void)
+{
+	const ServerIdType serverId = 123;
+	const TriggerIdType triggerId = "TRIG1";
+	const string trigBrief = "Test self monitor.";
+	const TriggerSeverityType severity = TRIGGER_SEVERITY_ERROR;
+
+	auto expectedContent = [&](
+	  UnifiedEventIdType &unifiedEventId,
+	  const EventType &expectedEventType,
+	  const TriggerStatusType expectedStatus,
+	  const string &expectedEventBrief) {
+		string s;
+		s += StringUtils::sprintf(
+		  "%" FMT_UNIFIED_EVENT_ID "|%" FMT_SERVER_ID "||",
+		  unifiedEventId, serverId);
+		s += StringUtils::sprintf(
+		  "%s|%s|%d|%" FMT_TRIGGER_ID "|%d|%d|" ,
+		  DBCONTENT_MAGIC_CURR_TIME, DBCONTENT_MAGIC_ANY, // ns
+		  expectedEventType, triggerId.c_str(),
+		  expectedStatus, severity);
+		s += StringUtils::sprintf(
+		  "%" FMT_HOST_ID "|__SELF_MONITOR|(SELF MONITOR)|%s|",
+		  INAPPLICABLE_HOST_ID, expectedEventBrief.c_str());
+		s += "\n";
+		unifiedEventId++;
+		return s;
+	};
+
+	SelfMonitor monitor(serverId, triggerId, trigBrief, severity);
+	const string evtBrief = "This is the test of the event.";
+	const EventType evtType = EVENT_TYPE_GOOD;
+	monitor.saveEvent(evtBrief, evtType);
+
+	string statement = "select * from ";
+	statement += DBTablesMonitoring::TABLE_NAME_EVENTS;
+	statement += " ORDER BY time_sec ASC, time_ns ASC";
+	UnifiedEventIdType uevtid = 1;
+	string expect;
+	expect += expectedContent(uevtid, evtType,
+	                          TRIGGER_STATUS_UNKNOWN, evtBrief);
+
+	ThreadLocalDBCache cache;
+	assertDBContent(&cache.getMonitoring().getDBAgent(), statement, expect);
+
+	// EVENT_TYPE_AUTO
+	const string evtBrief2 = "The 2nd Event message.";
+	monitor.update(TRIGGER_STATUS_PROBLEM);
+	monitor.saveEvent(evtBrief2);
+	expect += expectedContent(uevtid, EVENT_TYPE_BAD,
+	                          TRIGGER_STATUS_PROBLEM, evtBrief2);
+	assertDBContent(&cache.getMonitoring().getDBAgent(), statement, expect);
+
+	monitor.update(TRIGGER_STATUS_OK);
+	monitor.saveEvent(evtBrief2);
+	expect += expectedContent(uevtid, EVENT_TYPE_GOOD,
+	                          TRIGGER_STATUS_OK, evtBrief2);
+	assertDBContent(&cache.getMonitoring().getDBAgent(), statement, expect);
+
+	// event brief is empty
+	monitor.saveEvent();
+	expect += expectedContent(uevtid, EVENT_TYPE_GOOD,
+	                          TRIGGER_STATUS_OK, trigBrief);
+	assertDBContent(&cache.getMonitoring().getDBAgent(), statement, expect);
+}
+
+}; // namespace testSelfMonitor


### PR DESCRIPTION
The purpose of this class is to replace the self monitoring feature
which ArmUtils is currently in chage of. The implementation si ArmUtils
is a little complicated and it is hard to propagate status change among
self monitors. This new class is newly designed to addresses these problem.
****
The proposed code is identical to the one in the previous PR. It was just rebased.