### PR TITLE
[RestResourceHost] Implement POST method for incident

### DIFF
--- a/server/common/HatoholError.cc
+++ b/server/common/HatoholError.cc
@@ -195,6 +195,11 @@ void HatoholError::init(void)
 		   "HAP2 connection unavailable.");
 	DEFINE_ERR(INVALID_OBJECT_PASSED_BY_HAP2,
 		   "Invalid object passed by HAP2.");
+
+	// 16.01
+	// DBClient
+	DEFINE_ERR(RECORD_EXISTS,
+		   "The record already exists.");
 }
 
 void HatoholError::defineError(const HatoholErrorCode errorCode,

--- a/server/common/HatoholError.h
+++ b/server/common/HatoholError.h
@@ -124,6 +124,10 @@ enum HatoholErrorCode
 	HTERR_FAILED_CONNECT_HAP2, // for HAPI 2.0
 	HTERR_INVALID_OBJECT_PASSED_BY_HAP2, // for HAPI 2.0
 
+	// 16.01
+	// DBClient
+	HTERR_RECORD_EXISTS,
+
 	// End of code
 	NUM_HATOHOL_ERROR_CODE
 };

--- a/server/src/RestResourceHost.h
+++ b/server/src/RestResourceHost.h
@@ -36,7 +36,10 @@ struct RestResourceHost : public RestResourceMemberHandler
 	void handlerGetTrigger(void);
 	void handlerGetEvent(void);
 	void handlerIncident(void);
+	void handlerPostIncident(void);
 	void handlerPutIncident(void);
+	void createIncidentAsync(const UnifiedEventIdType &eventId,
+				 const IncidentTrackerIdType &trackerId);
 	void handlerGetHostgroup(void);
 	void handlerGetItem(void);
 	void replyGetItem(void);

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -2232,6 +2232,15 @@ void loadHostInfoCache(
 	}
 }
 
+IncidentTrackerIdType findIncidentTrackerIdByType(IncidentTrackerType type)
+{
+	for (auto &tracker : testIncidentTrackerInfo) {
+		if (tracker.type == type)
+			return tracker.id;
+	}
+	return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Setup methods
 // ---------------------------------------------------------------------------

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -235,6 +235,8 @@ extern const MonitoringSystemType MONITORING_SYSTEM_HAPI_TEST_PASSIVE;
 void loadHostInfoCache(
   HostInfoCache &hostInfoCache, const ServerIdType &serverId);
 
+IncidentTrackerIdType findIncidentTrackerIdByType(IncidentTrackerType type);
+
 /**
  * Setup database for test.
  *


### PR DESCRIPTION
Following two parameters are required to post an incident:

* unifiedEventId
* incidentTrackerId

Parameters of the incident are generated from the specified event.

For issue #681 