### PR TITLE
[WebUI] Use msgctxt of gettext for a little complicated usage. (#1904)

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/djangojs.po
+++ b/client/conf/locale/ja/LC_MESSAGES/djangojs.po
@@ -1285,6 +1285,7 @@ msgid "Try to reconnect after "
 msgstr "再接続します: "
 
 #: static/js/hatohol_reconnection_modal.js:58
+msgctxt "ReconnectionModal"
 msgid " sec."
 msgstr " 秒後"
 

--- a/client/static/js/hatohol_reconnection_modal.js
+++ b/client/static/js/hatohol_reconnection_modal.js
@@ -55,7 +55,7 @@ var HatoholReconnectModal = function(retryFunc, errorMsg) {
       s += errorMsg;
       s += "<hr>";
     }
-    s += gettext("Try to reconnect after ") + self.timeToReconnect + gettext(" sec.");
+    s += gettext("Try to reconnect after ") + self.timeToReconnect + pgettext("ReconnectionModal", " sec.");
     s += "</p>";
     return s;
   };


### PR DESCRIPTION
Generally "sec." means "Byou" in Japanese. However it is being used as
 "Byougo" in the context.