### PR TITLE
[hatohol-db-initiator] Add a default incident sender

### DIFF
--- a/server/data/Makefile.am
+++ b/server/data/Makefile.am
@@ -8,7 +8,9 @@ sql_DATA = \
 	server-type-hap2-ceilometer.sql \
 	server-type-hap2-fluentd.sql \
 	severity-ranks.sql \
-	custom-incident-statuses.sql
+	custom-incident-statuses.sql \
+	incident-trackers.sql \
+	actions.sql
 
 if WITH_QPID
 sql_DATA += \

--- a/server/data/Makefile.am
+++ b/server/data/Makefile.am
@@ -1,7 +1,14 @@
 sql_DATA = \
 	create-db.sql \
+	init-user.sql \
 	server-type-zabbix.sql \
-	server-type-nagios.sql
+	server-type-nagios.sql \
+	server-type-hap2-zabbix.sql \
+	server-type-hap2-nagios.sql \
+	server-type-hap2-ceilometer.sql \
+	server-type-hap2-fluentd.sql \
+	severity-ranks.sql \
+	custom-incident-statuses.sql
 
 if WITH_QPID
 sql_DATA += \
@@ -9,15 +16,6 @@ sql_DATA += \
 	server-type-hapi-json.sql \
 	server-type-ceilometer.sql
 endif
-
-sql_DATA += \
-	server-type-hap2-zabbix.sql \
-	server-type-hap2-nagios.sql \
-	server-type-hap2-ceilometer.sql \
-	server-type-hap2-fluentd.sql \
-	init-user.sql \
-	severity-ranks.sql \
-	custom-incident-statuses.sql
 
 sqldir = $(pkgdatadir)/sql
 

--- a/server/data/actions.sql
+++ b/server/data/actions.sql
@@ -1,0 +1,5 @@
+INSERT actions VALUES
+  (0, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+   2,
+   (select id from incident_trackers where type=1 order by id limit 1),
+   '', 0, 0);

--- a/server/data/incident-trackers.sql
+++ b/server/data/incident-trackers.sql
@@ -1,0 +1,1 @@
+INSERT incident_trackers VALUES (0, '1', '', '', '', '', '', '');

--- a/server/tools/hatohol-db-initiator.in
+++ b/server/tools/hatohol-db-initiator.in
@@ -70,6 +70,12 @@ sql_file_list.extend([
     {'table_name': 'custom_incident_statuses',
      'file_name': 'custom-incident-statuses.sql',
      'target': 'custom-incident-statuses'},
+    {'table_name': 'incident_trackers',
+     'file_name': 'incident-trackers.sql',
+     'target': 'incident-trackers'},
+    {'table_name': 'actions',
+     'file_name': 'actions.sql',
+     'target': 'actions'},
 ])
 
 config_map = {


### PR DESCRIPTION
To make it easy to use the incident feature of Hatohol, insert an incident tracker and
an incident sender action by default.
