### PR TITLE
Create hap2_starter

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -320,6 +320,9 @@ rm -rf %{buildroot}
 %{python_sitelib}/hatohol/transporters/__init__.pyc
 %{python_sitelib}/hatohol/transporters/__init__.pyo
 %{_libexecdir}/hatohol/hap2/hap2-control-functions.sh
+%{_libexecdir}/hatohol/hap2/hap2_starter.py
+%{_libexecdir}/hatohol/hap2/hap2_starter.pyc
+%{_libexecdir}/hatohol/hap2/hap2_starter.pyo
 %{_sysconfdir}/hatohol/hap2-logging.conf
 
 %files hap2-rabbitmq-connector

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -320,9 +320,9 @@ rm -rf %{buildroot}
 %{python_sitelib}/hatohol/transporters/__init__.pyc
 %{python_sitelib}/hatohol/transporters/__init__.pyo
 %{_libexecdir}/hatohol/hap2/hap2-control-functions.sh
-%{_libexecdir}/hatohol/hap2/hap2_starter.py
-%{_libexecdir}/hatohol/hap2/hap2_starter.pyc
-%{_libexecdir}/hatohol/hap2/hap2_starter.pyo
+%{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.py
+%{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.pyc
+%{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.pyo
 %{_sysconfdir}/hatohol/hap2-logging.conf
 
 %files hap2-rabbitmq-connector

--- a/server/hap2/Makefile.am
+++ b/server/hap2/Makefile.am
@@ -43,7 +43,8 @@ nobase_hatohol_hap2_SCRIPTS = \
 	hatohol/hap2_zabbix_api.py \
 	hatohol/hap2_fluentd.py \
 	hatohol/hap2_ceilometer.py \
-	hatohol/hap2_nagios_ndoutils.py
+	hatohol/hap2_nagios_ndoutils.py \
+	hatohol/hap2_starter.py
 
 EXTRA_DIST = \
 	hap2-control-functions.sh.in \

--- a/server/hap2/hap2-control-functions.sh.in
+++ b/server/hap2/hap2-control-functions.sh.in
@@ -5,7 +5,7 @@ set -e
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 
-PID_FILE_DIR="@localstatedir@/run"
+PID_FILE_DIR="@localstatedir@/run/hatohol"
 PLUGIN_DIR="@libexecdir@/hatohol/hap2"
 PLUGIN_PATH=""
 PID_FILE="${PID_FILE_DIR}/hatohol-arm-plugin-${HAPI_MONITORING_SERVER_ID}"

--- a/server/hap2/hap2-control-functions.sh.in
+++ b/server/hap2/hap2-control-functions.sh.in
@@ -34,11 +34,14 @@ prepare_plugin_options() {
     fi
 
     PLUGIN_OPTIONS="${PLUGIN_OPTIONS} --log-conf=$HAP2_LOG_CONF"
+    PLUGIN_OPTIONS="${PLUGIN_OPTIONS} --plugin-path=$PLUGIN_PATH"
+    PLUGIN_OPTIONS="${PLUGIN_OPTIONS} --server-id=$HAPI_MONITORING_SERVER_ID"
+    PLUGIN_OPTIONS="${PLUGIN_OPTIONS} --pid-file-dir=$PID_FILE_DIR"
 }
 
 check_pid_file() {
     if test -f "$PID_FILE"; then
-        PID=`cat ${PID_FILE}`
+        PID=`tail -n +2 ${PID_FILE}`
         ALIVE=`ps $PID | grep $PLUGIN_PATH | grep -v grep | wc -l`
         if test $ALIVE -ne 0; then
             echo "The plugin process already exists!"
@@ -57,23 +60,13 @@ start_plugin() {
     check_pid_file
     prepare_plugin_options
 
-    $PLUGIN_PATH $PLUGIN_OPTIONS &
-    PID=$!
+    ${PLUGIN_DIR}/hatohol/hap2_starter.py $PLUGIN_OPTIONS &
+    RESULT=$?
 
-    sleep 1
-
-    ALIVE=`ps $PID | grep $PLUGIN_PATH | grep -v grep | wc -l`
-
-    if test $ALIVE -ne 0; then
-        if test ! -e "$PID_FILE_DIR"; then
-            mkdir -p ${PID_FILE_DIR}
-        fi
-        echo -n $PID > $PID_FILE || kill $PID; exit 1
-        echo
-        echo "Succeeded to start $PLUGIN_PATH"
-        echo "PID: $PID"
+    if test $RESULT -eq 0; then
+        echo "Succeeded to execute hap2_starter.py"
     else
-        echo "Failed to start $PLUGIN_PATH"
+        echo "Failed to execute hap2_starter.py"
     fi
 }
 
@@ -82,10 +75,15 @@ stop_plugin() {
     echo "Server ID: $HAPI_MONITORING_SERVER_ID"
 
     if test -f "$PID_FILE"; then
-        PID=`cat ${PID_FILE}`
-        echo "PID: $PID"
-        if test -n $PID; then
-            kill $PID
+        STARTER_PID=`head -n +1 ${PID_FILE}`
+        HAP_PID=`tail -n +2 ${PID_FILE}`
+        echo "STARTER_PID: $STARTER_PID"
+        echo "HAP_PID: $HAP_PID"
+        if test -n $STARTER_PID; then
+            kill $STARTER_PID
+        fi
+        if test -n $HAP_PID; then
+            kill $HAP_PID
         fi
         rm -f ${PID_FILE}
         echo "Succeeded to stop $PLUGIN_PATH"

--- a/server/hap2/hatohol/hap2_starter.py
+++ b/server/hap2/hatohol/hap2_starter.py
@@ -26,10 +26,9 @@ import signal
 import logging
 import argparse
 import subprocess
-from hatohol import haplib
 
 DEFAULT_ERROR_SLEEP_TIME = 10
-logger = logging.Logger(__name__)
+logger = logging.Logger("hatohol." + __name__)
 
 def create_pid_file(pid_dir, server_id, hap_pid):
     with open("%s/hatohol-arm-plugin-%s" % (pid_dir, server_id), "w") as file:

--- a/server/hap2/hatohol/hap2_starter.py
+++ b/server/hap2/hatohol/hap2_starter.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# coding: UTF-8
+"""
+  Copyright (C) 2015 Project Hatohol
+
+  This file is part of Hatohol.
+
+  Hatohol is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License, version 3
+  as published by the Free Software Foundation.
+
+  Hatohol is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Hatohol. If not, see
+  <http://www.gnu.org/licenses/>.
+"""
+
+import os
+import sys
+import time
+import signal
+import logging
+import argparse
+import subprocess
+from hatohol import haplib
+
+DEFAULT_ERROR_SLEEP_TIME = 10
+logger = logging.Logger(__name__)
+
+def create_pid_file(pid_dir, server_id, hap_pid):
+    with open("%s/hatohol-arm-plugin-%s" % (pid_dir, server_id), "w") as file:
+        file.writelines([str(os.getpid()), "\n", str(hap_pid)])
+
+def remove_pid_file(pid_dir,server_id):
+    subprocess.call("rm %s/hatohol-arm-plugin-%s" % (pid_dir, server_id))
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plugin-path")
+    parser.add_argument("--server-id")
+    parser.add_argument("--pid-file-dir")
+    self_args, hap_args = parser.parse_known_args()
+
+    pid = os.fork()
+    if pid > 0:
+        sys.exit(0)
+
+    subprocess_args = ["python", self_args.plugin_path]
+    subprocess_args.extend(hap_args)
+
+    while True:
+        hap = subprocess.Popen(subprocess_args, preexec_fn=os.setsid, close_fds=True)
+
+        if self_args.server_id is not None and not hap.poll():
+            create_pid_file(self_args.pid_file_dir,
+                            self_args.server_id, hap.pid)
+
+        hap.wait()
+        try:
+            os.killpg(hap.pid, signal.SIGKILL)
+        except OSError:
+            logger.info("%s process was finished" % self_args.plugin_path)
+
+        if self_args.server_id is not None:
+            remove_pid_file(self_args.pid_file_dir, self_args.server_id)
+
+        logger.info("Rerun after %d sec" % DEFAULT_ERROR_SLEEP_TIME)
+        time.sleep(DEFAULT_ERROR_SLEEP_TIME)

--- a/server/hap2/hatohol/hap2_starter.py
+++ b/server/hap2/hatohol/hap2_starter.py
@@ -31,6 +31,8 @@ DEFAULT_ERROR_SLEEP_TIME = 10
 logger = logging.Logger("hatohol." + __name__)
 
 def create_pid_file(pid_dir, server_id, hap_pid):
+    if not os.path.isdir(pid_dir): os.makedirs(pid_dir)
+
     with open("%s/hatohol-arm-plugin-%s" % (pid_dir, server_id), "w") as file:
         file.writelines([str(os.getpid()), "\n", str(hap_pid)])
 

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -112,15 +112,7 @@ class StandardHap:
             exctype, value = hap.handle_exception(raises=raises)
 
         self.enable_handling_sigchld(False)
-        print "FINISH\n\n\n\n\n\n\n\n"
         sys.exit(1)
-#        if self.__main_plugin is not None:
-#            self.__main_plugin.destroy()
-#            self.__main_plugin = None
-#        if self.__poller is not None:
-#            self.__poller.terminate()
-#            self.__poller = None
-
 
     def __create_poller(self, sender, dispatcher, **kwargs):
         poller = self.create_poller(sender=sender, process_id="Poller",

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -112,7 +112,6 @@ class StandardHap:
             exctype, value = hap.handle_exception(raises=raises)
 
         self.enable_handling_sigchld(False)
-        sys.exit(1)
 
     def __create_poller(self, sender, dispatcher, **kwargs):
         poller = self.create_poller(sender=sender, process_id="Poller",

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -31,11 +31,7 @@ from hatohol import transporter
 logger = getLogger(__name__)
 
 class StandardHap:
-    DEFAULT_ERROR_SLEEP_TIME = 10
-
     def __init__(self, default_transporter="RabbitMQHapiConnector"):
-        self.__error_sleep_time = self.DEFAULT_ERROR_SLEEP_TIME
-
         parser = argparse.ArgumentParser()
         hap.initialize_logger(parser)
 
@@ -109,25 +105,22 @@ class StandardHap:
 
     def __call__(self):
         args = self.__setup()
-        while True:
-            try:
-                self.__run(args)
-            except:
-                raises = (KeyboardInterrupt, AssertionError, SystemExit)
-                exctype, value = hap.handle_exception(raises=raises)
-            else:
-                break
+        try:
+            self.__run(args)
+        except:
+            raises = (KeyboardInterrupt, AssertionError, SystemExit)
+            exctype, value = hap.handle_exception(raises=raises)
 
-            self.enable_handling_sigchld(False)
-            if self.__main_plugin is not None:
-                self.__main_plugin.destroy()
-                self.__main_plugin = None
-            if self.__poller is not None:
-                self.__poller.terminate()
-                self.__poller = None
+        self.enable_handling_sigchld(False)
+        print "FINISH\n\n\n\n\n\n\n\n"
+        sys.exit(1)
+#        if self.__main_plugin is not None:
+#            self.__main_plugin.destroy()
+#            self.__main_plugin = None
+#        if self.__poller is not None:
+#            self.__poller.terminate()
+#            self.__poller = None
 
-            logger.info("Rerun after %d sec" % self.__error_sleep_time)
-            time.sleep(self.__error_sleep_time)
 
     def __create_poller(self, sender, dispatcher, **kwargs):
         poller = self.create_poller(sender=sender, process_id="Poller",


### PR DESCRIPTION
Related to #1729 

I resolve a problem that hap2 ever creating pipe when hap restart by be mediated hap2_starter.
When main process of hap2 catches a signal(ex. SIGKILL, SIGTERM) from its child process,
hap2_starter kill all hap2 process and restart it.
As a result, hap2 reborn and pipe does not increase.