### PR TITLE
[client] Don't require Django for compiling mo files

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -178,4 +178,4 @@ update-po: misc/external-labels.js
 	$(srcdir)/manage.py makemessages -d djangojs -a
 
 .po.mo:
-	$(srcdir)/manage.py compilemessages
+	$(MSGFMT) -o $@ $<

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,17 @@ AC_SUBST(MLPL_LIBS)
 
 AC_LANG_POP([C++])
 
+
+dnl **************************************************************
+dnl Checks for gettext
+dnl **************************************************************
+AC_PATH_PROG(MSGFMT, msgfmt, msgfmt-not-found)
+if test x"$MSGFMT" = x"msgfmt-not-found"; then
+  AC_MSG_ERROR([You don't have msgfmt command. Please install gettext tools.])
+fi
+AC_SUBST(MSGFMT)
+
+
 dnl **************************************************************
 dnl Checks for Cutter
 dnl **************************************************************


### PR DESCRIPTION
Use msgfmt directly.

Fix #1939 