### PR TITLE
[AMQPConsumer] Suppress empty-body warning

### DIFF
--- a/server/common/AMQPConsumer.cc
+++ b/server/common/AMQPConsumer.cc
@@ -105,7 +105,7 @@ gpointer AMQPConsumer::mainThread(HatoholThreadArg *arg)
 
 		if (status == CONN_DISCONNECTED
 		    && m_impl->m_connection->isConnected()) {
-			if (m_impl->m_connection->startConsuming());
+			if (m_impl->m_connection->startConsuming())
 				status = CONN_ESTABLISHED;
 		}
 


### PR DESCRIPTION
```log
AMQPConsumer.cc:108:47: warning: if statement has empty body [-Wempty-body]
                        if (m_impl->m_connection->startConsuming());
                                                                   ^
AMQPConsumer.cc:108:47: note: put the semicolon on a separate line to silence
      this warning
1 warning generated.
```