### PR TITLE
[C++11][server] Replace AutoMutex with std::lock guard<mutex>

### DIFF
--- a/server/src/ArmRedmine.cc
+++ b/server/src/ArmRedmine.cc
@@ -22,6 +22,7 @@
 #include "ThreadLocalDBCache.h"
 #include "JSONParser.h"
 #include "UnifiedDataStore.h"
+#include <mutex>
 #include <time.h>
 #include <libsoup/soup.h>
 
@@ -51,7 +52,7 @@ struct ArmRedmine::Impl
 	int m_pageLimit;
 	time_t m_lastUpdateTime;
 	time_t m_lastUpdateTimePending;
-	Mutex m_startMutex;
+	mutex m_startMutex;
 
 	Impl(const IncidentTrackerInfo &trackerInfo)
 	: m_incidentTrackerInfo(trackerInfo),
@@ -341,7 +342,7 @@ RETRY:
 
 void ArmRedmine::startIfNeeded(void)
 {
-	AutoMutex autoLock(&m_impl->m_startMutex);
+	lock_guard<mutex> lock(m_impl->m_startMutex);
 	if (isStarted())
 		return;
 	if (!m_impl->checkLastUpdateTime())

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -21,7 +21,7 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <Mutex.h>
+#include <mutex>
 #include <errno.h>
 #include "ConfigManager.h"
 #include "DBTablesConfig.h"
@@ -130,7 +130,7 @@ CommandLineOptions::CommandLineOptions(void)
 // ConfigManager::Impl
 // ---------------------------------------------------------------------------
 struct ConfigManager::Impl {
-	static Mutex          mutex;
+	static std::mutex     mutex;
 	static ConfigManager *instance;
 	string                confFilePath;
 	string                databaseDirectory;
@@ -297,7 +297,7 @@ private:
 	}
 };
 
-Mutex          ConfigManager::Impl::mutex;
+mutex          ConfigManager::Impl::mutex;
 ConfigManager *ConfigManager::Impl::instance = NULL;
 
 // ---------------------------------------------------------------------------
@@ -466,25 +466,25 @@ int ConfigManager::getMaxNumberOfRunningCommandAction(void)
 
 string ConfigManager::getActionCommandDirectory(void)
 {
-	AutoMutex autoLock(&m_impl->mutex);
+	lock_guard<mutex> lock(m_impl->mutex);
 	return m_impl->actionCommandDirectory;
 }
 
 void ConfigManager::setActionCommandDirectory(const string &dir)
 {
-	AutoMutex autoLock(&m_impl->mutex);
+	lock_guard<mutex> lock(m_impl->mutex);
 	m_impl->actionCommandDirectory = dir;
 }
 
 string ConfigManager::getResidentYardDirectory(void)
 {
-	AutoMutex autoLock(&m_impl->mutex);
+	lock_guard<mutex> lock(m_impl->mutex);
 	return m_impl->residentYardDirectory;
 }
 
 void ConfigManager::setResidentYardDirectory(const string &dir)
 {
-	AutoMutex autoLock(&m_impl->mutex);
+	lock_guard<mutex> lock(m_impl->mutex);
 	m_impl->residentYardDirectory = dir;
 }
 

--- a/server/src/DB.cc
+++ b/server/src/DB.cc
@@ -17,7 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <Mutex.h>
+#include <mutex>
 #include "DB.h"
 #include "DBAgentMySQL.h"
 #include "HatoholException.h"
@@ -81,7 +81,7 @@ struct DB::Impl {
 		if (setupCtx.initialized)
 			return;
 
-		AutoMutex autoMutex(&setupCtx.lock);
+		lock_guard<mutex> lock(setupCtx.lock);
 		// NOTE: A flag 'setupCtx.initialized' is used to improve
 		// performance. Event if it isn't used, the existence check
 		// of TABLE_NAME_TABLE_VERSION is performed every time.

--- a/server/src/DB.h
+++ b/server/src/DB.h
@@ -21,7 +21,7 @@
 #define DB_h
 
 #include <memory>
-#include <Mutex.h>
+#include <mutex>
 #include <typeinfo>
 #include "Params.h"
 #include "DBAgent.h"
@@ -47,7 +47,7 @@ protected:
 		const std::type_info &dbClassType;
 		DBConnectInfo connectInfo;
 		bool          initialized;
-		mlpl::Mutex   lock;
+		std::mutex    lock;
 
 		SetupContext(const std::type_info &dbClassType);
 	};

--- a/server/src/DataStoreManager.cc
+++ b/server/src/DataStoreManager.cc
@@ -18,7 +18,7 @@
  */
 
 #include "DataStoreManager.h"
-#include <Mutex.h>
+#include <mutex>
 #include <Reaper.h>
 #include <Logger.h>
 using namespace std;
@@ -53,7 +53,7 @@ struct DataStoreManager::Impl {
 	// Elements in dataStoreMap and dataStoreVector are the same.
 	// So it's only necessary to free elements in one.
 	DataStoreMap    dataStoreMap;
-	Mutex                  mutex;
+	std::mutex             mutex;
 	DataStoreEventProcList eventProcList;
 	ReadWriteLock          eventProcListLock;
 };
@@ -89,7 +89,7 @@ bool DataStoreManager::hasDataStore(uint32_t storeId)
 
 bool DataStoreManager::add(uint32_t storeId, DataStore *dataStore)
 {
-	AutoMutex autoMutex(&m_impl->mutex);
+	lock_guard<mutex> lock(m_impl->mutex);
 	pair<DataStoreMapIterator, bool> result =
 	  m_impl->dataStoreMap.insert
 	    (pair<uint32_t, DataStore *>(storeId, dataStore));

--- a/server/src/IncidentSenderManager.cc
+++ b/server/src/IncidentSenderManager.cc
@@ -18,7 +18,7 @@
  */
 
 #include <map>
-#include <Mutex.h>
+#include <mutex>
 #include "Reaper.h"
 #include "IncidentSenderManager.h"
 #include "IncidentSenderRedmine.h"
@@ -32,11 +32,11 @@ struct IncidentSenderManager::Impl
 {
 	static IncidentSenderManager instance;
 	map<IncidentTrackerIdType, IncidentSender*> sendersMap;
-	Mutex sendersLock;
+	mutex sendersLock;
 
 	~Impl()
 	{
-		AutoMutex autoMutex(&sendersLock);
+		lock_guard<mutex> lock(sendersLock);
 		map<IncidentTrackerIdType, IncidentSender*>::iterator it;
 		for (it = sendersMap.begin(); it != sendersMap.end(); ++it) {
 			IncidentSender *sender = it->second;
@@ -85,7 +85,7 @@ struct IncidentSenderManager::Impl
 	IncidentSender *getSender(const IncidentTrackerIdType &id,
 				  bool autoCreate = true)
 	{
-		AutoMutex autoMutex(&sendersLock);
+		lock_guard<mutex> lock(sendersLock);
 		if (sendersMap.find(id) != sendersMap.end())
 			return sendersMap[id];
 
@@ -103,7 +103,7 @@ struct IncidentSenderManager::Impl
 
 	void deleteSender(const IncidentTrackerIdType &id)
 	{
-		AutoMutex autoMutex(&sendersLock);
+		lock_guard<mutex> lock(sendersLock);
 		map<IncidentTrackerIdType, IncidentSender*>::iterator it;
 		it = sendersMap.find(id);
 		if (it == sendersMap.end()) {
@@ -162,7 +162,7 @@ IncidentSenderManager::~IncidentSenderManager()
 
 bool IncidentSenderManager::isIdling(void)
 {
-	AutoMutex autoMutex(&m_impl->sendersLock);
+	lock_guard<mutex> lock(m_impl->sendersLock);
 
 	map<IncidentTrackerIdType, IncidentSender*>::iterator it
 	  = m_impl->sendersMap.begin();

--- a/server/src/ThreadLocalDBCache.cc
+++ b/server/src/ThreadLocalDBCache.cc
@@ -163,7 +163,7 @@ void ThreadLocalDBCache::cleanup(void)
 
 size_t ThreadLocalDBCache::getNumberOfDBClientMaps(void)
 {
-	lock_guard<mutex> mutextLock(Impl::lock);
+	lock_guard<mutex> mutexLock(Impl::lock);
 	return Impl::dbCacheLRU.list.size();
 }
 

--- a/server/src/ThreadLocalDBCache.cc
+++ b/server/src/ThreadLocalDBCache.cc
@@ -19,7 +19,7 @@
 
 #include <map>
 #include <list>
-#include <Mutex.h>
+#include <mutex>
 #include "Params.h"
 #include "ThreadLocalDBCache.h"
 using namespace std;
@@ -88,14 +88,14 @@ struct ThreadLocalDBCache::Impl {
 	static size_t maxNumCacheMySQL;
 	static size_t maxNumCacheSQLite3;
 
-	static Mutex                   lock;
+	static std::mutex              lock;
 	static ThreadContextSet        ctxSet;
 	static ThreadLocalDBCacheLRU   dbCacheLRU;
 	static __thread ThreadContext *ctx;
 
 	static ThreadContext *getContext(void)
 	{
-		AutoMutex autoMutex(&lock);
+		lock_guard<mutex> mutexLock(lock);
 		if (!ctx) {
 			ctx = new ThreadContext();
 			ctxSet.insert(ctx);
@@ -119,7 +119,7 @@ struct ThreadLocalDBCache::Impl {
 
 	static void insert(DB *db)
 	{
-		AutoMutex autoMutex(&lock);
+		lock_guard<mutex> mutexLock(lock);
 		dbCacheLRU.touch(db);
 	}
 
@@ -127,7 +127,7 @@ struct ThreadLocalDBCache::Impl {
 	{
 		if (!ctx)
 			return;
-		AutoMutex autoMutex(&lock);
+		lock_guard<mutex> mutexLock(lock);
 		ThreadContextSetIterator it = ctxSet.find(ctx);
 		const bool found = (it != ctxSet.end());
 		HATOHOL_ASSERT(found, "Failed to found: ctx: %p\n", ctx);
@@ -143,7 +143,7 @@ size_t ThreadLocalDBCache::Impl::maxNumCacheMySQL
 size_t ThreadLocalDBCache::Impl::maxNumCacheSQLite3
   = DEFAULT_MAX_NUM_CACHE_SQLITE3;
 
-Mutex                   ThreadLocalDBCache::Impl::lock;
+mutex                   ThreadLocalDBCache::Impl::lock;
 ThreadContextSet        ThreadLocalDBCache::Impl::ctxSet;
 ThreadLocalDBCacheLRU              ThreadLocalDBCache::Impl::dbCacheLRU;
 __thread ThreadContext *ThreadLocalDBCache::Impl::ctx = NULL;
@@ -163,7 +163,7 @@ void ThreadLocalDBCache::cleanup(void)
 
 size_t ThreadLocalDBCache::getNumberOfDBClientMaps(void)
 {
-	AutoMutex autoMutex(&Impl::lock);
+	lock_guard<mutex> mutextLock(Impl::lock);
 	return Impl::dbCacheLRU.list.size();
 }
 

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -18,7 +18,7 @@
  */
 
 #include <stdexcept>
-#include <Mutex.h>
+#include <mutex>
 #include <AtomicValue.h>
 #include <Reaper.h>
 #include "UnifiedDataStore.h"
@@ -82,7 +82,7 @@ struct UnifiedDataStore::Impl
 	};
 
 	static UnifiedDataStore *instance;
-	static Mutex             mutex;
+	static std::mutex        mutex;
 
 	AtomicValue<bool>        isCopyOnDemandEnabled;
 	ItemFetchWorker          itemFetchWorker;
@@ -224,7 +224,7 @@ struct UnifiedDataStore::Impl
 	void startArmIncidentTrackerIfNeeded(
 	  const IncidentTrackerInfo &trackerInfo)
 	{
-		AutoMutex autoLock(&armIncidentTrackerMapMutex);
+		lock_guard<std::mutex> lock(armIncidentTrackerMapMutex);
 		ArmIncidentTrackerMapIterator it
 		  = armIncidentTrackerMap.find(trackerInfo.id);
 		ArmIncidentTracker *arm = NULL;
@@ -262,7 +262,7 @@ struct UnifiedDataStore::Impl
 	void stopArmIncidentTrackerIfNeeded(
 	  const IncidentTrackerIdType &trackerId)
 	{
-		AutoMutex autoLock(&armIncidentTrackerMapMutex);
+		lock_guard<std::mutex> lock(armIncidentTrackerMapMutex);
 		ArmIncidentTrackerMapIterator it
 		  = armIncidentTrackerMap.find(trackerId);
 		if (it == armIncidentTrackerMap.end())
@@ -292,7 +292,7 @@ struct UnifiedDataStore::Impl
 
 	void stopAllArmIncidentTrackers(void)
 	{
-		AutoMutex autoLock(&armIncidentTrackerMapMutex);
+		lock_guard<std::mutex> lock(armIncidentTrackerMapMutex);
 		ArmIncidentTrackerMapIterator it
 			= armIncidentTrackerMap.begin();
 		while (it != armIncidentTrackerMap.end()) {
@@ -349,7 +349,7 @@ struct UnifiedDataStore::Impl
 	ReadWriteLock            serverIdDataStoreMapLock;
 	ServerIdDataStoreMap     serverIdDataStoreMap;
 	DataStoreManager         dataStoreManager;
-	Mutex                    armIncidentTrackerMapMutex;
+	std::mutex               armIncidentTrackerMapMutex;
 	ArmIncidentTrackerMap    armIncidentTrackerMap;
 	bool                     isStarted;
 	ReadWriteLock            customIncidentStatusMapLock;
@@ -357,7 +357,7 @@ struct UnifiedDataStore::Impl
 };
 
 UnifiedDataStore *UnifiedDataStore::Impl::instance = NULL;
-Mutex             UnifiedDataStore::Impl::mutex;
+mutex             UnifiedDataStore::Impl::mutex;
 
 // ---------------------------------------------------------------------------
 // Public static methods


### PR DESCRIPTION
Related to #1233.

This PR does not include replacing  `HatoholArmPluginGate.cc` because this file is for HAP1.
And `DBTables.(cc|h)`'s AutoMutex are not replaced with `std::lock guard<mutex>` because it causes following internal compiler error:

```log
testDBTables.cc: In function 'void testDBTables::test_tableInitializer()':
testDBTables.cc:210:2: internal compiler error: in create_tmp_var, at gimplify.c:479
  };
  ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.8/README.Bugs> for instructions.
```