### PR TITLE
[HAP2][doc] Initial writing up HAP2 document

### DIFF
--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -21,7 +21,21 @@ Finally, you can install rabbitmq-server package by following command:
 
 ### How to start rabbitmq-server on CentOS 7
 
-TBD.
+You need to permit 5672/tcp port with firewalld and turn off SELinux.
+
+First, you need to permit 5672/tcp with firewall-cmd by the following commands:
+
+    # firewall-cmd --add-port=5672/tcp --zone=public --permanent
+    # firewall-cmd --add-port=5672/tcp --zone=public
+
+And you need to disable SELinux by the following command:
+
+    # setsebool -P nis_enabled 1
+
+Finally, you can enable and start rabbitmq-server by the following commands:
+
+    # systemctl enable rabbitmq-server
+    # systemctl rabbitmq-server start
 
 ## Install RabbitMQ server on Ubuntu 14.04
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -57,7 +57,7 @@ $ sudo rabbitmqctl add_vhost hatohol
 
 2. Create user and password
 
-``bash
+```bash
 $ sudo rabbitmqctl add\_user hatohol hatohol
 ```
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -60,3 +60,39 @@ In this document, it assumes that virtual host is `hatohol`, user and password i
 3. Set permissions to created user
 
     $ sudo rabbitmqctl set\_permissions -p hatohol hatohol ".*" ".*" ".*"
+
+## Install hap2 plugin dependent python modules
+
+### On CentOS
+
+You need to install hap2 dependent packages via pip:
+    # pip install pika daemon
+
+If you want to use hap2-nagios-livestatus, you need to install `python-mk-livestatus`
+via pip with the following command:
+
+    # pip install python-mk-livestatus
+
+### On Ubuntu 14.04
+
+You need to install hap2 dependent packages via apt-get with the following command:
+
+    $ sudo apt-get install python-pika python-daemon
+
+If you want to use hap2-nagios-livestatus, you need to install `python-mk-livestatus`
+via pip with the following command:
+
+    $ sudo pip install python-mk-livestatus
+
+## Starting HAP2 Tips
+
+### HAP2 Zabbix
+
+You should input http://<servername or ip>/zabbix/api_jsonrpc.php into
+"Zabbix API URL" instead of <servername or ip> simply.
+
+### HAP2 Nagios Livestatus
+
+HAP2 Nagios Livestatus depends `nagios-mk-livestatus` package.
+You should install this dependent package on Nagios node and its node's Nagios proicess
+before you start to use this HAP2.

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -58,13 +58,13 @@ $ sudo rabbitmqctl add_vhost hatohol
 2. Create user and password
 
 ```bash
-$ sudo rabbitmqctl add\_user hatohol hatohol
+$ sudo rabbitmqctl add_user hatohol hatohol
 ```
 
 3. Set permissions to created user
 
 ```bash
-$ sudo rabbitmqctl set\_permissions -p hatohol hatohol ".*" ".*" ".*"
+$ sudo rabbitmqctl set_permissions -p hatohol hatohol ".*" ".*" ".*"
 ```
 
 ## Install hap2 plugin dependent python modules

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -14,7 +14,8 @@ Then, you can install erlang from EPEL repository by following command:
 
     # yum install erlang
 
-Finally, you can install rabbitmq-server package by following command:
+Finally, you can install rabbitmq-server package by following command
+after downloading the server package from [RabbitMQ official site](https://www.rabbitmq.com/install-rpm.html):
 
     # rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
     # yum install rabbitmq-server-3.6.0-1.noarch.rpm

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -49,19 +49,19 @@ Then, rabbitmq-server runs automatically.
 
 In this document, it assumes that virtual host is `hatohol`, user and password is `hatohol`.
 
-1. Create virtual host
+First, create virtual host
 
 ```bash
 $ sudo rabbitmqctl add_vhost hatohol
 ```
 
-2. Create user and password
+And then, create user and password
 
 ```bash
 $ sudo rabbitmqctl add_user hatohol hatohol
 ```
 
-3. Set permissions to created user
+Finally, set permissions to created user
 
 ```bash
 $ sudo rabbitmqctl set_permissions -p hatohol hatohol ".*" ".*" ".*"

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -104,5 +104,5 @@ You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
 ### HAP2 Nagios Livestatus
 
 HAP2 Nagios Livestatus depends `nagios-mk-livestatus` package.
-You should install this dependent package on Nagios node and its node's Nagios proicess
-before you start to use this HAP2.
+You should install this dependent package on Nagios node
+and restart its node's Nagios process before you start to use this HAP2.

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -1,0 +1,48 @@
+How to Use HAP2
+===============
+
+## Install RabbitMQ server on CentOS 7
+
+First, you need to install erlang package.
+In this document, we use epel to install RabbitMQ server.
+
+First, you need to setup EPEL by following command:
+
+    # wget -O /etc/yum.repos.d/epel-erlang.repo http://repos.fedorapeople.org/repos/peter/erlang/epel-erlang.repo
+
+Then, you can install erlang from EPEL repository by following command:
+
+    # yum install erlang
+
+Finally, you can install rabbitmq-server package by following command:
+
+    # rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+    # yum install rabbitmq-server-3.6.0-1.noarch.rpm
+
+### How to start rabbitmq-server on CentOS 7
+
+TBD.
+
+## Install RabbitMQ server on Ubuntu 14.04
+
+You can install rabbitmq-server via apt by following command:
+
+    $ sudo apt-get install rabbitmq-server
+
+Then, rabbitmq-server runs automatically.
+
+## Prepare RabbitMQ server settings
+
+In this document, it assumes that virtual host is `hatohol`, user and password is `hatohol`.
+
+1. Create virtual host
+
+    $ sudo rabbitmqctl add_vhost hatohol
+
+2. Create user and password
+
+    $ sudo rabbitmqctl add\_user hatohol hatohol
+
+3. Set permissions to created user
+
+    $ sudo rabbitmqctl set\_permissions -p hatohol hatohol ".*" ".*" ".*"

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -49,6 +49,8 @@ Then, rabbitmq-server runs automatically.
 ## Prepare RabbitMQ server settings
 
 In this document, it assumes that virtual host is `hatohol`, user and password is `hatohol`.
+If you use CentOS 7, you need to perform following command as root instead of
+a user who belongs to `sudo` group.
 
 First, create virtual host
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -66,6 +66,7 @@ In this document, it assumes that virtual host is `hatohol`, user and password i
 ### On CentOS 7
 
 You need to install hap2 dependent packages via pip:
+
     # pip install pika daemon
 
 If you want to use hap2-nagios-livestatus, you need to install `python-mk-livestatus`

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -51,15 +51,21 @@ In this document, it assumes that virtual host is `hatohol`, user and password i
 
 1. Create virtual host
 
-    $ sudo rabbitmqctl add_vhost hatohol
+```bash
+$ sudo rabbitmqctl add_vhost hatohol
+```
 
 2. Create user and password
 
-    $ sudo rabbitmqctl add\_user hatohol hatohol
+``bash
+$ sudo rabbitmqctl add\_user hatohol hatohol
+```
 
 3. Set permissions to created user
 
-    $ sudo rabbitmqctl set\_permissions -p hatohol hatohol ".*" ".*" ".*"
+```bash
+$ sudo rabbitmqctl set\_permissions -p hatohol hatohol ".*" ".*" ".*"
+```
 
 ## Install hap2 plugin dependent python modules
 
@@ -89,8 +95,8 @@ via pip with the following command:
 
 ### HAP2 Zabbix
 
-You should input http://<servername or ip>/zabbix/api_jsonrpc.php into
-"Zabbix API URL" instead of <servername or ip> simply.
+You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
+"Zabbix API URL" instead of `<servername or ip>` simply.
 
 ### HAP2 Nagios Livestatus
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -63,7 +63,7 @@ In this document, it assumes that virtual host is `hatohol`, user and password i
 
 ## Install hap2 plugin dependent python modules
 
-### On CentOS
+### On CentOS 7
 
 You need to install hap2 dependent packages via pip:
     # pip install pika daemon


### PR DESCRIPTION
* Add `rabbitmq-server` installation document
  * For CentOS 7, add `erlang` and `rabbitmq-server` installation 
* Add `rabbitmq-server` settings document
* Add hap2 plugins dependent Python packages installation document
* Add Tips for pitfail (mainly HAP2 Zabbix)