### PR TITLE
[WebUI] Redirect the top page to ajax_dashboard. (#1761)

### DIFF
--- a/client/viewer/urls.py
+++ b/client/viewer/urls.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Project Hatohol
+# Copyright (C) 2013,2016 Project Hatohol
 #
 # This file is part of Hatohol.
 #
@@ -16,14 +16,14 @@
 # <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import patterns, url
+from django.views.generic import RedirectView
 
 from hatohol import hatohol_def
 from views import HatoholView
 
 urlpatterns = patterns(
     '',
-    url(r'^$',
-        HatoholView.as_view(template_name='viewer/dashboard_ajax.html')),
+    url(r'^$', RedirectView.as_view(url='ajax_dashboard')),
     url(r'^ajax_dashboard$',
         HatoholView.as_view(
             template_name='viewer/dashboard_ajax.html')),


### PR DESCRIPTION
Previous implementaion returns the content that is the same
as ajax_dashboard when the top page is requested. In this
case, a browser looks that the url /hatohol has the contents.
And if the login dialog is shown at that time, the JavaScript
code saves the session ID in the cookie for the page.
with the path: '/'.

However, the login dialog is shown at other pages such as
/hatohol/ajax_events, the path in the cookie is '/hatohol'.
Thus the two cookies are saved and the wrong (expired) one
may be used.

This patch ensures that all contents (pages) of WebUI are
under /hatohol.