### PR TITLE
[16.01][HistroyView][Graph] Fix default option in graph settings modal

### DIFF
--- a/client/viewer/history_ajax.html
+++ b/client/viewer/history_ajax.html
@@ -61,22 +61,22 @@
                     <td></td>
                     <td>
                       <select id="select-server" class="form-control">
-                        <option>---------</option>
+                        <option value="">---------</option>
                       </select>
                     </td>
                     <td>
                       <select id="select-host-group" class="form-control">
-                        <option>---------</option>
+                        <option value="">---------</option>
                       </select>
                     </td>
                     <td>
                       <select id="select-host" class="form-control">
-                        <option>---------</option>
+                        <option value="">---------</option>
                       </select>
                     </td>
                     <td id="hatohol-graph-item">
                       <select id="select-item" class="form-control">
-                        <option>---------</option>
+                        <option value="">---------</option>
                       </select>
                     </td>
                     <td>


### PR DESCRIPTION
In Graph settings, following `server-item` selector wrongly selected:

![screenshot from 2016-01-14 16 08 12](https://cloud.githubusercontent.com/assets/700876/12317928/473e03c4-bad9-11e5-83c2-61d21cff0ebb.png)

This PR fixes as follows:

![screenshot from 2016-01-14 16 08 42](https://cloud.githubusercontent.com/assets/700876/12317934/52c7d300-bad9-11e5-8323-a6b6c6ea1091.png)

Similar PR is #1893.