### PR TITLE
[ArmIncidentTracker] Suppress verbose log

### DIFF
--- a/server/src/ArmIncidentTracker.cc
+++ b/server/src/ArmIncidentTracker.cc
@@ -91,7 +91,7 @@ ArmIncidentTracker *ArmIncidentTracker::create(
 		return new ArmRedmine(trackerInfo);
 	case INCIDENT_TRACKER_HATOHOL:
 		// TODO: should treat more appropriate way
-		MLPL_INFO("Hatohol incident tracking system selected: %d\n",
+		MLPL_DBG("Hatohol incident tracking system selected: %d\n",
 			 trackerInfo.type);
 		break;
 	default:

--- a/server/src/ArmIncidentTracker.cc
+++ b/server/src/ArmIncidentTracker.cc
@@ -90,7 +90,6 @@ ArmIncidentTracker *ArmIncidentTracker::create(
 	case INCIDENT_TRACKER_REDMINE:
 		return new ArmRedmine(trackerInfo);
 	case INCIDENT_TRACKER_HATOHOL:
-		// TODO: should treat more appropriate way
 		MLPL_DBG("Hatohol incident tracking system selected: %d\n",
 			 trackerInfo.type);
 		break;


### PR DESCRIPTION
In the previous implementation the following message is reported
every time on registering an incident. It's too verbose.
The log level for it should be DBG.

[INFO] ArmIncidentTracker.cc:95 Hatohol incident tracking system selected: 1
