### PR TITLE
Fix test standard hap

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -268,6 +268,13 @@ class MonitoringServerInfo:
         }
         return handlers[type](self.extended_info)
 
+    def __str__(self):
+        s = str()
+        s += "%s %s %s " % (self.server_id, self.url, self.type)
+        s += "%s %s %s " % (self.nick_name, self.user_name, self.password)
+        s += "%s %s " % (self.polling_interval_sec, self.retry_interval_sec)
+        s += self.extended_info
+        return s
 
 class ParsedMessage:
     def __init__(self):

--- a/server/hap2/hatohol/test/TestStandardHap.py
+++ b/server/hap2/hatohol/test/TestStandardHap.py
@@ -97,7 +97,6 @@ class TestStandardHap(unittest.TestCase):
         sys.argv = [sys.argv[0], "--transporter", "EzTransporter"]
         hap()
         hap.enable_handling_sigchld(False)
-        exact_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))
-        result_ms = hap.get_received_ms_info()
-
-        self.assertTrue(result_ms, exact_ms)
+        expect_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))
+        actual_ms = hap.get_received_ms_info()
+        self.assertTrue(actual_ms, expect_ms)

--- a/server/hap2/hatohol/test/TestStandardHap.py
+++ b/server/hap2/hatohol/test/TestStandardHap.py
@@ -99,4 +99,4 @@ class TestStandardHap(unittest.TestCase):
         hap.enable_handling_sigchld(False)
         expect_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))
         actual_ms = hap.get_received_ms_info()
-        self.assertTrue(actual_ms, expect_ms)
+        self.assertEqual(str(actual_ms), str(expect_ms))


### PR DESCRIPTION
The actual object and the expected one should be compared.
However, previous code uses assertTrue(), which would be
wrongly written.