### PR TITLE
[spec][wercker] Remove Django build require from hatohol package in spec

### DIFF
--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -32,7 +32,6 @@ BuildRequires: mariadb-devel
 %endif
 BuildRequires: libuuid-devel >= 2.17
 BuildRequires: librabbitmq-devel >= 0.4.1
-BuildRequires: Django >= 1.5.3
 
 %description
 Hatohol collects monitoring information from running monitoring systems

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -32,6 +32,7 @@ BuildRequires: mariadb-devel
 %endif
 BuildRequires: libuuid-devel >= 2.17
 BuildRequires: librabbitmq-devel >= 0.4.1
+BuildRequires: gettext
 
 %description
 Hatohol collects monitoring information from running monitoring systems

--- a/wercker.yml
+++ b/wercker.yml
@@ -32,7 +32,7 @@ build:
         code: |
           cd /etc/yum.repos.d && wget http://people.centos.org/tru/devtools-2/devtools-2.repo
           yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
-          yum install -y Django
+          yum install -y gettext
           rpm -Uvh http://sourceforge.net/projects/cutter/files/centos/cutter-release-1.1.0-0.noarch.rpm
           yum install -y cutter tar
 


### PR DESCRIPTION
It got success building Hatohol rpms in Wercker: https://app.wercker.com/#buildstep/569c71813e708cf423045b51