### PR TITLE
[EventsView] Apply user-defined incident labels to filer settings candidates

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -153,6 +153,7 @@ var EventsView = function(userProfile, options) {
   function start() {
     $.when(loadUserConfig(), loadSeverityRank(), loadCustomIncidentStatus()).done(function() {
       load();
+      applyCustomIncidentLabelsToEventsConfig();
     }).fail(function() {
       hatoholInfoMsgBox(gettext("Failed to get the configuration!"));
       load(); // Ensure to work with the default config
@@ -233,6 +234,53 @@ var EventsView = function(userProfile, options) {
       },
     });
     return deferred.promise();
+  }
+
+  function applyCustomIncidentLabelsToEventsConfig() {
+    var defaultCandidates = self.defaultIncidentStatusesMap;
+    var candidates = self.customIncidentStatusesMap;
+    var customIncidentLabelChoices = [];
+
+    if (Object.keys(candidates).length == 0)
+      candidates = defaultCandidates;
+
+    $.map(candidates, function(aCandidate) {
+      var option;
+      var label = null;
+
+      if (aCandidate.label !== "") {
+        label = aCandidate.label;
+      } else if ( aCandidate.label == "" && defaultCandidates[aCandidate.code]) {
+        label = defaultCandidates[aCandidate.code].label;
+      }
+
+      if (label && aCandidate) {
+        customIncidentLabelChoices.push({
+          label: label,
+          value: aCandidate.code
+        });
+      }
+    });
+    var customEventPropertyChoices = {
+      incident: customIncidentLabelChoices,
+      status: eventPropertyChoices.status,
+      type: eventPropertyChoices.type,
+      severity: eventPropertyChoices.severity,
+    };
+    self.userConfig = new HatoholEventsViewConfig({
+      columnDefinitions: columnDefinitions,
+      filterCandidates: customEventPropertyChoices,
+      loadedCallback: function(config) {
+        applyConfig(config);
+        updatePager();
+        setupFilterValues();
+        setupCallbacks();
+      },
+      savedCallback: function(config) {
+        applyConfig(config);
+        load();
+      },
+    });
   }
 
   function applyConfig(config) {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -267,20 +267,7 @@ var EventsView = function(userProfile, options) {
       type: eventPropertyChoices.type,
       severity: eventPropertyChoices.severity,
     };
-    self.userConfig = new HatoholEventsViewConfig({
-      columnDefinitions: columnDefinitions,
-      filterCandidates: customEventPropertyChoices,
-      loadedCallback: function(config) {
-        applyConfig(config);
-        updatePager();
-        setupFilterValues();
-        setupCallbacks();
-      },
-      savedCallback: function(config) {
-        applyConfig(config);
-        load();
-      },
-    });
+    self.userConfig.setFilterCandidates(customEventPropertyChoices);
   }
 
   function applyConfig(config) {

--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -514,6 +514,7 @@ HatoholEventsViewConfig.prototype.setFilterCandidates = function(candidates) {
   var self = this;
 
   self.options.filterCandidates = candidates;
+  self.resetFilterList();
 };
 
 HatoholEventsViewConfig.prototype.setCurrentFilterConfig = function(filter) {

--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -514,7 +514,7 @@ HatoholEventsViewConfig.prototype.setFilterCandidates = function(candidates) {
   var self = this;
 
   self.options.filterCandidates = candidates;
-  self.resetFilterList();
+  self.setCurrentFilterConfig();
 };
 
 HatoholEventsViewConfig.prototype.setCurrentFilterConfig = function(filter) {

--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -510,6 +510,12 @@ HatoholEventsViewConfig.prototype.resetFilterList = function() {
   };
 };
 
+HatoholEventsViewConfig.prototype.setFilterCandidates = function(candidates) {
+  var self = this;
+
+  self.options.filterCandidates = candidates;
+};
+
 HatoholEventsViewConfig.prototype.setCurrentFilterConfig = function(filter) {
   var self = this;
 


### PR DESCRIPTION
Related to #1834.

If users set up following custom incident labels,

![screenshot from 2015-12-18 12 01 53](https://cloud.githubusercontent.com/assets/700876/11888287/2b2659c6-a57f-11e5-9bec-a5cb18e01e07.png)

Incident filter candidates are shown like this:

![screenshot from 2015-12-18 12 03 49](https://cloud.githubusercontent.com/assets/700876/11888311/6a2f9074-a57f-11e5-9cc5-8cea5d30698f.png)

![screenshot from 2015-12-18 12 04 14](https://cloud.githubusercontent.com/assets/700876/11888324/7aa68a66-a57f-11e5-9719-ae64d7a3015c.png)
