### PR TITLE
[EventsView] Enable to post new incident

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -630,7 +630,7 @@ var EventsView = function(userProfile, options) {
 
   function updateIncidentStatus() {
     var status = $("#change-incident").val();
-    var unifiedId;
+    var unifiedId, trackerId;
     var incidents = $(".incident.selected");
     var promise, promises = [], errors = [];
     var errorMessage;
@@ -639,7 +639,8 @@ var EventsView = function(userProfile, options) {
       return;
 
     for (var i = 0; i < incidents.length; i++) {
-      unifiedId = incidents[i].getAttribute("data-unified-id");
+      unifiedId = parseInt(incidents[i].getAttribute("data-unified-id"));
+      trackerId = parseInt(incidents[i].getAttribute("data-tracker-id"));
       promise = applyIncidentStatus(unifiedId, errors);
       promises.push(promise);
     }
@@ -1063,9 +1064,11 @@ var EventsView = function(userProfile, options) {
   function renderTableDataIncidentStatus(event, server) {
     var html = "", incident = getIncident(event);
     var unifiedId = event["unifiedId"];
+    var trackerId = incident["trackerId"];
 
     html += "<td class='selectable incident " + getSeverityClass(event) + "'";
-    html += "data-unified-id='" + unifiedId + "'";
+    html += " data-unified-id='" + unifiedId + "'";
+    html += " data-tracker-id='" + trackerId + "'";
     html += " style='display:none;'>";
 
     if (!incident)

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1148,7 +1148,7 @@ var EventsView = function(userProfile, options) {
     if (!incident)
       return html + "</td>";
 
-    if (!incident.localtion)
+    if (!incident.location)
       return html + getIncidentStatusLabel(event) + "</td>";
 
     html += "<a href='" + escapeHTML(incident.location)

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -665,11 +665,11 @@ var EventsView = function(userProfile, options) {
     }
   }
 
-  function applyIncidentStatus(updateIncidentId, errors) {
+  function applyIncidentStatus(incidentId, errors) {
     var status = $("#change-incident").val();
     var deferred = new $.Deferred;
     var url = "/incident";
-    url += "/" + updateIncidentId;
+    url += "/" + incidentId;
     new HatoholConnector({
       url: url,
       request: "PUT",
@@ -682,7 +682,7 @@ var EventsView = function(userProfile, options) {
         if (!message) {
           message =
             gettext("An unknown error occured on changing treatment of an event with ID: ") +
-            updateIncidentId;
+            incidentId;
         }
         if (parser.optionMessages)
           message += " " + parser.optionMessages;

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -423,7 +423,7 @@ var EventsView = function(userProfile, options) {
       if (exclude && !selected[unifiedId])
         return true;
       return false;
-    }
+    };
     var elementId = "#select-" + type;
 
     if (type == "hostgroup")

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -630,7 +630,7 @@ var EventsView = function(userProfile, options) {
 
   function updateIncidentStatus() {
     var status = $("#change-incident").val();
-    var updateIncidentIds = [], unifiedId;
+    var unifiedId;
     var incidents = $(".incident.selected");
     var promise, promises = [], errors = [];
     var errorMessage;
@@ -640,11 +640,7 @@ var EventsView = function(userProfile, options) {
 
     for (var i = 0; i < incidents.length; i++) {
       unifiedId = incidents[i].getAttribute("data-unified-id");
-      updateIncidentIds.push(unifiedId);
-    }
-
-    for (var idx = 0; idx < updateIncidentIds.length; idx++) {
-      promise = applyIncidentStatus(updateIncidentIds[idx], errors);
+      promise = applyIncidentStatus(unifiedId, errors);
       promises.push(promise);
     }
 

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -434,6 +434,7 @@ static void addIncident(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 			const IncidentInfo &incident)
 {
 	agent.startObject("incident");
+	agent.add("trackerId", incident.trackerId);
 	agent.add("identifier", incident.identifier);
 	agent.add("location", incident.location);
 	agent.add("status", incident.status);


### PR DESCRIPTION
Revise #1848 

When Hatohol server doesn't register an incident for an event, Hatohol client can't update the status of
the incident. This patch fixes this issue by posting a new incident before changing it's status.

Currently this feature is enabled for INCIDENT_TRACKER_HATOHOL only.
When other type of incident trackers are enabled, the feature that changing incident status isn't enabled.
