### PR TITLE
[server] Return HTTP code 200 on login failure. (#1581)

### DIFF
--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -572,14 +572,14 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	gchar *user = (gchar *)g_hash_table_lookup(job->m_query, "user");
 	if (!user) {
 		MLPL_INFO("Not found: user\n");
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
+		job->replyError(HTERR_AUTH_FAILED);
 		return;
 	}
 	gchar *password
 	  = (gchar *)g_hash_table_lookup(job->m_query, "password");
 	if (!password) {
 		MLPL_INFO("Not found: password\n");
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
+		job->replyError(HTERR_AUTH_FAILED);
 		return;
 	}
 
@@ -588,7 +588,7 @@ void FaceRest::handlerLogin(ResourceHandler *job)
 	if (userId == INVALID_USER_ID) {
 		MLPL_INFO("Failed to authenticate: Client: %s, User: %s.\n",
 			  soup_client_context_get_host(job->m_client), user);
-		job->replyError(HTERR_AUTH_FAILED, SOUP_STATUS_BAD_REQUEST);
+		job->replyError(HTERR_AUTH_FAILED);
 		return;
 	}
 

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -66,7 +66,7 @@ void _assertLoginFailure(
 		query["password"] = password;
 	RequestArg arg("/login", "cbname");
 	arg.parameters = query;
-	unique_ptr<JSONParser> parserPtr(getServerResponseAsJSONParserWithFailure(arg));
+	unique_ptr<JSONParser> parserPtr(getResponseAsJSONParser(arg));
 	assertErrorCode(parserPtr.get(), expectCode);
 	if (sessionId) {
 		cppcut_assert_equal(true, parserPtr.get()->read("sessionId",


### PR DESCRIPTION
The failure of login to Hatohol Server is not HTTP error.
So we should return Code 200.