### PR TITLE
[Hap2] Resolve global variable name collision.

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -536,5 +536,4 @@ class Hap2Ceilometer(standardhap.StandardHap):
 
 
 if __name__ == '__main__':
-    hap = Hap2Ceilometer()
-    hap()
+    Hap2Ceilometer().run()

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -197,5 +197,4 @@ class Hap2Fluentd(standardhap.StandardHap):
         return plugin
 
 if __name__ == '__main__':
-    hap = Hap2Fluentd()
-    hap()
+    Hap2Fluentd().run()

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -407,5 +407,4 @@ class Hap2NagiosNDOUtils(standardhap.StandardHap):
 
 
 if __name__ == '__main__':
-    hap = Hap2NagiosNDOUtils()
-    hap()
+    Hap2NagiosNDOUtils().run()

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -209,5 +209,4 @@ class Hap2ZabbixAPI(standardhap.StandardHap):
 
 
 if __name__ == '__main__':
-    hap = Hap2ZabbixAPI()
-    hap()
+    Hap2ZabbixAPI().run();

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -103,6 +103,9 @@ class StandardHap:
         self.on_parsed_argument(args)
         return args
 
+    def run(self):
+        self()
+
     def __call__(self):
         args = self.__setup()
         try:


### PR DESCRIPTION
'hap' is defined as a global variable and it overwrites the package
with the same name. This patch addresses it by removing the global
variable.