### PR TITLE
Make some self monitors stateless.

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -52,6 +52,16 @@ struct JSONRPCError {
 	const StringList &getErrors(void) {
 		return errors;
 	}
+
+	string getConcatenatedMessage(void) const {
+		string s;
+		for (const auto &errMsg: errors) {
+			if (!s.empty())
+				s += " || ";
+			s += errMsg;
+		}
+		return s;
+	}
 };
 
 #define PARSE_AS_MANDATORY(MEMBER, VALUE, RPCERR)			\
@@ -129,11 +139,11 @@ struct HatoholArmPluginGateHAPI2::Impl
 	    HatoholError::getMessage(HTERR_HAP_INTERNAL_ERROR),
 	    TRIGGER_SEVERITY_CRITICAL)),
 	  monitorParseError(new SelfMonitor(
-	    _serverInfo.id, FAILED_PARSER_JSON_DATA_TRIGGER_ID,
+	    _serverInfo.id, SelfMonitor::STATELESS_MONITOR,
 	    HatoholError::getMessage(HTERR_INVALID_OBJECT_PASSED_BY_HAP2),
 	    TRIGGER_SEVERITY_CRITICAL)),
 	  monitorGateInternal(new SelfMonitor(
-	    _serverInfo.id, FAILED_INTERNAL_ERROR_TRIGGER_ID,
+	    _serverInfo.id, SelfMonitor::STATELESS_MONITOR,
 	    HatoholError::getMessage(HTERR_INTERNAL_ERROR),
 	    TRIGGER_SEVERITY_CRITICAL)),
 	  monitorBrokerConn(new SelfMonitor(
@@ -146,8 +156,9 @@ struct HatoholArmPluginGateHAPI2::Impl
 		DBTablesConfig &dbConfig = cache.getConfig();
 		const ServerIdType &serverId = m_serverInfo.id;
 		if (!dbConfig.getArmPluginInfo(m_pluginInfo, serverId)) {
-			MLPL_ERR("Failed to get ArmPluginInfo: serverId: %d\n",
-				 serverId);
+			internalError(
+			  "Failed to get ArmPluginInfo: serverId: %d\n",
+			   serverId);
 			return;
 		}
 		if (m_pluginInfo.staticQueueAddress.empty()) {
@@ -175,6 +186,29 @@ struct HatoholArmPluginGateHAPI2::Impl
 			delete closure;
 		}
 		m_armStatus.setRunningStatus(false);
+	}
+
+	void logError(SelfMonitorPtr monitor, const char *fmt, va_list ap)
+	{
+		string msg = StringUtils::vsprintf(fmt, ap);
+		MLPL_ERR("%s", msg.c_str());
+		monitor->saveEvent(msg, EVENT_TYPE_BAD);
+	}
+
+	void internalError(const char *fmt, ...)
+	{
+		va_list ap;
+		va_start(ap, fmt);
+		logError(monitorGateInternal, fmt, ap);
+		va_end(ap);
+	}
+
+	void parseError(const char *fmt, ...)
+	{
+		va_list ap;
+		va_start(ap, fmt);
+		logError(monitorParseError, fmt, ap);
+		va_end(ap);
 	}
 
 	void setupSelfMonitors(void)
@@ -299,16 +333,16 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 		virtual void onGotResponse(JSONParser &parser) override
 		{
-			bool isErr = parser.isMember("error");
-			updateSelfMonitor(m_impl.monitorParseError, isErr);
-			if (isErr) {
+			if (parser.isMember("error")) {
 				string errorMessage;
 				parser.startObject("error");
 				parser.read("message", errorMessage);
 				parser.endObject();
-				MLPL_WARN("Received an error on calling "
-					  "exchangeProfile: %s\n",
-					  errorMessage.c_str());
+				// TODO: Consider this is really parse error?
+				m_impl.parseError(
+				  "Received an error on calling "
+				  "exchangeProfile: %s\n",
+				  errorMessage.c_str());
 				return;
 			}
 
@@ -319,9 +353,7 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 			setArmInfoStatus(errObj);
 
-			isErr = errObj.hasErrors();
-			updateSelfMonitor(m_impl.monitorParseError, isErr);
-			if (isErr)
+			if (errObj.hasErrors())
 				return;
 
 			m_impl.m_hapi2.setEstablished(true);
@@ -638,10 +670,10 @@ struct HatoholArmPluginGateHAPI2::Impl
 			       flags, NULL, NULL, NULL, NULL,
 			       &exitStatus, &error);
 		if (!succeeded) {
-			MLPL_ERR("Failed to %s: %s\n",
-				 command.c_str(), scriptPath.c_str());
+			internalError("Failed to %s: %s\n",
+			              command.c_str(), scriptPath.c_str());
 			// The error always exists in this case.
-			MLPL_ERR("Reason: %s\n", error->message);
+			internalError("Reason: %s\n", error->message);
 			g_error_free(error);
 			return false;
 		}
@@ -662,10 +694,10 @@ struct HatoholArmPluginGateHAPI2::Impl
 		dataStore->getTargetServers(monitoringServers, option);
 
 		if (monitoringServers.size() == 0) {
-			MLPL_ERR("Target monitoring server is not found.\n");
+			internalError("Target monitoring server is not found.\n");
 			return HTERR_UNKNOWN_REASON;
 		} else if (monitoringServers.size() > 1) {
-			MLPL_ERR("Multiple monitoring servers is tied up.\n");
+			internalError("Multiple monitoring servers is tied up.\n");
 			return HTERR_UNKNOWN_REASON;
 		}
 		monitoringServerInfo = *monitoringServers.begin();
@@ -812,7 +844,6 @@ HatoholArmPluginGateHAPI2::HatoholArmPluginGateHAPI2(
 
 void HatoholArmPluginGateHAPI2::start(void)
 {
-	updateSelfMonitor(m_impl->monitorGateInternal, false);
 	HatoholArmPluginInterfaceHAPI2::start();
 	m_impl->start();
 	m_impl->startPlugin();
@@ -1148,9 +1179,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerLastInfo(JSONParser &parser)
 	JSONRPCError errObj;
 	parseLastInfoParams(parser, lastInfoType, errObj);
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1267,9 +1297,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutItems(JSONParser &parser)
 
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1341,9 +1370,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHistory(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1428,9 +1456,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHosts(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1506,9 +1533,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHostGroups(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1609,9 +1635,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHostGroupMembership(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1777,9 +1802,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutTriggers(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1918,9 +1942,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutEvents(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -1998,9 +2021,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutHostParents(
 	}
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -2068,9 +2090,8 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutArmInfo(
 
 	parser.endObject(); // params
 
-	updateSelfMonitor(m_impl->monitorParseError, errObj.hasErrors());
-
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);
@@ -2079,6 +2100,12 @@ string HatoholArmPluginGateHAPI2::procedureHandlerPutArmInfo(
 	status.setArmInfo(armInfo);
 	updateSelfMonitor(m_impl->monitorPluginInternal,
 	                  armInfo.stat != ARM_WORK_STAT_OK);
+	if (armInfo.stat == ARM_WORK_STAT_FAILURE &&
+	    !armInfo.failureComment.empty()) {
+		string msg = "Plugin Error: ";
+		msg += armInfo.failureComment;
+		m_impl->monitorPluginInternal->saveEvent(msg, EVENT_TYPE_BAD);
+	}
 
 	// TODO: add failure clause
 	string result = "SUCCESS";

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -353,8 +353,10 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 			setArmInfoStatus(errObj);
 
-			if (errObj.hasErrors())
+			if (errObj.hasErrors()) {
+				m_impl.parseError(errObj.getConcatenatedMessage().c_str());
 				return;
+			}
 
 			m_impl.m_hapi2.setEstablished(true);
 		}
@@ -1092,6 +1094,7 @@ string HatoholArmPluginGateHAPI2::procedureHandlerExchangeProfile(
 	parser.endObject(); // params
 
 	if (errObj.hasErrors()) {
+		m_impl->parseError(errObj.getConcatenatedMessage().c_str());
 		return HatoholArmPluginInterfaceHAPI2::buildErrorResponse(
 		  JSON_RPC_INVALID_PARAMS, "Invalid method parameter(s).",
 		  &errObj.getErrors(), &parser);

--- a/server/src/SelfMonitor.h
+++ b/server/src/SelfMonitor.h
@@ -31,7 +31,9 @@ typedef std::weak_ptr<SelfMonitor> SelfMonitorWeakPtr;
 
 class SelfMonitor {
 public:
+	static const TriggerIdType STATELESS_MONITOR;
 	static const char *DEFAULT_SELF_MONITOR_HOST_NAME;
+
 	typedef std::function<void (
 	          SelfMonitor &monitor,
 	          const TriggerStatusType &prevStatus,
@@ -44,6 +46,22 @@ public:
 	          const TriggerStatusType &newStatus)
 	> NotificationHandler;
 
+	/**
+	 * Constructor.
+	 *
+	 * @param serverId
+	 * A serverId that is concerned with this monitor.
+	 *
+	 * @param triggerID
+	 * A trigger ID of this monitor. If STATELESS_TRIGGER is given,
+	 * the monitor is not listed in the trigger list and doesn't work as
+	 * a normal trigger.
+	 * This is typically used when the monitoring target doesn't
+	 * have a state, but generates events.
+	 *
+	 * @param brief    A brief message of this monitor.
+	 * @param severity A severity of this monitor.
+	 */
 	SelfMonitor(
 	  const ServerIdType &serverId,
 	  const TriggerIdType &triggerId,

--- a/server/test/testSelfMonitor.cc
+++ b/server/test/testSelfMonitor.cc
@@ -130,6 +130,15 @@ void test_constructor_define_same_multiple()
 	test_constructor();
 }
 
+void test_constructorWithStatelessTrigger(void)
+{
+	const ServerIdType serverId = 1035;
+	const string brief = "Test stateless trigger for self monitoring.";
+	SelfMonitor monitor(serverId, SelfMonitor::STATELESS_MONITOR, brief);
+	assertTriggerDB("");
+	assertHostDB(expectedServerHostDefDBContent(serverId));
+}
+
 void test_constructor_define_different_multiple()
 {
 	struct {


### PR DESCRIPTION
Some monitoring items don't have the status. They detect some issues
discontinuously. The concept trigger is not suitable form them.
This patch adds a new working mode: STATELESS_MONITOR. Monitors
with the mode mainly generates events.

Thie PR also includes the patch that makes the following two self monitors STATELESS_MONITOR.
    - monitorGateInternal
    - monitorParseError
    
In addtion, some errors are saved as event. As a result, they
are shown in WebUI.
