### PR TITLE
[EventsView] Enable to post new incident

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -630,7 +630,7 @@ var EventsView = function(userProfile, options) {
 
   function updateIncidentStatus() {
     var status = $("#change-incident").val();
-    var unifiedId;
+    var unifiedId, trackerId;
     var incidents = $(".incident.selected");
     var promise, promises = [], errors = [];
     var errorMessage;
@@ -639,7 +639,8 @@ var EventsView = function(userProfile, options) {
       return;
 
     for (var i = 0; i < incidents.length; i++) {
-      unifiedId = incidents[i].getAttribute("data-unified-id");
+      unifiedId = parseInt(incidents[i].getAttribute("data-unified-id"));
+      trackerId = parseInt(incidents[i].getAttribute("data-tracker-id"));
       promise = applyIncidentStatus(unifiedId, errors);
       promises.push(promise);
     }
@@ -1063,9 +1064,11 @@ var EventsView = function(userProfile, options) {
   function renderTableDataIncidentStatus(event, server) {
     var html = "", incident = getIncident(event);
     var unifiedId = event["unifiedId"];
+    var trackerId = incident["trackerId"];
 
     html += "<td class='selectable incident " + getSeverityClass(event) + "'";
-    html += "data-unified-id='" + unifiedId + "'";
+    html += " data-unified-id='" + unifiedId + "'";
+    html += " data-tracker-id='" + trackerId + "'";
     html += " style='display:none;'>";
 
     if (!incident)

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -761,6 +761,12 @@ var EventsView = function(userProfile, options) {
           message += " " + parser.optionMessages;
         errors.push(message);
       },
+      connectErrorCallback: function() {
+        var message =
+          gettext("Failed to connect to Hatohol server on changing treatment of an event with ID: ") +
+          eventId;
+        errors.push(message);
+      },
       completionCallback: function() {
         deferred.resolve();
       },

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -634,14 +634,35 @@ var EventsView = function(userProfile, options) {
     var incidents = $(".incident.selected");
     var promise, promises = [], errors = [];
     var errorMessage;
+    var selectedTrackerId = undefined;
+    var i;
 
     if (!status)
       return;
 
-    for (var i = 0; i < incidents.length; i++) {
+    // Select an incident tracker to post new incidents
+    for (i = 0; i < incidents.length; i++) {
+      trackerId = parseInt(incidents[i].getAttribute("data-tracker-id"));
+      if (isNaN(trackerId)) {
+        selectedTrackerId = chooseIncidentTracker();
+        if (!selectedTrackerId) {
+          errorMessage = gettext("There is no valid incident tracker to post!");
+          hatoholErrorMsgBox(errorMessage);
+          return;
+        }
+        break;
+      }
+    }
+
+    // update existing incidents and post new incidents
+    for (i = 0; i < incidents.length; i++) {
       unifiedId = parseInt(incidents[i].getAttribute("data-unified-id"));
       trackerId = parseInt(incidents[i].getAttribute("data-tracker-id"));
-      promise = applyIncidentStatus(unifiedId, errors);
+      if (trackerId > 0) {
+        promise = applyIncidentStatus(unifiedId, status, errors);
+      } else {
+        promise = addIncident(unifiedId, selectedTrackerId, status, errors);
+      }
       promises.push(promise);
     }
 
@@ -665,8 +686,60 @@ var EventsView = function(userProfile, options) {
     }
   }
 
-  function applyIncidentStatus(incidentId, errors) {
-    var status = $("#change-incident").val();
+  function chooseIncidentTracker() {
+    var trackers = self.rawData.incidentTrackers;
+    var ids = Object.keys(trackers), id;
+
+    // TODO: show a selection dialog when plural trackers exist
+
+    for (var i = 0; i < ids.length; i++) {
+      id = ids[i];
+      if (trackers[id].type == hatohol.INCIDENT_TRACKER_HATOHOL) {
+        return id;
+      }
+    }
+    return undefined;
+  }
+
+  function addIncident(eventId, trackerId, status, errors) {
+    var deferred = new $.Deferred;
+    new HatoholConnector({
+      url: "/incident",
+      request: "POST",
+      data: {
+	  unifiedEventId: eventId,
+	  incidentTrackerId: trackerId,
+      },
+      replyCallback: function() {
+        var promise = applyIncidentStatus(eventId, status, errors);
+        $.when(promise).done(function() {
+          deferred.resolve();
+        });
+      },
+      parseErrorCallback: function(reply, parser)  {
+        var message = parser.getMessage();
+        if (!message) {
+          message =
+            gettext("An unknown error occured on creating an incident for the event: ") +
+            eventId;
+        }
+        if (parser.optionMessages)
+          message += " " + parser.optionMessages;
+        errors.push(message);
+        deferred.resolve();
+      },
+      connectErrorCallback: function() {
+        var message =
+          gettext("Failed to connect to Hatohol server on posting an incident for the event: ") +
+          eventId;
+        errors.push(message);
+        deferred.resolve();
+      },
+    });
+    return deferred.promise();
+  }
+
+  function applyIncidentStatus(incidentId, status, errors) {
     var deferred = new $.Deferred;
     var url = "/incident";
     url += "/" + incidentId;
@@ -1068,7 +1141,10 @@ var EventsView = function(userProfile, options) {
 
     html += "<td class='selectable incident " + getSeverityClass(event) + "'";
     html += " data-unified-id='" + unifiedId + "'";
-    html += " data-tracker-id='" + trackerId + "'";
+    if (trackerId > 0)
+      html += " data-tracker-id='" + trackerId + "'";
+    else
+      html += " data-tracker-id=''";
     html += " style='display:none;'>";
 
     if (!incident)

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -665,11 +665,11 @@ var EventsView = function(userProfile, options) {
     }
   }
 
-  function applyIncidentStatus(updateIncidentId, errors) {
+  function applyIncidentStatus(incidentId, errors) {
     var status = $("#change-incident").val();
     var deferred = new $.Deferred;
     var url = "/incident";
-    url += "/" + updateIncidentId;
+    url += "/" + incidentId;
     new HatoholConnector({
       url: url,
       request: "PUT",
@@ -682,7 +682,7 @@ var EventsView = function(userProfile, options) {
         if (!message) {
           message =
             gettext("An unknown error occured on changing treatment of an event with ID: ") +
-            updateIncidentId;
+            incidentId;
         }
         if (parser.optionMessages)
           message += " " + parser.optionMessages;

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -423,7 +423,7 @@ var EventsView = function(userProfile, options) {
       if (exclude && !selected[unifiedId])
         return true;
       return false;
-    }
+    };
     var elementId = "#select-" + type;
 
     if (type == "hostgroup")

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -630,7 +630,7 @@ var EventsView = function(userProfile, options) {
 
   function updateIncidentStatus() {
     var status = $("#change-incident").val();
-    var updateIncidentIds = [], unifiedId;
+    var unifiedId;
     var incidents = $(".incident.selected");
     var promise, promises = [], errors = [];
     var errorMessage;
@@ -640,11 +640,7 @@ var EventsView = function(userProfile, options) {
 
     for (var i = 0; i < incidents.length; i++) {
       unifiedId = incidents[i].getAttribute("data-unified-id");
-      updateIncidentIds.push(unifiedId);
-    }
-
-    for (var idx = 0; idx < updateIncidentIds.length; idx++) {
-      promise = applyIncidentStatus(updateIncidentIds[idx], errors);
+      promise = applyIncidentStatus(unifiedId, errors);
       promises.push(promise);
     }
 

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -434,6 +434,7 @@ static void addIncident(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 			const IncidentInfo &incident)
 {
 	agent.startObject("incident");
+	agent.add("trackerId", incident.trackerId);
 	agent.add("identifier", incident.identifier);
 	agent.add("location", incident.location);
 	agent.add("status", incident.status);


### PR DESCRIPTION
When Hatohol server doesn't register an incident for an event, Hatohol client can't update the status of
the incident. This patch fixes this issue by posting a new incident before changing it's status.

Currently this feature is enabled for INCIDENT_TRACKER_HATOHOL only.
When other type of incident trackers are enabled, the feature that changing incident status isn't enabled.
