### PR TITLE
[HatoholArmPluginGateHAPI2] Use SelfMonitor instead of ArmUtils (#1745)

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.h
+++ b/server/src/HatoholArmPluginGateHAPI2.h
@@ -66,7 +66,6 @@ protected:
 	void updateSelfMonitoringTrigger(bool hasError,
 	                                 const HAPI2PluginCollectType &type,
 	                                 const HAPI2PluginErrorCode &errorCode);
-	virtual void onSetPluginInitialInfo(void) override;
 	virtual void onConnect(void) override;
 	virtual void onConnectFailure(void) override;
 	void setPluginAvailableTrigger(const HAPI2PluginCollectType &type,


### PR DESCRIPTION
The self monitoring feature by ArmUtils makes code complicated and
hard to change the status depending on the other monitors.
This patch uses the newly desgined self monitroing SelfMonitor which
address the above problems.

Patch also added one self monitoring target. The class has the
following four self monitors in the result.

(1) Internal Error (Plugin)
(2) Parse Error of JSON object from a plugin
(3) Internal Error (HatoholArmPluginGateHAPI2)
(4) Broker connection

Note: (4) is not working correctly. I will address that (#1778).