### PR TITLE
[mlpl] Fix the failure of syslogoutput.

### DIFF
--- a/server/mlpl/test/testLogger.cc
+++ b/server/mlpl/test/testLogger.cc
@@ -231,7 +231,7 @@ static void _assertSyslogOutput(const char *envMessage, const char *outMessage,
 		Logger::enableSyslogOutput();
 	else
 		Logger::disableSyslogOutput();
-	Logger::log(level, fileName, lineNumber, "%s", outMessage);
+	Logger::log(level, fileName, lineNumber, "%s\n", outMessage);
 
 	static const int TIMEOUT = 5 * 1000; // millisecond
 	auto currTimeInMSec = [] {


### PR DESCRIPTION
It might be lucky. The test of syslogoutput() succeeded.
And because this patch is considered that the test does not degrades, I sent a PR.

https://travis-ci.org/project-hatohol/hatohol/builds/95976552