### PR TITLE
[server] Register a host for self monitor (#1836).

### DIFF
--- a/server/src/SelfMonitor.cc
+++ b/server/src/SelfMonitor.cc
@@ -27,6 +27,8 @@
 using namespace std;
 using namespace mlpl;
 
+const char *SelfMonitor::DEFAULT_SELF_MONITOR_HOST_NAME = "(self-monitor)";
+
 struct SelfMonitor::Impl
 {
 	TriggerInfo        triggerInfo;
@@ -66,6 +68,7 @@ struct SelfMonitor::Impl
 	{
 		initEventGenerators();
 		setupTriggerInfo(serverId, triggerId, brief, severity);
+		setupHostForSelfMonitor(serverId);
 	}
 
 	bool hasTriggerId(void)
@@ -92,7 +95,7 @@ struct SelfMonitor::Impl
 		  SmartTime::getCurrTime().getAsTimespec();
 		triggerInfo.globalHostId = INAPPLICABLE_HOST_ID;
 		triggerInfo.hostIdInServer = MONITORING_SELF_LOCAL_HOST_ID;
-		triggerInfo.hostName = "(SELF MONITOR)";
+		triggerInfo.hostName = DEFAULT_SELF_MONITOR_HOST_NAME;
 
 		triggerInfo.brief = brief;
 		triggerInfo.extendedInfo.clear();
@@ -100,6 +103,19 @@ struct SelfMonitor::Impl
 
 		ThreadLocalDBCache cache;
 		cache.getMonitoring().addTriggerInfo(&triggerInfo);
+	}
+
+	void setupHostForSelfMonitor(const ServerIdType &serverId)
+	{
+		ServerHostDef svHostDef;
+		svHostDef.id = AUTO_INCREMENT_VALUE;
+		svHostDef.hostId = AUTO_ASSIGNED_ID;
+		svHostDef.serverId = serverId;
+		svHostDef.hostIdInServer = MONITORING_SELF_LOCAL_HOST_ID;
+		svHostDef.name = DEFAULT_SELF_MONITOR_HOST_NAME;
+		svHostDef.status = HOST_STAT_SELF_MONITOR;
+		ThreadLocalDBCache cache;
+		cache.getHost().upsertHost(svHostDef);
 	}
 
 	void initEventGenerators(void)

--- a/server/src/SelfMonitor.h
+++ b/server/src/SelfMonitor.h
@@ -31,6 +31,7 @@ typedef std::weak_ptr<SelfMonitor> SelfMonitorWeakPtr;
 
 class SelfMonitor {
 public:
+	static const char *DEFAULT_SELF_MONITOR_HOST_NAME;
 	typedef std::function<void (
 	          SelfMonitor &monitor,
 	          const TriggerStatusType &prevStatus,

--- a/server/test/testHatoholArmPluginGateHAPI2.cc
+++ b/server/test/testHatoholArmPluginGateHAPI2.cc
@@ -595,6 +595,7 @@ void test_procedureHandlerPutHosts(void)
 	DBTablesHost &dbHost = cache.getHost();
 	ServerHostDefVect hostDefVect;
 	HostsQueryOption option(USER_ID_SYSTEM);
+	option.setStatus(HOST_STAT_NORMAL);
 	option.setTargetServerId(monitoringServerInfo.id);
 	dbHost.getServerHostDefs(hostDefVect, option);
 	string actualOutput;
@@ -640,6 +641,7 @@ void test_procedureHandlerPutHostsInvalidJSON(void)
 	DBTablesHost &dbHost = cache.getHost();
 	ServerHostDefVect hostDefVect;
 	HostsQueryOption option(USER_ID_SYSTEM);
+	option.setStatus(HOST_STAT_NORMAL);
 	option.setTargetServerId(monitoringServerInfo.id);
 	dbHost.getServerHostDefs(hostDefVect, option);
 	cppcut_assert_equal(hostDefVect.size(), static_cast<size_t>(0));


### PR DESCRIPTION
Previously, the host name is not correctly shown in WebUI.
This patch shows it as "(self-monitor)".