### PR TITLE
[DBTablesConfig] Remove update procedures for severity_ranks table

### DIFF
--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -790,17 +790,6 @@ static bool updateDB(
 			IDX_ARM_PLUGINS_UUID);
 		dbAgent.addColumns(addArgForArmPlugins);
 	}
-	if (oldVer < 17) {
-		dbAgent.createTable(tableProfileSeverityRanks);
-	}
-	if (oldVer < 18) {
-		DBAgent::AddColumnsArg addColumnsArg(tableProfileSeverityRanks);
-		addColumnsArg.columnIndexes.push_back(
-			IDX_SEVERITY_RANK_LABEL);
-		addColumnsArg.columnIndexes.push_back(
-			IDX_SEVERITY_RANK_AS_IMPORTANT);
-		dbAgent.addColumns(addColumnsArg);
-	}
 	return true;
 }
 


### PR DESCRIPTION
Because the table doesn't exist in the previous version (15.06).