### PR TITLE
[travis] Use apt-get instead of pip to install MySQLdb of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,12 @@ before_install:
 install:
   - server/misc/setup-cutter.sh
   - server/misc/setup-librabbitmq-ppa.sh
-  - sudo apt-get install -qq -y autotools-dev libglib2.0-dev libjson-glib-dev libsoup2.4-dev libmysqlclient-dev sqlite3 ndoutils-nagios3-mysql uuid-dev npm python-pip expect python-dev libqpidmessaging2-dev libqpidtypes1-dev libqpidcommon2-dev qpidd rabbitmq-server python-pika
+  - sudo apt-get install -qq -y autotools-dev libglib2.0-dev libjson-glib-dev libsoup2.4-dev libmysqlclient-dev sqlite3 ndoutils-nagios3-mysql uuid-dev npm python-pip expect python-dev libqpidmessaging2-dev libqpidtypes1-dev libqpidcommon2-dev qpidd rabbitmq-server python-mysqldb python-pika
   - sudo sh -c "printf '[%s]\n%s=%s\n' mysqld character-set-server utf8  > /etc/mysql/conf.d/utf8.cnf"
   - sudo sh -c "printf '[%s]\n%s=%s\n' client default-character-set utf8  >> /etc/mysql/conf.d/utf8.cnf"
   - mysql -u root < data/test/setup.sql
   - npm install
   - sudo pip install django==1.5.4
-  - sudo pip install mysql-python
   - sudo pip install daemon
   - sudo sh -c "echo acl allow all all > /etc/qpid/qpidd.acl"
   - sudo /etc/init.d/qpidd restart


### PR DESCRIPTION
Because pip fails to build it on the new TravisCI infrastructure
(sincde Dec. 2015).