### PR TITLE
[EventsView] Fix a bug that "Abbreviate Event Descriptions" check box isn't shown by default

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -181,6 +181,15 @@ input#quick-host-search-entry {
     display: inline-block;
 }
 
+div#change-incident-container {
+    display: inline-block;
+}
+
+div#abbreviating-event-descriptions-container {
+    display: inline-block;
+    margin-top: 24px;
+}
+
 div.view-layout-mock {
     display: inline-block;
     vertical-align: middle;
@@ -333,7 +342,6 @@ h2.hatohol-graph {
 
 .abbreviate-checkbox {
     margin-top: -3px !important;
-    margin-left: 15px !important;
 }
 
 .calendar-group {

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -198,9 +198,14 @@
 		<option value="HOLD">{% trans "HOLD" %}</option>
               </select>
 	    </div>
+      	  </form>
+	</div>
+
+	<div id="abbreviating-event-descriptions-container">
+	  <form class="form-inline hatohol-filter-toolbar">
 	    <div class="filter-element">
 	      <p><input class="form-control abbreviate-checkbox" type="checkbox" id="toggle-abbreviating-event-descriptions"></input>
-              <label>{% trans "Abbreviate Event Descriptions" %}</label></p>
+              <label for="toggle-abbreviating-event-descriptions">{% trans "Abbreviate Event Descriptions" %}</label></p>
 	    </div>
       	  </form>
 	</div>


### PR DESCRIPTION
In the previous implementation the check box is placed in
"change-incident-container" which isn't shown when no incident
tracking system exists. But the check box should always be shown
because it's not concerned with incidents.