### PR TITLE
[RestResourceHost][IncidentSenderManager] Report error on updating incident

### DIFF
--- a/server/src/IncidentSenderManager.cc
+++ b/server/src/IncidentSenderManager.cc
@@ -123,7 +123,7 @@ IncidentSenderManager &IncidentSenderManager::getInstance(void)
 	return Impl::instance;
 }
 
-void IncidentSenderManager::queue(
+HatoholError IncidentSenderManager::queue(
   const IncidentTrackerIdType &trackerId, const EventInfo &eventInfo,
   IncidentSender::CreateIncidentCallback callback, void *userData)
 {
@@ -132,12 +132,13 @@ void IncidentSenderManager::queue(
 		MLPL_ERR("Failed to queue sending an incident"
 			 " for the event: %" FMT_EVENT_ID "\n",
 			 eventInfo.id.c_str());
-		return;
+		return HTERR_FAILED_TO_SEND_INCIDENT;
 	}
 	sender->queue(eventInfo, callback, userData);
+	return HTERR_OK;
 }
 
-void IncidentSenderManager::queue(
+HatoholError IncidentSenderManager::queue(
   const IncidentInfo &incidentInfo, const string &comment,
   IncidentSender::UpdateIncidentCallback callback, void *userData)
 {
@@ -146,9 +147,10 @@ void IncidentSenderManager::queue(
 		MLPL_ERR("Can't find or create IncidentSender for: "
 			 "%" FMT_INCIDENT_TRACKER_ID "\n",
 			 incidentInfo.trackerId);
-		return;
+		return HTERR_FAILED_TO_SEND_INCIDENT;
 	}
 	sender->queue(incidentInfo, comment, callback, userData);
+	return HTERR_OK;
 }
 
 IncidentSenderManager::IncidentSenderManager(void)

--- a/server/src/IncidentSenderManager.h
+++ b/server/src/IncidentSenderManager.h
@@ -29,14 +29,47 @@ class IncidentSenderManager
 public:
 	static IncidentSenderManager &getInstance(void);
 
-	void queue(const IncidentTrackerIdType &trackerId,
-		   const EventInfo &info,
-		   IncidentSender::CreateIncidentCallback callback = NULL,
-		   void *userData = NULL);
-	void queue(const IncidentInfo &incidentInfo,
-		   const std::string &comment,
-		   IncidentSender::UpdateIncidentCallback callback = NULL,
-		   void *userData = NULL);
+	/**
+	 * Queue a job to register an incident which will be tied to an event.
+	 *
+	 * @param trackerId
+	 * An ID of IncidentTracker to register an incident.
+	 * @param event
+	 * An event which will be tied to the registered incident.
+	 * @param callback
+	 * A callback function which will be called when the IncidentSender
+	 * succeed or fail to register an incident.
+	 * @param userData
+	 * A data which is passed to the callback function.
+	 *
+	 * @return A HatoholError instance.
+	 */
+	HatoholError queue(const IncidentTrackerIdType &trackerId,
+			   const EventInfo &event,
+			   IncidentSender::CreateIncidentCallback callback = NULL,
+			   void *userData = NULL);
+
+	/**
+	 * Queue a job to update an incident.
+	 *
+	 * @param incidentInfo
+	 * An IncidentInfo to update.
+	 * @param comment
+	 * A comment string to add to the incident. Note that the incident
+	 * tracker may not support adding comments.
+	 * @param callback
+	 * A callback function which will be called when the IncidentSender
+	 * succeed or fail to send an incident.
+	 * @param userData
+	 * A data which is passed to the callback function.
+	 *
+	 * @return A HatoholError instance.
+	 */
+	HatoholError queue(const IncidentInfo &incidentInfo,
+			   const std::string &comment,
+			   IncidentSender::UpdateIncidentCallback callback = NULL,
+			   void *userData = NULL);
+
 	bool isIdling(void);
 	void setOnChangedIncidentTracker(const IncidentTrackerIdType id);
 	void deleteIncidentTracker(const IncidentTrackerIdType id);

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -658,8 +658,12 @@ void RestResourceHost::handlerPutIncident(void)
 	ref();
 	IncidentSenderManager &senderManager
 	  = IncidentSenderManager::getInstance();
-	senderManager.queue(incidentInfo, comment,
-			    updateIncidentCallback, this);
+	err = senderManager.queue(incidentInfo, comment,
+				  updateIncidentCallback, this);
+	if (err != HTERR_OK) {
+		unref();
+		replyError(err);
+	}
 }
 
 // TODO: Add a macro or template to simplify the definition


### PR DESCRIPTION
Revise #1812

In the previous code RestResourceHost doesn't return error when
it fails to update an incident that doesn't have valid incident
tracker. This patch fixes the issue.

Fix #1589