### PR TITLE
[OperationPrivilege] Move ALL_PRIVILEGES & NONE_PRIGILEGE into OperationPrivilege class

### DIFF
--- a/server/src/DBTablesUser.cc
+++ b/server/src/DBTablesUser.cc
@@ -232,7 +232,7 @@ static void updateAdminPrivilege(DBAgent &dbAgent,
 	static const OperationPrivilegeFlag oldAdminFlags =
 		OperationPrivilege::makeFlag(old_NUM_OPPRVLG) - 1;
 	DBAgent::UpdateArg arg(tableProfileUsers);
-	arg.add(IDX_USERS_FLAGS, ALL_PRIVILEGES);
+	arg.add(IDX_USERS_FLAGS, OperationPrivilege::ALL_PRIVILEGES);
 	arg.condition = StringUtils::sprintf(
 	  "%s=%" FMT_OPPRVLG,
 	  COLUMN_DEF_USERS[IDX_USERS_FLAGS].columnName, oldAdminFlags);
@@ -979,8 +979,8 @@ HatoholError DBTablesUser::addUserRoleInfo(UserRoleInfo &userRoleInfo,
 	err = isValidFlags(userRoleInfo.flags);
 	if (err != HTERR_OK)
 		return err;
-	if (userRoleInfo.flags == ALL_PRIVILEGES ||
-	    userRoleInfo.flags == NONE_PRIVILEGE) {
+	if (userRoleInfo.flags == OperationPrivilege::ALL_PRIVILEGES ||
+	    userRoleInfo.flags == OperationPrivilege::NONE_PRIVILEGE) {
 		return HTERR_USER_ROLE_NAME_OR_PRIVILEGE_FLAGS_EXIST;
 	}
 
@@ -1040,8 +1040,8 @@ HatoholError DBTablesUser::updateUserRoleInfo(
 	err = isValidFlags(userRoleInfo.flags);
 	if (err != HTERR_OK)
 		return err;
-	if (userRoleInfo.flags == ALL_PRIVILEGES ||
-	    userRoleInfo.flags == NONE_PRIVILEGE) {
+	if (userRoleInfo.flags == OperationPrivilege::ALL_PRIVILEGES ||
+	    userRoleInfo.flags == OperationPrivilege::NONE_PRIVILEGE) {
 		return HTERR_USER_ROLE_NAME_OR_PRIVILEGE_FLAGS_EXIST;
 	}
 

--- a/server/src/OperationPrivilege.cc
+++ b/server/src/OperationPrivilege.cc
@@ -22,6 +22,10 @@
 #include "ThreadLocalDBCache.h"
 using namespace mlpl;
 
+const OperationPrivilegeFlag OperationPrivilege::NONE_PRIVILEGE = 0;
+const OperationPrivilegeFlag OperationPrivilege::ALL_PRIVILEGES =
+  OperationPrivilege::makeFlag(NUM_OPPRVLG) - 1ULL;;
+
 struct OperationPrivilege::Impl {
 	UserIdType userId;
 	uint64_t flags;

--- a/server/src/OperationPrivilege.h
+++ b/server/src/OperationPrivilege.h
@@ -78,11 +78,13 @@ enum OperationPrivilegeType
 };
 
 typedef uint64_t OperationPrivilegeFlag;
-const static OperationPrivilegeFlag NONE_PRIVILEGE = 0;
 #define FMT_OPPRVLG PRIu64
 
 class OperationPrivilege {
 public:
+	const static OperationPrivilegeFlag NONE_PRIVILEGE;
+	const static OperationPrivilegeFlag ALL_PRIVILEGES;
+
 	OperationPrivilege(const UserIdType &userId);
 	OperationPrivilege(const OperationPrivilegeFlag &flags = 0);
 	OperationPrivilege(const OperationPrivilege &src);
@@ -111,8 +113,5 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-const static OperationPrivilegeFlag ALL_PRIVILEGES =
-  OperationPrivilege::makeFlag(NUM_OPPRVLG) - 1ULL;
 
 #endif // OperationPrivilege_h

--- a/server/src/RestResourceUser.cc
+++ b/server/src/RestResourceUser.cc
@@ -143,14 +143,18 @@ static void addUserRolesMap(
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	UserRoleInfoList userRoleList;
 	UserRoleQueryOption option(job->m_dataQueryContextPtr);
+	string nonePrivilege
+	  = StringUtils::toString(OperationPrivilege::NONE_PRIVILEGE);
+	string allPrivileges
+	  = StringUtils::toString(OperationPrivilege::ALL_PRIVILEGES);
 	dataStore->getUserRoleList(userRoleList, option);
 
 	agent.startObject("userRoles");
 	UserRoleInfoListIterator it = userRoleList.begin();
-	agent.startObject(StringUtils::toString(NONE_PRIVILEGE));
+	agent.startObject(nonePrivilege);
 	agent.add("name", "Guest");
 	agent.endObject();
-	agent.startObject(StringUtils::toString(ALL_PRIVILEGES));
+	agent.startObject(allPrivileges);
 	agent.add("name", "Admin");
 	agent.endObject();
 	for (; it != userRoleList.end(); ++it) {

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -815,7 +815,7 @@ static UserInfo bareTestUserInfo[] = {
 	0,                 // id
 	"pineapple",       // name
 	"Po+-\\|}{\":?><", // password
-	ALL_PRIVILEGES,    // flags
+	OperationPrivilege::ALL_PRIVILEGES,    // flags
 }, {
 	0,                 // id
 	"m1ffy@v@",        // name
@@ -2294,7 +2294,7 @@ void loadTestDBServer(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestServerInfo; i++) {
 		// We have to make a copy since addTargetServer() changes
 		// a member of MonitoringServerInfo.
@@ -2308,7 +2308,7 @@ void loadTestDBUser(void)
 	ThreadLocalDBCache cache;
 	DBTablesUser &dbUser = cache.getUser();
 	HatoholError err;
-	OperationPrivilege opePrivilege(ALL_PRIVILEGES);
+	OperationPrivilege opePrivilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (auto &userInfo : bareTestUserInfo) {
 		err = dbUser.addUserInfo(userInfo, opePrivilege);
 		assertHatoholError(HTERR_OK, err);
@@ -2320,7 +2320,7 @@ void loadTestDBUserRole(void)
 	ThreadLocalDBCache cache;
 	DBTablesUser &dbUser = cache.getUser();
 	HatoholError err;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (auto userRoleInfo : testUserRoleInfo) {
 		err = dbUser.addUserRoleInfo(userRoleInfo, privilege);
 		assertHatoholError(HTERR_OK, err);
@@ -2332,7 +2332,7 @@ void loadTestDBAccessList(void)
 	ThreadLocalDBCache cache;
 	DBTablesUser &dbUser = cache.getUser();
 	HatoholError err;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (auto &accessInfo : bareTestAccessInfo) {
 		err = dbUser.addAccessInfo(accessInfo, privilege);
 		assertHatoholError(HTERR_OK, err);
@@ -2355,7 +2355,7 @@ void loadTestDBTriggers(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestTriggerInfo; i++)
 		dbMonitoring.addTriggerInfo(&testTriggerInfo[i]);
 }
@@ -2364,7 +2364,7 @@ void loadTestDBEvents(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestEventInfo; i++) {
 		// Make a copy since EventInfo.id will be changed.
 		EventInfo evtInfo = testEventInfo[i];
@@ -2376,7 +2376,7 @@ void loadTestDBItems(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestItemInfo; i++)
 		dbMonitoring.addItemInfo(&testItemInfo[i]);
 }
@@ -2412,7 +2412,7 @@ void loadTestDBIncidentTracker(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (auto incidentTrackerInfo : testIncidentTrackerInfo)
 		dbConfig.addIncidentTracker(incidentTrackerInfo, privilege);
 }
@@ -2445,7 +2445,7 @@ void loadTestDBServerHostDef(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesHost &dbHost = cache.getHost();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestServerHostDef; i++)
 		dbHost.upsertServerHostDef(testServerHostDef[i]);
 }
@@ -2454,7 +2454,7 @@ void loadTestDBVMInfo(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesHost &dbHost = cache.getHost();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestVMInfo; i++)
 		dbHost.upsertVMInfo(testVMInfo[i]);
 }
@@ -2463,7 +2463,7 @@ void loadTestDBHostgroup(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesHost &dbHost = cache.getHost();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestHostgroup; i++)
 		dbHost.upsertHostgroup(testHostgroup[i]);
 }
@@ -2472,7 +2472,7 @@ void loadTestDBHostgroupMember(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesHost &dbHost = cache.getHost();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < NumTestHostgroupMember; i++)
 		dbHost.upsertHostgroupMember(testHostgroupMember[i]);
 }

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -946,9 +946,6 @@ static AccessInfo bareTestAccessInfo[] = {
 const AccessInfo *testAccessInfo = bareTestAccessInfo;
 const size_t NumTestAccessInfo = ARRAY_SIZE(bareTestAccessInfo);
 
-static const string _HOST_VALID_STRING = StringUtils::sprintf("%d", HOST_VALID);
-static const char *HOST_VALID_STRING = _HOST_VALID_STRING.c_str();
-
 const UserRoleInfo testUserRoleInfo[] = {
 {
 	0,                            // id

--- a/server/test/testDBTablesAction.cc
+++ b/server/test/testDBTablesAction.cc
@@ -511,7 +511,7 @@ void test_deleteNoOwnerAction(void)
 	}
 
 	ThreadLocalDBCache cache;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = cache.getUser().deleteUserInfo(targetId, privilege);
 	assertHatoholError(HTERR_OK, err);
 
@@ -540,7 +540,7 @@ void test_deleteNoIncidentTrackerAction(void)
 
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = dbConfig.deleteIncidentTracker(targetId, privilege);
 	assertHatoholError(HTERR_OK, err);
 
@@ -930,7 +930,7 @@ void test_getActionListWithNoIncidentTracker(void)
 
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = dbConfig.deleteIncidentTracker(targetId, privilege);
 	assertHatoholError(HTERR_OK, err);
 

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -67,7 +67,7 @@ void _assertArmPluginInfo(
 static void addTargetServer(MonitoringServerInfo *serverInfo)
 {
 	DECLARE_DBTABLES_CONFIG(dbConfig);
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	dbConfig.addTargetServer(serverInfo, privilege);
 }
 #define assertAddServerToDB(X) \
@@ -336,7 +336,7 @@ void test_createTableServers(void)
 
 void _assertAddTargetServer(
   MonitoringServerInfo serverInfo, const HatoholErrorCode expectedErrorCode,
-  OperationPrivilege privilege = ALL_PRIVILEGES)
+  OperationPrivilege privilege = OperationPrivilege::ALL_PRIVILEGES)
 {
 	DECLARE_DBTABLES_CONFIG(dbConfig);
 	HatoholError err;
@@ -361,7 +361,7 @@ void test_addTargetServer(void)
 void test_addTargetServerWithoutPrivilege(void)
 {
 	const MonitoringServerInfo *testInfo = testServerInfo;
-	OperationPrivilegeFlag privilege = ALL_PRIVILEGES;
+	OperationPrivilegeFlag privilege = OperationPrivilege::ALL_PRIVILEGES;
 	OperationPrivilege::removeFlag(privilege, OPPRVLG_CREATE_SERVER);
 	assertAddTargetServer(*testInfo, HTERR_NO_PRIVILEGE, privilege);
 }
@@ -556,7 +556,7 @@ void test_addTargetServerWithValidRetryInterval(gconstpointer data)
 
 void _assertUpdateTargetServer(
   MonitoringServerInfo serverInfo, const HatoholErrorCode expectedErrorCode,
-  OperationPrivilege privilege = ALL_PRIVILEGES)
+  OperationPrivilege privilege = OperationPrivilege::ALL_PRIVILEGES)
 {
 	loadTestDBServer();
 
@@ -595,7 +595,7 @@ void test_updateTargetServerWithoutPrivilege(void)
 	int targetId = 2;
 	MonitoringServerInfo serverInfo = testServerInfo[0];
 	serverInfo.id = targetId;
-	OperationPrivilegeFlag privilege = ALL_PRIVILEGES;
+	OperationPrivilegeFlag privilege = OperationPrivilege::ALL_PRIVILEGES;
 	OperationPrivilegeFlag updateFlags =
 	 (1 << OPPRVLG_UPDATE_SERVER) | (1 << OPPRVLG_UPDATE_ALL_SERVER);
 	privilege &= ~updateFlags;
@@ -1141,7 +1141,7 @@ void test_incidentTrackerQueryOptionWithId(void)
 void _assertAddIncidentTracker(
   IncidentTrackerInfo incidentTrackerInfo,
   const HatoholErrorCode expectedErrorCode,
-  OperationPrivilege privilege = ALL_PRIVILEGES)
+  OperationPrivilege privilege = OperationPrivilege::ALL_PRIVILEGES)
 {
 	DECLARE_DBTABLES_CONFIG(dbConfig);
 	HatoholError err;
@@ -1166,7 +1166,7 @@ void test_addIncidentTracker(void)
 
 void test_addIncidentTrackerWithoutPrivilege(void)
 {
-	OperationPrivilegeFlag privilege = ALL_PRIVILEGES;
+	OperationPrivilegeFlag privilege = OperationPrivilege::ALL_PRIVILEGES;
 	OperationPrivilege::removeFlag(
 	  privilege, OPPRVLG_CREATE_INCIDENT_SETTING);
 	const IncidentTrackerInfo *testInfo = testIncidentTrackerInfo;
@@ -1190,7 +1190,7 @@ void test_addIncidentTrackerWithInvalieType(void)
 void _assertUpdateIncidentTracker(
   IncidentTrackerInfo incidentTrackerInfo,
   const HatoholErrorCode expectedErrorCode,
-  OperationPrivilege privilege = ALL_PRIVILEGES)
+  OperationPrivilege privilege = OperationPrivilege::ALL_PRIVILEGES)
 {
 	loadTestDBIncidentTracker();
 
@@ -1231,7 +1231,7 @@ void test_updateIncidentTrackerWithoutPrivilege(void)
 	int targetId = 2;
 	IncidentTrackerInfo incidentTrackerInfo = testIncidentTrackerInfo[0];
 	incidentTrackerInfo.id = targetId;
-	OperationPrivilegeFlag privilege = ALL_PRIVILEGES;
+	OperationPrivilegeFlag privilege = OperationPrivilege::ALL_PRIVILEGES;
 	OperationPrivilege::removeFlag(
 	  privilege, OPPRVLG_UPDATE_INCIDENT_SETTING);
 	assertUpdateIncidentTracker(
@@ -1252,7 +1252,7 @@ void test_updateIncidentTrackerWithEmptyLoction(void)
 static void addIncidentTracker(IncidentTrackerInfo *info)
 {
 	DECLARE_DBTABLES_CONFIG(dbConfig);
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	dbConfig.addIncidentTracker(*info, privilege);
 }
 #define assertAddIncidentTrackerToDB(X) \
@@ -1422,7 +1422,7 @@ void test_upsertSeverityRankInfoWithoutPrivilege(void)
 	severityRankInfo.label = "Information";
 	severityRankInfo.asImportant = false;
 
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_CREATE_SEVERITY_RANK);
 	OperationPrivilege privilege(flags);
 
@@ -1500,7 +1500,7 @@ void test_updateSeverityRankInfoWithoutPrivilege(void)
 	severityRankInfo.label = "Critical";
 	severityRankInfo.asImportant = true;
 
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_UPDATE_SEVERITY_RANK);
 	OperationPrivilege privilege(flags);
 	assertHatoholError(HTERR_NO_PRIVILEGE,
@@ -1677,7 +1677,7 @@ void test_deleteSeverityRankInfoWithoutPrivilege(void)
 	SeverityRankIdType targetId = 2;
 	SeverityRankIdType actualId = targetId + 1;
 
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_DELETE_SEVERITY_RANK);
 	OperationPrivilege privilege(flags);
 

--- a/server/test/testDBTablesUser.cc
+++ b/server/test/testDBTablesUser.cc
@@ -327,7 +327,7 @@ void test_addUser(void)
 
 void test_addUserDuplicate(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserInfo userInfo = testUserInfo[1];
 	assertHatoholError(HTERR_USER_NAME_EXIST,
@@ -337,7 +337,7 @@ void test_addUserDuplicate(void)
 
 void test_addUserWithLongName(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	const size_t limitLength = DBTablesUser::MAX_USER_NAME_LENGTH;
 	UserInfo userInfo = testUserInfo[1];
@@ -350,11 +350,11 @@ void test_addUserWithLongName(void)
 
 void test_addUserWithInvalidFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserInfo userInfo = testUserInfo[1];
 	userInfo.name = "Crasher";
-	userInfo.flags = ALL_PRIVILEGES + 1;
+	userInfo.flags = OperationPrivilege::ALL_PRIVILEGES + 1;
 	assertHatoholError(HTERR_INVALID_PRIVILEGE_FLAGS,
 	                   dbUser.addUserInfo(userInfo, privilege));
 	assertUsersInDB();
@@ -362,7 +362,7 @@ void test_addUserWithInvalidFlags(void)
 
 void test_addUserWithoutPrivilege(void)
 {
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_CREATE_USER);
 	OperationPrivilege privilege(flags);
 	DECLARE_DBTABLES_USER(dbUser);
@@ -481,7 +481,7 @@ void test_updateNonExistUser(void)
 	DECLARE_DBTABLES_USER(dbUser);
 	UserInfo userInfo = setupForUpdate();
 	userInfo.id = NumTestUserInfo + 5;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = dbUser.updateUserInfo(userInfo, privilege);
 	assertHatoholError(HTERR_NOT_FOUND_TARGET_RECORD, err);
 }
@@ -539,7 +539,7 @@ void test_deleteUser(void)
 {
 	DECLARE_DBTABLES_USER(dbUser);
 	const UserIdType targetId = 2;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = dbUser.deleteUserInfo(targetId, privilege);
 	assertHatoholError(HTERR_OK, err);
 
@@ -552,7 +552,7 @@ void test_deleteUser(void)
 void test_deleteMyself(void)
 {
 	DECLARE_DBTABLES_USER(dbUser);
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	const UserIdType targetId = privilege.getUserId();
 	HatoholError err = dbUser.deleteUserInfo(targetId, privilege);
 	assertHatoholError(HTERR_DELETE_MYSELF, err);
@@ -715,7 +715,8 @@ void test_getUserInfoListWithNonExistUser(void)
 
 void test_getUserInfoListWithMyNameAsTargetName(void)
 {
-	assertGetUserInfoListWithTargetName(ALL_PRIVILEGES, 1);
+	assertGetUserInfoListWithTargetName(
+	  OperationPrivilege::ALL_PRIVILEGES, 1);
 }
 
 void test_getUserInfoListWithMyNameAsTargetNameWithoutPrivileges(void)
@@ -729,8 +730,8 @@ void test_getUserInfoListWithOtherName(void)
 {
 	const size_t expectNumList = 1;
 	const bool searchMySelf = true;
-	assertGetUserInfoListWithTargetName(ALL_PRIVILEGES, expectNumList,
-					    !searchMySelf);
+	assertGetUserInfoListWithTargetName(
+	  OperationPrivilege::ALL_PRIVILEGES, expectNumList, !searchMySelf);
 }
 
 void test_getUserInfoListWithOtherNameWithoutPrivileges(void)
@@ -1172,7 +1173,7 @@ void test_addUserRole(void)
 
 void test_addUserRoleWithDuplicatedName(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo = testUserRoleInfo[1];
 	userRoleInfo.flags
@@ -1184,7 +1185,7 @@ void test_addUserRoleWithDuplicatedName(void)
 
 void test_addUserRoleWithDuplicatedFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo = testUserRoleInfo[1];
 	userRoleInfo.name = "Unique name kea#osemrnscs+";
@@ -1195,11 +1196,11 @@ void test_addUserRoleWithDuplicatedFlags(void)
 
 void test_addUserRoleWithAllPrivilegeFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo = testUserRoleInfo[1];
 	userRoleInfo.name = "Unique name kea#osemrnscs+";
-	userRoleInfo.flags = ALL_PRIVILEGES;
+	userRoleInfo.flags = OperationPrivilege::ALL_PRIVILEGES;
 	assertHatoholError(HTERR_USER_ROLE_NAME_OR_PRIVILEGE_FLAGS_EXIST,
 	                   dbUser.addUserRoleInfo(userRoleInfo, privilege));
 	assertUserRolesInDB();
@@ -1207,11 +1208,11 @@ void test_addUserRoleWithAllPrivilegeFlags(void)
 
 void test_addUserRoleWithNonePrivilegeFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo = testUserRoleInfo[1];
 	userRoleInfo.name = "Unique name kea#osemrnscs+";
-	userRoleInfo.flags = NONE_PRIVILEGE;
+	userRoleInfo.flags = OperationPrivilege::NONE_PRIVILEGE;
 	assertHatoholError(HTERR_USER_ROLE_NAME_OR_PRIVILEGE_FLAGS_EXIST,
 	                   dbUser.addUserRoleInfo(userRoleInfo, privilege));
 	assertUserRolesInDB();
@@ -1219,7 +1220,7 @@ void test_addUserRoleWithNonePrivilegeFlags(void)
 
 void test_addUserRoleWithLongName(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	const size_t limitLength = DBTablesUser::MAX_USER_ROLE_NAME_LENGTH;
 	UserRoleInfo userRoleInfo = testUserRoleInfo[1];
@@ -1232,12 +1233,12 @@ void test_addUserRoleWithLongName(void)
 
 void test_addUserRoleWithInvalidFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo;
 	userRoleInfo.id = 0;
 	userRoleInfo.name = "Crasher";
-	userRoleInfo.flags = ALL_PRIVILEGES + 1;
+	userRoleInfo.flags = OperationPrivilege::ALL_PRIVILEGES + 1;
 	assertHatoholError(HTERR_INVALID_PRIVILEGE_FLAGS,
 	                   dbUser.addUserRoleInfo(userRoleInfo, privilege));
 	assertUserRolesInDB();
@@ -1245,11 +1246,11 @@ void test_addUserRoleWithInvalidFlags(void)
 
 void test_addUserRoleWithEmptyUserName(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	DECLARE_DBTABLES_USER(dbUser);
 	UserRoleInfo userRoleInfo;
 	userRoleInfo.id = 0;
-	userRoleInfo.flags = ALL_PRIVILEGES;
+	userRoleInfo.flags = OperationPrivilege::ALL_PRIVILEGES;
 	assertHatoholError(HTERR_EMPTY_USER_ROLE_NAME,
 	                   dbUser.addUserRoleInfo(userRoleInfo, privilege));
 	assertUserRolesInDB();
@@ -1257,7 +1258,7 @@ void test_addUserRoleWithEmptyUserName(void)
 
 void test_addUserRoleWithoutPrivilege(void)
 {
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~(1 << OPPRVLG_CREATE_USER_ROLE);
 	OperationPrivilege privilege(flags);
 	DECLARE_DBTABLES_USER(dbUser);
@@ -1286,13 +1287,14 @@ void test_isValidUserRoleNameWithLongName(void)
 
 void test_getUserRoleInfoList(void)
 {
-	assertGetUserRoleInfo(ALL_PRIVILEGES);
+	assertGetUserRoleInfo(OperationPrivilege::ALL_PRIVILEGES);
 }
 
 void test_getUserRoleInfoListWithTargetId(void)
 {
 	UserRoleIdType targetUserRoleId = 2;
-	assertGetUserRoleInfo(ALL_PRIVILEGES, targetUserRoleId);
+	assertGetUserRoleInfo(OperationPrivilege::ALL_PRIVILEGES,
+			      targetUserRoleId);
 }
 
 void test_getUserRoleInfoListWithNoPrivilege(void)
@@ -1317,7 +1319,7 @@ void test_updateUserRoleWithoutPrivilege(void)
 {
 	UserRoleInfo userRoleInfo = setupUserRoleInfoForUpdate();
 	DECLARE_DBTABLES_USER(dbUser);
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	flags &= ~OperationPrivilege::makeFlag(OPPRVLG_UPDATE_ALL_USER_ROLE);
 	OperationPrivilege privilege(flags);
 	HatoholError err = dbUser.updateUserRoleInfo(userRoleInfo, privilege);
@@ -1358,7 +1360,7 @@ void test_updateUserRoleWithAllPrivilegeFlags(void)
 {
 	size_t targetIndex = 1;
 	UserRoleInfo userRoleInfo = setupUserRoleInfoForUpdate(targetIndex);
-	userRoleInfo.flags = ALL_PRIVILEGES;
+	userRoleInfo.flags = OperationPrivilege::ALL_PRIVILEGES;
 	DECLARE_DBTABLES_USER(dbUser);
 	OperationPrivilege privilege(
 	  OperationPrivilege::makeFlag(OPPRVLG_UPDATE_ALL_USER_ROLE));
@@ -1372,7 +1374,7 @@ void test_updateUserRoleWithNonePrivilegeFlags(void)
 {
 	size_t targetIndex = 1;
 	UserRoleInfo userRoleInfo = setupUserRoleInfoForUpdate(targetIndex);
-	userRoleInfo.flags = NONE_PRIVILEGE;
+	userRoleInfo.flags = OperationPrivilege::NONE_PRIVILEGE;
 	DECLARE_DBTABLES_USER(dbUser);
 	OperationPrivilege privilege(
 	  OperationPrivilege::makeFlag(OPPRVLG_UPDATE_ALL_USER_ROLE));
@@ -1400,7 +1402,7 @@ void test_updateUserRoleWithInvalidFlags(void)
 {
 	size_t targetIndex = 1;
 	UserRoleInfo userRoleInfo = setupUserRoleInfoForUpdate(targetIndex);
-	userRoleInfo.flags = ALL_PRIVILEGES + 1;
+	userRoleInfo.flags = OperationPrivilege::ALL_PRIVILEGES + 1;
 	DECLARE_DBTABLES_USER(dbUser);
 	OperationPrivilege privilege(
 	  OperationPrivilege::makeFlag(OPPRVLG_UPDATE_ALL_USER_ROLE));
@@ -1414,7 +1416,7 @@ void test_deleteUserRole(void)
 {
 	DECLARE_DBTABLES_USER(dbUser);
 	const UserRoleIdType targetId = 2;
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	HatoholError err = dbUser.deleteUserRoleInfo(targetId, privilege);
 	assertHatoholError(HTERR_OK, err);
 

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -259,7 +259,7 @@ void test_addUser(void)
 void test_updateUser(void)
 {
 	const UserIdType targetId = 1;
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	const string user = "y@r@n@i0";
 	const string password = "=(-.-)zzZZ";
 
@@ -317,7 +317,7 @@ void test_updateUserWithInvalidFlags(void)
 void test_updateUserWithoutPassword(void)
 {
 	const UserIdType targetId = 1;
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	const string user = "y@r@n@i0";
 	const string expectedPassword = testUserInfo[targetId - 1].password;
 
@@ -340,7 +340,7 @@ void test_updateUserWithoutPassword(void)
 void test_updateUserWithoutUserId(void)
 {
 	const UserIdType targetId = 1;
-	OperationPrivilegeFlag flags = ALL_PRIVILEGES;
+	OperationPrivilegeFlag flags = OperationPrivilege::ALL_PRIVILEGES;
 	const string user = "y@r@n@i0";
 	const string expectedPassword = testUserInfo[targetId - 1].password;
 
@@ -502,12 +502,14 @@ static void assertUserRolesMapInParser(JSONParser *parser)
 	assertStartObject(parser, "userRoles");
 
 	string flagsStr =
-	  StringUtils::sprintf("%" FMT_OPPRVLG, NONE_PRIVILEGE);
+	  StringUtils::sprintf("%" FMT_OPPRVLG,
+			       OperationPrivilege::NONE_PRIVILEGE);
 	assertStartObject(parser, flagsStr);
 	assertValueInParser(parser, "name", string("Guest"));
 	parser->endObject();
 
-	flagsStr = StringUtils::sprintf("%" FMT_OPPRVLG, ALL_PRIVILEGES);
+	flagsStr = StringUtils::sprintf("%" FMT_OPPRVLG,
+					OperationPrivilege::ALL_PRIVILEGES);
 	assertStartObject(parser, flagsStr);
 	assertValueInParser(parser, "name", string("Admin"));
 	parser->endObject();
@@ -813,7 +815,8 @@ void test_addUserRoleWithoutPrivilege(void)
 {
 	StringMap params;
 	params["name"] = "maintainer";
-	params["flags"] = StringUtils::sprintf("%" FMT_OPPRVLG, ALL_PRIVILEGES);
+	params["flags"] = StringUtils::sprintf(
+	  "%" FMT_OPPRVLG, OperationPrivilege::ALL_PRIVILEGES);
 	bool operatorHasPrivilege = true;
 	assertAddUserRoleWithSetup(params, HTERR_NO_PRIVILEGE,
 				   !operatorHasPrivilege);
@@ -824,7 +827,8 @@ void test_addUserRoleWithoutPrivilege(void)
 void test_addUserRoleWithoutName(void)
 {
 	StringMap params;
-	params["flags"] = StringUtils::sprintf("%" FMT_OPPRVLG, ALL_PRIVILEGES);
+	params["flags"] = StringUtils::sprintf(
+	  "%" FMT_OPPRVLG, OperationPrivilege::ALL_PRIVILEGES);
 	assertAddUserRoleWithSetup(params, HTERR_NOT_FOUND_PARAMETER);
 
 	assertUserRolesInDB();
@@ -843,7 +847,8 @@ void test_addUserRoleWithEmptyUserName(void)
 {
 	StringMap params;
 	params["name"] = "";
-	params["flags"] = StringUtils::sprintf("%" FMT_OPPRVLG, ALL_PRIVILEGES);
+	params["flags"] = StringUtils::sprintf(
+	  "%" FMT_OPPRVLG, OperationPrivilege::ALL_PRIVILEGES);
 	assertAddUserRoleWithSetup(params, HTERR_EMPTY_USER_ROLE_NAME);
 
 	assertUserRolesInDB();
@@ -854,7 +859,7 @@ void test_addUserRoleWithInvalidFlags(void)
 	StringMap params;
 	params["name"] = "maintainer";
 	params["flags"] = StringUtils::sprintf(
-	  "%" FMT_OPPRVLG, ALL_PRIVILEGES + 1);
+	  "%" FMT_OPPRVLG, OperationPrivilege::ALL_PRIVILEGES + 1);
 	assertAddUserRoleWithSetup(params, HTERR_INVALID_PRIVILEGE_FLAGS);
 
 	assertUserRolesInDB();

--- a/server/test/testHatoholArmPluginGateHAPI2.cc
+++ b/server/test/testHatoholArmPluginGateHAPI2.cc
@@ -86,7 +86,7 @@ static void loadDummyHosts(void)
 {
 	ThreadLocalDBCache cache;
 	DBTablesHost &dbHost = cache.getHost();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	for (size_t i = 0; i < ARRAY_SIZE(dummyHosts); i++)
 		dbHost.upsertServerHostDef(dummyHosts[i]);
 }
@@ -216,7 +216,7 @@ void cut_setup(void)
 
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	MonitoringServerInfo serverInfo = monitoringServerInfo;
 	ArmPluginInfo pluginInfo = armPluginInfo;
 	dbConfig.addTargetServer(&serverInfo, privilege, &pluginInfo);
@@ -1180,7 +1180,7 @@ void prepareDB(const char *amqpURL)
 
 	ThreadLocalDBCache cache;
 	DBTablesConfig &dbConfig = cache.getConfig();
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	MonitoringServerInfo serverInfo = monitoringServerInfo;
 	ArmPluginInfo pluginInfo = armPluginInfo;
 	pluginInfo.brokerUrl = amqpURL;
@@ -2044,7 +2044,7 @@ void test_updateMonitoringServerInfo(void)
 	ArmPluginInfo pluginInfo = armPluginInfo;
 	dbConfig.getArmPluginInfo(pluginInfo, serverInfo.id);
 	serverInfo.baseURL = "http://www.example.net/zabbix/";
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	dbConfig.updateTargetServer(&serverInfo, privilege, &pluginInfo);
 
 	// delete the gate to emit updateMonitoringServerInfo notification

--- a/server/test/testOperationPrivilege.cc
+++ b/server/test/testOperationPrivilege.cc
@@ -98,13 +98,14 @@ void test_copyConstructorWithUserId(void)
 
 void test_getSpecifiedFlags(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
-	cppcut_assert_equal(ALL_PRIVILEGES, privilege.getFlags());
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
+	cppcut_assert_equal(OperationPrivilege::ALL_PRIVILEGES,
+			    privilege.getFlags());
 }
 
 void test_allPrivileges(void)
 {
-	OperationPrivilege privilege(ALL_PRIVILEGES);
+	OperationPrivilege privilege(OperationPrivilege::ALL_PRIVILEGES);
 	cppcut_assert_equal(true, privilege.has(OPPRVLG_CREATE_USER));
 }
 

--- a/server/tools/hatohol-def-src-file-generator.cc
+++ b/server/tools/hatohol-def-src-file-generator.cc
@@ -217,8 +217,10 @@ static void makeDefSourceValues(string &s, LanguageType langType)
 	//
 	// OperationPrivilege
 	//
-	ADD_LINE(s, langType, ALL_PRIVILEGES);
-	ADD_LINE(s, langType, NONE_PRIVILEGE);
+	DEF_LINE(s, langType, ALL_PRIVILEGES, OperationPrivilegeFlag,
+		 OperationPrivilege::ALL_PRIVILEGES);
+	DEF_LINE(s, langType, NONE_PRIVILEGE, OperationPrivilegeFlag,
+		 OperationPrivilege::NONE_PRIVILEGE);
 
 	ADD_LINE(s, langType, OPPRVLG_CREATE_USER);
 	ADD_LINE(s, langType, OPPRVLG_UPDATE_USER);


### PR DESCRIPTION
Revise #1824.

Suppress the following compile time warnings:

OperationPrivilege.h:115:37: warning: 'ALL_PRIVILEGES' defined but not used [-Wunused-variable]
  const static OperationPrivilegeFlag ALL_PRIVILEGES =

In addition, remove an unused variable.
