### PR TITLE
[WebUI] Show an error message when Hatohol server is not working (#1581)

### DIFF
--- a/client/static/js/hatohol_connector.js
+++ b/client/static/js/hatohol_connector.js
@@ -150,24 +150,9 @@ HatoholConnector.prototype.start = function(connectParams) {
   }
 
   function parseLoginResultWithError(XMLHttpRequest, textStatus, errorThrown) {
-    var response = XMLHttpRequest.responseText;
-    var data = $.parseJSON(response);
-    if (data) {
-      var parser = new HatoholLoginReplyParser(data);
-      if (parser.getStatus() != REPLY_STATUS.OK) {
-        var msg = gettext("Failed to login. ") + parser.getMessage();
-        hatoholErrorMsgBox(msg);
-        return;
-      }
-    } else {
-      var status = XMLHttpRequest.status;
-      if (!(status >= 200 && status < 300)) {
-        var errorMsg = "Error: " + textStatus + ": " + errorThrown;
-        var unknownErrorMsg = gettext("Failed to login. ") + errorMsg;
-        hatoholErrorMsgBox(unknownErrorMsg);
-        return;
-      }
-    }
+    var detail = "Error: " + textStatus + ": " + errorThrown;
+    var msg = gettext("Failed to login. ") + detail;
+    hatoholErrorMsgBox(msg);
   }
 
   function request() {


### PR DESCRIPTION
The previous implementation never show any message and doesn't
happen anything after the login button is puressed when the
Hatohol server is down.

Although it has the basic mechasim to show the message.
However, it's never been performed due to the exception at
$.parseJSON() with an empty data.

However, parsing the response data has been meaningless,
because parseLoginResultWithError() is called only when
the HTTP respose is NOT 200 (OK).

This patch simply show an error message when this method
is called back.