### PR TITLE
[WebUI] Fix overflow elements in graph settings

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -298,6 +298,10 @@ h2.hatohol-graph {
     margin-bottom: 3.6em;
 }
 
+#hatohol-graph-item .form-control {
+    width: 100%;
+}
+
 #hatohol-item-list label {
     font-size: 18px;
     margin-right: 0.5em;

--- a/client/static/js/hatohol_item_selector.js
+++ b/client/static/js/hatohol_item_selector.js
@@ -73,6 +73,7 @@ var HatoholItemSelector = function(options) {
       if (self.appendItemCallback)
         self.appendItemCallback(index, query);
     });
+    setupPopover("#select-item");
   }
 
   function isAlreadyAddedItem(item1) {
@@ -113,6 +114,19 @@ var HatoholItemSelector = function(options) {
 
     query = self.view.getHostFilterQuery();
     self.view.startConnection("items?" + $.param(query), setItemCandidates);
+  }
+
+  function setupPopover(selector) {
+    $(selector).popover({
+      content: function() {
+        var selectedItem = $(selector).children(':selected').text();
+        return selectedItem;
+      }
+    }).on("mouseenter", function () {
+      $(selector).popover("show");
+    }).on("mouseleave", function () {
+      $(selector).popover("hide");
+    });
   }
 };
 

--- a/client/viewer/history_ajax.html
+++ b/client/viewer/history_ajax.html
@@ -74,7 +74,7 @@
                         <option>---------</option>
                       </select>
                     </td>
-                    <td>
+                    <td id="hatohol-graph-item">
                       <select id="select-item" class="form-control">
                         <option>---------</option>
                       </select>


### PR DESCRIPTION
Related to #1918.

For too long item elements, I've added popover for them as follows:

![screenshot from 2016-01-12 16 41 12](https://cloud.githubusercontent.com/assets/700876/12257593/6abcb47e-b94b-11e5-80cf-af8cb71b781d.png)
