### PR TITLE
[hap2_zabbix_api] Enable to work with Zabbix 2.0

### DIFF
--- a/server/hap2/hatohol/test/TestZabbixApi.py
+++ b/server/hap2/hatohol/test/TestZabbixApi.py
@@ -95,14 +95,15 @@ class TestZabbixApi(unittest.TestCase):
         result = self.api.get_trigger_expand_description()
         expected = {u"result": [{u"triggerid": u"1",
                  u"description": u"test_expand_description",
-                 u"state": u"0", u"priority": u"3"}]}
+                 u"value": u"0", u"priority": u"3"}]}
 
         self.assertEquals(expected, result)
 
     def test_get_select_trigger(self):
         result = self.api.get_select_trigger("test_id")
-        expected = {u"triggerid": u"1", u"priority": u"3", u"state": u"0",
-                 u"description": u"test_expand_description"}
+        expected = {u"triggerid": u"1", u"priority": u"3", u"value": u"0",
+                    u"description": u"test_expand_description",
+                    u"hosts": [{u"hostid":u"1", u"name": u"test_host"}]}
 
         self.assertEquals(expected, result)
 

--- a/server/hap2/hatohol/test/test_urllib2.py
+++ b/server/hap2/hatohol/test/test_urllib2.py
@@ -34,13 +34,15 @@ RESULTS = {
     "hostgroup.get": [{"groupid":"1", "name":"test_name"}],
     "trigger.get": [{"triggerid":"1", "priority":"3",
                      "description":"test_description", "lastchange":"0",
-                     "hosts":[{"hostid":"1","name":"test_host"}], "state":"0"}],
+                     "hosts":[{"hostid":"1","name":"test_host"}], "value":"0"}],
     "trigger.get.expand":[{"triggerid":"1", "priority": "3",
                            "description":"test_expand_description",
-                           "state": "0"}],
+                           "value": "0"}],
+    "trigger.get.select.expand":[{"triggerid":"1", "priority": "3",
+                           "description":"test_expand_description",
+                           "hosts":[{"hostid":"1","name":"test_host"}], "value": "0"}],
     "event.get": [{"eventid":"1", "objectid":"1",
-                   "clock":"0","value":"0", "ns":"111111111",
-                   "hosts":[{"hostid":"1","name":"test_host"}]}],
+                   "clock":"0","value":"0", "ns":"111111111"}],
     "event.get.expand": [{"eventid":"1"}]
 }
 
@@ -49,6 +51,8 @@ class urllib2:
         request = json.loads(post)
         self.method = request["method"]
         if str(request["method"]) == "trigger.get":
+            if request["params"].get(u"triggerids"):
+                self.method += ".select"
             if request["params"].get(u"expandDescription"):
                 self.method += ".expand"
         if str(request["method"]) == "event.get":

--- a/server/hap2/hatohol/zabbixapi.py
+++ b/server/hap2/hatohol/zabbixapi.py
@@ -214,7 +214,7 @@ class ZabbixAPI:
             lastchange = trigger["lastchange"]
             time = Utils.translate_unix_time_to_hatohol_time(lastchange)
             triggers.append({"triggerId": trigger["triggerid"],
-                             "status": TRIGGER_STATUS[trigger["state"]],
+                             "status": TRIGGER_STATUS[trigger["value"]],
                              "severity": TRIGGER_SEVERITY[trigger["priority"]],
                              "lastChangeTime": time,
                              "hostId": trigger["hosts"][0]["hostid"],
@@ -243,8 +243,9 @@ class ZabbixAPI:
         return res_dict
 
     def get_select_trigger(self, trigger_id):
-        params = {"output": ["triggerid", "priority", "description", "state"],
-                  "triggerids": [trigger_id], "expandDescription": 1}
+        params = {"output": ["triggerid", "priority", "description", "value"],
+                  "triggerids": [trigger_id], "expandDescription": 1,
+                  "selectHosts": ["name"]}
         res_dict = self.get_response_dict("trigger.get", params,
                                           self.auth_token)
 
@@ -254,8 +255,7 @@ class ZabbixAPI:
         return res_dict["result"][0]
 
     def get_events(self, event_id_from, event_id_till=None):
-        params = {"output": "extend", "eventid_from": event_id_from,
-                  "selectHosts": ["name"]}
+        params = {"output": "extend", "eventid_from": event_id_from}
         if event_id_till is not None:
             params["eventid_till"] = event_id_till
 
@@ -274,10 +274,10 @@ class ZabbixAPI:
                            "time": time,
                            "type": EVENT_TYPE[event["value"]],
                            "triggerId": trigger["triggerid"],
-                           "status": TRIGGER_STATUS[trigger["state"]],
+                           "status": TRIGGER_STATUS[trigger["value"]],
                            "severity": TRIGGER_SEVERITY[trigger["priority"]],
-                           "hostId": event["hosts"][0]["hostid"],
-                           "hostName": event["hosts"][0]["name"],
+                           "hostId": trigger["hosts"][0]["hostid"],
+                           "hostName": trigger["hosts"][0]["name"],
                            "brief": trigger["description"],
                            "extendedInfo": ""})
 


### PR DESCRIPTION
* "state" property of trigger object isn't supported by Zabbix 2.0.
  In addition, it's not suitable propery to determine trigger's
  state, we should use "value" property instead. See the following
  page for more details:

  https://www.zabbix.com/documentation/2.2/manual/api/reference/trigger/object

* In Zabbix 2.0, array of property for "selectHosts" on getting
  events isn't supported:

  https://www.zabbix.com/documentation/2.0/manual/appendix/api/event/get

  Instead require hosts on getting triggers.

Fix #1799