### PR TITLE
[client] Set the correct label for the wild card item of filters 

### DIFF
--- a/client/static/js/hatohol_monitoring_view.js
+++ b/client/static/js/hatohol_monitoring_view.js
@@ -360,17 +360,32 @@ HatoholMonitoringView.prototype.setupCheckboxForDelete =
 
 HatoholMonitoringView.prototype.setupHostFilters = function(servers, query, withoutSelfMonitor) {
   this.setServerFilterCandidates(servers);
-  if (query && ("serverId" in query))
-    $("#select-server").val(query.serverId);
+  if (query && ("serverId" in query)) {
+    if (query.serverId == "-1") {
+      $("#select-server").val("");
+    } else {
+      $("#select-server").val(query.serverId);
+    }
+  }
 
   this.setHostgroupFilterCandidates(servers);
-  if (query && ("hostgroupId" in query))
-    $("#select-host-group").val(query.hostgroupId);
+  if (query && ("hostgroupId" in query)) {
+    if (query.hostgroupId == "*") {
+      $("#select-host-group").val("");
+    } else {
+      $("#select-host-group").val(query.hostgroupId);
+    }
+  }
 
   this.setHostFilterCandidates(servers, this.getTargetServerId(), withoutSelfMonitor);
 
-  if (query && ("hostId" in query))
-    $("#select-host").val(query.hostId);
+  if (query && ("hostId" in query)) {
+    if (query.hostId == "*") {
+      $("#select-host").val("");
+    } else {
+      $("#select-host").val(query.hostId);
+    }
+  }
 };
 
 HatoholMonitoringView.prototype.displayUpdateTime =

--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -200,9 +200,6 @@ var LatestView = function(userProfile) {
     rawData = reply;
     parsedData = parseData(rawData);
 
-    self.setServerFilterCandidates(rawData["servers"]);
-    self.setHostgroupFilterCandidates(rawData["servers"]);
-    self.setHostFilterCandidates(rawData["servers"]);
     self.setApplicationFilterCandidates(parsedData.applications);
 
     drawTableContents(rawData);

--- a/client/static/js/overview_items.js
+++ b/client/static/js/overview_items.js
@@ -167,9 +167,6 @@ var OverviewItems = function(userProfile) {
   function updateCore(reply) {
     rawData = reply;
     parsedData = parseData(reply);
-    self.setServerFilterCandidates(rawData["servers"]);
-    self.setHostgroupFilterCandidates(rawData["servers"]);
-    self.setHostFilterCandidates(rawData["servers"]);
     drawTableContents(parsedData);
     setupFilterValues(rawData.servers,
                       self.lastQuery ? self.lastQuery : self.baseQuery,

--- a/client/static/js/overview_triggers.js
+++ b/client/static/js/overview_triggers.js
@@ -195,9 +195,6 @@ var OverviewTriggers = function(userProfile) {
   function updateCore(reply, param) {
     rawData = reply;
     parsedData = parseData(rawData, param);
-    self.setServerFilterCandidates(rawData["servers"]);
-    self.setHostgroupFilterCandidates(rawData["servers"]);
-    self.setHostFilterCandidates(rawData["servers"]);
     drawTableContents(parsedData);
     setupFilterValues();
     setLoading(false);

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -250,10 +250,6 @@ var TriggersView = function(userProfile) {
   function updateCore(reply) {
     rawData = reply;
 
-    self.setServerFilterCandidates(rawData["servers"]);
-    self.setHostgroupFilterCandidates(rawData["servers"]);
-    self.setHostFilterCandidates(rawData["servers"]);
-
     drawTableContents(rawData);
     updatePager();
     setupFilterValues();

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -163,19 +163,19 @@
 	    <div class="filter-element">
 	      <p><label>{% trans "Monitoring Server:" %}</label></p>
 	      <select id="select-server" class="form-control">
-		<option>---------</option>
+		<option value="">---------</option>
 	      </select>
 	    </div>
 	    <div class="filter-element">
 	      <p><label>{% trans "Group:" %}</label></p>
 	      <select id="select-host-group" class="form-control">
-		<option>---------</option>
+		<option value="">---------</option>
 	      </select>
 	    </div>
 	    <div class="filter-element">
 	      <p><label>{% trans "Host:" %}</label></p>
 	      <select id="select-host" class="form-control">
-		<option>---------</option>
+		<option value="">---------</option>
 	      </select>
 	    </div>
 	    <div class="filter-element">

--- a/client/viewer/latest_ajax.html
+++ b/client/viewer/latest_ajax.html
@@ -31,22 +31,22 @@
   <form class="form-inline hatohol-filter-toolbar">
     <label>{% trans "Monitoring Server:" %}</label>
     <select id="select-server" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
 
     <label>{% trans "Group:" %}</label>
     <select id="select-host-group" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
 
     <label>{% trans "Host:" %}</label>
     <select id="select-host" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
 
     <label>{% trans "Application:" %}</label>
     <select id="select-application" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
       <option>_non_</option>
     </select>
     <label for="num-records-per-page">{% trans "# of items per page" %}</label>

--- a/client/viewer/overview_items_ajax.html
+++ b/client/viewer/overview_items_ajax.html
@@ -41,15 +41,15 @@
     -->
     <label>{% trans "Monitoring Server:" %}</label>
     <select id="select-server" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Group:" %}</label>
     <select id="select-host-group" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Host:" %}</label>
     <select id="select-host" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
   </form>
 

--- a/client/viewer/overview_triggers_ajax.html
+++ b/client/viewer/overview_triggers_ajax.html
@@ -46,15 +46,15 @@
     </select>
     <label>{% trans "Monitoring Server:" %}</label>
     <select id="select-server" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Group:" %}</label>
     <select id="select-host-group" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Host:" %}</label>
     <select id="select-host" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
   </form>
 

--- a/client/viewer/triggers_ajax.html
+++ b/client/viewer/triggers_ajax.html
@@ -46,15 +46,15 @@
     </select>
     <label>{% trans "Monitoring Server:" %}</label>
     <select id="select-server" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Group:" %}</label>
     <select id="select-host-group" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label>{% trans "Host:" %}</label>
     <select id="select-host" class="form-control">
-      <option>---------</option>
+      <option value="">---------</option>
     </select>
     <label for="num-records-per-page">{% trans "# of triggers per page" %}</label>
     <input type="text" id="num-records-per-page" class="form-control num-records-per-page" style="width:4em;">


### PR DESCRIPTION
Although we use "---------" as the label of the wild card item
of each filters, it's not shown since we upgrade jQuery in our
repository.

The cause is that HatoholMonitoringView.setupHostFilters() tries
to set a wrong value to the drop down menu when the wild card item
is selected.

This commit fixes the issue.