### PR TITLE
[hap2] Give a logger name prefix 'hatohol.' (#1876).

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -31,7 +31,7 @@ from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
-logger = getLogger(__name__)
+logger = getLogger("hatohol.hap2_ceilometer")
 
 class Common:
 

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -30,7 +30,7 @@ from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
-logger = getLogger(__name__)
+logger = getLogger("hatohol.hap2_fluentd")
 
 class Hap2FluentdMain(haplib.BaseMainPlugin):
 

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -28,7 +28,7 @@ from hatohol import hap
 from hatohol import haplib
 from hatohol import standardhap
 
-logger = getLogger(__name__)
+logger = getLogger("hatohol.hap2_nagios_ndoutils")
 
 class Common:
 

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -25,12 +25,13 @@ import multiprocessing
 import Queue
 import argparse
 import time
+from logging import getLogger
 from hatohol.haplib import Utils
 from hatohol import haplib
 from hatohol import zabbixapi
 from hatohol import standardhap
 
-logger = haplib.logger
+logger = getLogger("hatohol.hap2_zabbix_api")
 MAX_NUMBER_OF_EVENTS_FROM_ZABBIX = 1000
 MAX_NUMBER_OF_EVENTS_OF_HAPI2 = 1000
 


### PR DESCRIPTION
The previous code, __name__ of hap_zabbix_api.py and the family
is replaced with  '__main__'.
The default logging setting: hap2-logging.conf has the following
line to specify the logging target.

    qualname: hatohol

As a result, their logging APIs are not loggged.