### PR TITLE
Fire self monitor on timeout #1590

### DIFF
--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -260,8 +260,6 @@ struct HatoholArmPluginGateHAPI2::Impl
 		};
 
 		SelfMonitorPtr monitors[] = {
-			monitorParseError,
-			monitorGateInternal,
 			monitorBrokerConn,
 		};
 		for (auto &m : monitors)


### PR DESCRIPTION
This PR contains
- a new self monitor for HAP2 connection
- making the plugin internal monitor stateless