### PR TITLE
[SeverityRanksView][server] Reactivate placeholder in severity ranks view

### DIFF
--- a/client/static/js/severity_ranks_view.js
+++ b/client/static/js/severity_ranks_view.js
@@ -186,10 +186,6 @@ var SeverityRanksView = function(userProfile) {
     drawTableContents(rawData);
     setupApplyButton(rawData);
     setupColorPickers(rawData);
-
-    // I don't know why but the following elements are unexpectedly inserted
-    // on Firefox.
-    $('#table td br[type="_moz"]').remove();
   }
 
   function load() {

--- a/client/static/js/severity_ranks_view.js
+++ b/client/static/js/severity_ranks_view.js
@@ -65,7 +65,7 @@ var SeverityRanksView = function(userProfile) {
         " style='background-color: " + escapeHTML(color) + "'>" +
         escapeHTML(color) + "</td>";
       html += "<td><input type=\"text\" id='severity-rank-label" + escapeHTML(status) +"'" +
-        "contenteditable='true' data-placeholder='" + defaultLabel + "' value='" +
+        "contenteditable='true' placeholder='" + defaultLabel + "' value='" +
 	 escapeHTML(label) + "'></td>";
       html += "<td class='delete-selector'>";
       html += "<input type='checkbox' id='severity-rank-checkbox" +


### PR DESCRIPTION
重要度設定のプレースホルダーが新デザインのマージの時からなくなってしまっていた。これを修正。

![screenshot from 2016-01-12 18 41 09](https://cloud.githubusercontent.com/assets/700876/12259925/3620594e-b95c-11e5-8a48-68bde34060ef.png)

修正は大したことがないのですが、これは意図したデザインかどうかがわからないので @BlueSkyDetector さんあたりに目を通して頂きたいです。