### PR TITLE
[HatoholServerEditDialog] Fix the position of check boxes

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -263,6 +263,11 @@ div#noscript-background div#noscript-notice
   white-space: nowrap;
 }
 
+#add-server-param-form .checkbox input[type="checkbox"] {
+    position: static;
+    float: left;
+}
+
 /* graph */
 h2.hatohol-graph {
     text-align: center;


### PR DESCRIPTION
Since the style of '.checkbox input[type="checkbox"]' has been
changed in the latest Bootstarp, the layout of the checkbox in the
server edit dialog is broken. This commit fixes the issue.

Fix #1874