### PR TITLE
[IncidentStatusHistory] Implement server side incident status history feature

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -257,4 +257,11 @@ typedef std::vector<IncidentInfo>        IncidentInfoVect;
 typedef IncidentInfoVect::iterator       IncidentInfoVectIterator;
 typedef IncidentInfoVect::const_iterator IncidentInfoVectConstIterator;
 
+struct IncidentStatusHistory {
+	IncidentStatusHistoryIdType id;
+	UnifiedEventIdType          unifiedId;
+	UserIdType                  userId;
+	mlpl::Time                  createdAt;
+};
+
 #endif // Monitoring_h

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -262,6 +262,8 @@ struct IncidentStatusHistory {
 	UnifiedEventIdType          unifiedEventId;
 	UserIdType                  userId;
 	mlpl::Time                  createdAt;
+
+	static void initialize(IncidentStatusHistory &incidentStatusHistory);
 };
 
 #endif // Monitoring_h

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -259,7 +259,7 @@ typedef IncidentInfoVect::const_iterator IncidentInfoVectConstIterator;
 
 struct IncidentStatusHistory {
 	IncidentStatusHistoryIdType id;
-	UnifiedEventIdType          unifiedId;
+	UnifiedEventIdType          unifiedEventId;
 	UserIdType                  userId;
 	mlpl::Time                  createdAt;
 };

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -262,6 +262,7 @@ struct IncidentStatusHistory {
 	UnifiedEventIdType          unifiedEventId;
 	UserIdType                  userId;
 	std::string                 status;
+	std::string                 comment;
 	mlpl::Time                  createdAt;
 
 	static void initialize(IncidentStatusHistory &incidentStatusHistory);

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -261,6 +261,7 @@ struct IncidentStatusHistory {
 	IncidentStatusHistoryIdType id;
 	UnifiedEventIdType          unifiedEventId;
 	UserIdType                  userId;
+	std::string                 status;
 	mlpl::Time                  createdAt;
 
 	static void initialize(IncidentStatusHistory &incidentStatusHistory);

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -105,6 +105,9 @@ typedef int SeverityRankStatusType;
 typedef int CustomIncidentStatusIdType;
 #define FMT_CUSTOM_INCIDENT_STATUS_ID "d"
 
+typedef int IncidentStatusHistoryIdType;
+#define FMT_INCIDENT_STATUS_HISTORY_ID "d"
+
 // Special Server IDs =========================================================
 static const ServerIdType ALL_SERVERS       = -1;
 static const ServerIdType INVALID_SERVER_ID = -2;

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3085,6 +3085,9 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 
 	arg.condition = option.getCondition();
 
+	// Order By
+	arg.orderBy = option.getOrderBy();
+
 	getDBAgent().runTransaction(arg);
 
 	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -790,8 +790,8 @@ static const DBAgent::TableProfile tableProfileIncidents =
 static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
 {
 	"id",                              // columnName
-	SQL_COLUMN_TYPE_INT,               // type
-	11,                                // columnLength
+	SQL_COLUMN_TYPE_BIGUINT,           // type
+	20,                                // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
 	SQL_KEY_PRI,                       // keyType

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3030,7 +3030,6 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 		itemGroupStream >> incidentStatusHistory.userId;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_sec;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_nsec;
-		incidentStatusHistory.createdAt.tv_nsec = 0;
 
 		IncidentStatusHistoriesList.push_back(incidentStatusHistory);
 	}

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -794,7 +794,7 @@ static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
 	11,                                // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
-	SQL_KEY_PRI,                      // keyType
+	SQL_KEY_PRI,                       // keyType
 	SQL_COLUMN_FLAG_AUTO_INC,          // flags
 	NULL,                              // defaultValue
 }, {
@@ -803,7 +803,7 @@ static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
 	20,                                // columnLength
 	0,                                 // decFracLength
 	false,                             // canBeNull
-	SQL_KEY_NONE,                       // keyType
+	SQL_KEY_NONE,                      // keyType
 	0,                                 // flags
 	NULL,                              // defaultValue
 }, {

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -825,6 +825,15 @@ static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
 	0,                                 // flags
 	NULL,                              // defaultValue
 }, {
+	"comment",                         // columnName
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	2048,                              // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+}, {
 	"created_at_sec",                  // columnName
 	SQL_COLUMN_TYPE_BIGUINT,           // type
 	20,                                // columnLength
@@ -850,6 +859,7 @@ enum {
 	IDX_INCIDENT_STATUS_HISTORIES_UNIFIED_EVENT_ID,
 	IDX_INCIDENT_STATUS_HISTORIES_USER_ID,
 	IDX_INCIDENT_STATUS_HISTORIES_STATUS,
+	IDX_INCIDENT_STATUS_HISTORIES_COMMENT,
 	IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_SEC,
 	IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_NS,
 	NUM_IDX_INCIDENT_STATUS_HISTORIES,

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -816,6 +816,15 @@ static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
 	0,                                 // flags
 	NULL,                              // defaultValue
 }, {
+	"status",                          // columnName
+	SQL_COLUMN_TYPE_VARCHAR,           // type
+	255,                               // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+}, {
 	"created_at_sec",                  // columnName
 	SQL_COLUMN_TYPE_BIGUINT,           // type
 	20,                                // columnLength
@@ -840,6 +849,7 @@ enum {
 	IDX_INCIDENT_STATUS_HISTORIES_ID,
 	IDX_INCIDENT_STATUS_HISTORIES_UNIFIED_EVENT_ID,
 	IDX_INCIDENT_STATUS_HISTORIES_USER_ID,
+	IDX_INCIDENT_STATUS_HISTORIES_STATUS,
 	IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_SEC,
 	IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_NS,
 	NUM_IDX_INCIDENT_STATUS_HISTORIES,
@@ -3060,6 +3070,7 @@ void IncidentStatusHistory::initialize(IncidentStatusHistory &incidentStatusHist
 	incidentStatusHistory.id = AUTO_INCREMENT_VALUE;
 	incidentStatusHistory.unifiedEventId = INVALID_EVENT_ID;
 	incidentStatusHistory.userId = INVALID_USER_ID;
+	incidentStatusHistory.status = "";
 	timespec currTimespec = SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
 	incidentStatusHistory.createdAt.tv_sec = currTimespec.tv_sec;
 	incidentStatusHistory.createdAt.tv_nsec = currTimespec.tv_nsec;
@@ -3074,6 +3085,7 @@ HatoholError DBTablesMonitoring::addIncidentStatusHistory(
 	arg.add(incidentStatusHistory.id);
 	arg.add(incidentStatusHistory.unifiedEventId);
 	arg.add(incidentStatusHistory.userId);
+	arg.add(incidentStatusHistory.status);
 	arg.add(incidentStatusHistory.createdAt.tv_sec);
 	arg.add(incidentStatusHistory.createdAt.tv_nsec);
 
@@ -3090,6 +3102,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_ID);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_UNIFIED_EVENT_ID);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_USER_ID);
+	arg.add(IDX_INCIDENT_STATUS_HISTORIES_STATUS);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_SEC);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_NS);
 
@@ -3108,6 +3121,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 		itemGroupStream >> incidentStatusHistory.id;
 		itemGroupStream >> incidentStatusHistory.unifiedEventId;
 		itemGroupStream >> incidentStatusHistory.userId;
+		itemGroupStream >> incidentStatusHistory.status;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_sec;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_nsec;
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -45,6 +45,8 @@ const char *DBTablesMonitoring::TABLE_NAME_EVENTS     = "events";
 const char *DBTablesMonitoring::TABLE_NAME_ITEMS      = "items";
 const char *DBTablesMonitoring::TABLE_NAME_SERVER_STATUS = "server_status";
 const char *DBTablesMonitoring::TABLE_NAME_INCIDENTS  = "incidents";
+const char *DBTablesMonitoring::TABLE_NAME_INCIDENT_STATUS_HISTORIES =
+  "incident_status_histories";
 
 // -> 1.0
 //   * remove IDX_TRIGGERS_HOST_ID,
@@ -781,6 +783,62 @@ static const DBAgent::TableProfile tableProfileIncidents =
 			    COLUMN_DEF_INCIDENTS,
 			    NUM_IDX_INCIDENTS,
 			    indexDefsIncidents);
+
+// ----------------------------------------------------------------------------
+// Table: incident_status_histories
+// ----------------------------------------------------------------------------
+static const ColumnDef COLUMN_DEF_INCIDENT_STATUS_HISTORIES[] = {
+{
+	"id",                              // columnName
+	SQL_COLUMN_TYPE_INT,               // type
+	11,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_PRI,                      // keyType
+	SQL_COLUMN_FLAG_AUTO_INC,          // flags
+	NULL,                              // defaultValue
+}, {
+	"unified_id",                      // columnName
+	SQL_COLUMN_TYPE_BIGUINT,           // type
+	20,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                       // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+}, {
+	"user_id",                         // columnName
+	SQL_COLUMN_TYPE_INT,               // type
+	11,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+},  {
+	"created_at",                      // columnName
+	SQL_COLUMN_TYPE_BIGUINT,           // type
+	20,                                // columnLength
+	0,                                 // decFracLength
+	false,                             // canBeNull
+	SQL_KEY_NONE,                      // keyType
+	0,                                 // flags
+	NULL,                              // defaultValue
+},
+};
+
+enum {
+	IDX_INCIDENT_STATUS_HISTORIES_ID,
+	IDX_INCIDENT_STATUS_HISTORIES_UNIFIED_ID,
+	IDX_INCIDENT_STATUS_HISTORIES_USER_ID,
+	IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT,
+	NUM_IDX_INCIDENT_STATUS_HISTORIES,
+};
+
+static const DBAgent::TableProfile tableProfileIncidentStatusHistories =
+  DBAGENT_TABLEPROFILE_INIT(DBTablesMonitoring::TABLE_NAME_INCIDENT_STATUS_HISTORIES,
+			    COLUMN_DEF_INCIDENT_STATUS_HISTORIES,
+			    NUM_IDX_INCIDENT_STATUS_HISTORIES);
 
 struct DBTablesMonitoring::Impl
 {
@@ -2852,6 +2910,8 @@ DBTables::SetupInfo &DBTablesMonitoring::getSetupInfo(void)
 		&tableProfileServerStatus,
 	}, {
 		&tableProfileIncidents,
+	}, {
+		&tableProfileIncidentStatusHistories,
 	}
 	};
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3081,6 +3081,7 @@ void IncidentStatusHistory::initialize(IncidentStatusHistory &incidentStatusHist
 	incidentStatusHistory.unifiedEventId = INVALID_EVENT_ID;
 	incidentStatusHistory.userId = INVALID_USER_ID;
 	incidentStatusHistory.status = "";
+	incidentStatusHistory.comment = "";
 	timespec currTimespec = SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
 	incidentStatusHistory.createdAt.tv_sec = currTimespec.tv_sec;
 	incidentStatusHistory.createdAt.tv_nsec = currTimespec.tv_nsec;
@@ -3096,6 +3097,7 @@ HatoholError DBTablesMonitoring::addIncidentStatusHistory(
 	arg.add(incidentStatusHistory.unifiedEventId);
 	arg.add(incidentStatusHistory.userId);
 	arg.add(incidentStatusHistory.status);
+	arg.add(incidentStatusHistory.comment);
 	arg.add(incidentStatusHistory.createdAt.tv_sec);
 	arg.add(incidentStatusHistory.createdAt.tv_nsec);
 
@@ -3113,6 +3115,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_UNIFIED_EVENT_ID);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_USER_ID);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_STATUS);
+	arg.add(IDX_INCIDENT_STATUS_HISTORIES_COMMENT);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_SEC);
 	arg.add(IDX_INCIDENT_STATUS_HISTORIES_CREATED_AT_NS);
 
@@ -3132,6 +3135,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 		itemGroupStream >> incidentStatusHistory.unifiedEventId;
 		itemGroupStream >> incidentStatusHistory.userId;
 		itemGroupStream >> incidentStatusHistory.status;
+		itemGroupStream >> incidentStatusHistory.comment;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_sec;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_nsec;
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3017,6 +3017,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 		itemGroupStream >> incidentStatusHistory.unifiedId;
 		itemGroupStream >> incidentStatusHistory.userId;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_sec;
+		incidentStatusHistory.createdAt.tv_nsec = 0;
 
 		IncidentStatusHistoriesList.push_back(incidentStatusHistory);
 	}

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3055,6 +3055,16 @@ HatoholError DBTablesMonitoring::getSystemInfo(
 	return HatoholError(HTERR_OK);
 }
 
+void IncidentStatusHistory::initialize(IncidentStatusHistory &incidentStatusHistory)
+{
+	incidentStatusHistory.id = AUTO_INCREMENT_VALUE;
+	incidentStatusHistory.unifiedEventId = INVALID_EVENT_ID;
+	incidentStatusHistory.userId = INVALID_USER_ID;
+	timespec currTimespec = SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
+	incidentStatusHistory.createdAt.tv_sec = currTimespec.tv_sec;
+	incidentStatusHistory.createdAt.tv_nsec = currTimespec.tv_nsec;
+}
+
 HatoholError DBTablesMonitoring::addIncidentStatusHistory(
   IncidentStatusHistory &incidentStatusHistory)
 {

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1679,7 +1679,7 @@ string IncidentsQueryOption::getCondition(void) const
 // ---------------------------------------------------------------------------
 // IncidentStatusHistoriesQueryOption
 // ---------------------------------------------------------------------------
-const UnifiedEventIdType IncidentStatusHistoriesQueryOption::ALL_INCIDENTS = -1;
+const UnifiedEventIdType IncidentStatusHistoriesQueryOption::INVALID_ID = -1;
 
 struct IncidentStatusHistoriesQueryOption::Impl {
 	UnifiedEventIdType unifiedEventId;
@@ -1688,7 +1688,7 @@ struct IncidentStatusHistoriesQueryOption::Impl {
 	SortDirection sortDirection;
 
 	Impl()
-	: unifiedEventId(ALL_INCIDENTS),
+	: unifiedEventId(INVALID_ID),
 	  userId(INVALID_USER_ID),
 	  sortType(SORT_UNIFIED_EVENT_ID),
 	  sortDirection(SORT_DONT_CARE)
@@ -1797,7 +1797,7 @@ IncidentStatusHistoriesQueryOption::getSortDirection(void) const
 string IncidentStatusHistoriesQueryOption::getCondition(void) const
 {
 	string condition = DataQueryOption::getCondition();
-	if (m_impl->unifiedEventId != ALL_INCIDENTS) {
+	if (m_impl->unifiedEventId != INVALID_ID) {
 		DBTermCStringProvider rhs(*getDBTermCodec());
 		string unifiedIdCondition =
 		  StringUtils::sprintf(

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -3073,7 +3073,7 @@ HatoholError DBTablesMonitoring::addIncidentStatusHistory(
 }
 
 HatoholError DBTablesMonitoring::getIncidentStatusHistory(
-  list<IncidentStatusHistory> &IncidentStatusHistoriesList,
+  list<IncidentStatusHistory> &incidentStatusHistoriesList,
   const IncidentStatusHistoriesQueryOption &option)
 {
 	DBAgent::SelectExArg arg(tableProfileIncidentStatusHistories);
@@ -3101,7 +3101,7 @@ HatoholError DBTablesMonitoring::getIncidentStatusHistory(
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_sec;
 		itemGroupStream >> incidentStatusHistory.createdAt.tv_nsec;
 
-		IncidentStatusHistoriesList.push_back(incidentStatusHistory);
+		incidentStatusHistoriesList.push_back(incidentStatusHistory);
 	}
 
 	return HTERR_OK;

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -141,8 +141,8 @@ public:
 
 	virtual std::string getCondition(void) const override;
 
-	void setTargetUnifiedId(const UnifiedEventIdType &id);
-	const UnifiedEventIdType getTargetUnifiedId(void);
+	void setTargetUnifiedEventId(const UnifiedEventIdType &id);
+	const UnifiedEventIdType getTargetUnifiedEventId(void);
 	void setTargetUserId(const UserIdType &userId);
 	const UserIdType getTargetUserId(void);
 

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -129,6 +129,28 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
+class IncidentStatusHistoriesQueryOption : public DataQueryOption {
+public:
+	static const UnifiedEventIdType ALL_INCIDENTS;
+
+public:
+	IncidentStatusHistoriesQueryOption(const UserIdType &userId = INVALID_USER_ID);
+	IncidentStatusHistoriesQueryOption(DataQueryContext *dataQueryContext);
+	IncidentStatusHistoriesQueryOption(const IncidentStatusHistoriesQueryOption &src);
+	~IncidentStatusHistoriesQueryOption();
+
+	virtual std::string getCondition(void) const override;
+
+	void setTargetUnifiedId(const UnifiedEventIdType &id);
+	const UnifiedEventIdType getTargetUnifiedId(void);
+	void setTargetUserId(const UserIdType &userId);
+	const UserIdType getTargetUserId(void);
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
 class IncidentsQueryOption : public DataQueryOption {
 public:
 	static const UnifiedEventIdType ALL_INCIDENTS;
@@ -309,6 +331,10 @@ public:
 	};
 	static HatoholError getSystemInfo(SystemInfo &info,
 	                                  const DataQueryOption &option);
+	HatoholError addIncidentStatusHistory(IncidentStatusHistory &incidentStatusHistory);
+	HatoholError getIncidentStatusHistory(
+	  std::list<IncidentStatusHistory> &IncidentStatusHistoriesList,
+	  const IncidentStatusHistoriesQueryOption &option);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -161,6 +161,7 @@ public:
 	static const char *TABLE_NAME_ITEMS;
 	static const char *TABLE_NAME_SERVER_STATUS;
 	static const char *TABLE_NAME_INCIDENTS;
+	static const char *TABLE_NAME_INCIDENT_STATUS_HISTORIES;
 
 	DBTablesMonitoring(DBAgent &dbAgent);
 	virtual ~DBTablesMonitoring();

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -137,7 +137,7 @@ public:
 		NUM_SORT_TYPES
 	};
 
-	static const UnifiedEventIdType ALL_INCIDENTS;
+	static const UnifiedEventIdType INVALID_ID;
 
 public:
 	IncidentStatusHistoriesQueryOption(const UserIdType &userId = INVALID_USER_ID);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -131,6 +131,12 @@ private:
 
 class IncidentStatusHistoriesQueryOption : public DataQueryOption {
 public:
+	enum SortType {
+		SORT_UNIFIED_EVENT_ID,
+		SORT_TIME,
+		NUM_SORT_TYPES
+	};
+
 	static const UnifiedEventIdType ALL_INCIDENTS;
 
 public:
@@ -145,6 +151,9 @@ public:
 	const UnifiedEventIdType getTargetUnifiedEventId(void);
 	void setTargetUserId(const UserIdType &userId);
 	const UserIdType getTargetUserId(void);
+	void setSortType(const SortType &type, const SortDirection &direction);
+	SortType getSortType(void) const;
+	SortDirection getSortDirection(void) const;
 
 private:
 	struct Impl;

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -767,6 +767,7 @@ void RestResourceHost::handlerPutIncident(void)
 	incidentStatusHistory.unifiedEventId = unifiedEventId;
 	incidentStatusHistory.userId = this->m_userId;
 	incidentStatusHistory.status = incidentInfo.status;
+	incidentStatusHistory.comment = comment;
 
 	dataStore->addIncidentStatusHistory(incidentStatusHistory);
 }

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -762,6 +762,7 @@ void RestResourceHost::handlerPutIncident(void)
 		unref();
 		replyError(err);
 	}
+
 	IncidentStatusHistory incidentStatusHistory;
 	IncidentStatusHistory::initialize(incidentStatusHistory);
 	incidentStatusHistory.unifiedEventId = unifiedEventId;

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -762,6 +762,15 @@ void RestResourceHost::handlerPutIncident(void)
 		unref();
 		replyError(err);
 	}
+	IncidentStatusHistory incidentStatusHistory;
+	incidentStatusHistory.id = AUTO_INCREMENT_VALUE;
+	incidentStatusHistory.unifiedEventId = unifiedEventId;
+	incidentStatusHistory.userId = this->m_userId;
+	timespec currTimespec = SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
+	incidentStatusHistory.createdAt.tv_sec = currTimespec.tv_sec;
+	incidentStatusHistory.createdAt.tv_nsec = currTimespec.tv_nsec;
+
+	dataStore->addIncidentStatusHistory(incidentStatusHistory);
 }
 
 // TODO: Add a macro or template to simplify the definition

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -766,6 +766,7 @@ void RestResourceHost::handlerPutIncident(void)
 	IncidentStatusHistory::initialize(incidentStatusHistory);
 	incidentStatusHistory.unifiedEventId = unifiedEventId;
 	incidentStatusHistory.userId = this->m_userId;
+	incidentStatusHistory.status = incidentInfo.status;
 
 	dataStore->addIncidentStatusHistory(incidentStatusHistory);
 }

--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -763,12 +763,9 @@ void RestResourceHost::handlerPutIncident(void)
 		replyError(err);
 	}
 	IncidentStatusHistory incidentStatusHistory;
-	incidentStatusHistory.id = AUTO_INCREMENT_VALUE;
+	IncidentStatusHistory::initialize(incidentStatusHistory);
 	incidentStatusHistory.unifiedEventId = unifiedEventId;
 	incidentStatusHistory.userId = this->m_userId;
-	timespec currTimespec = SmartTime(SmartTime::INIT_CURR_TIME).getAsTimespec();
-	incidentStatusHistory.createdAt.tv_sec = currTimespec.tv_sec;
-	incidentStatusHistory.createdAt.tv_nsec = currTimespec.tv_nsec;
 
 	dataStore->addIncidentStatusHistory(incidentStatusHistory);
 }

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -994,6 +994,24 @@ HatoholError UnifiedDataStore::updateIncidentInfo(IncidentInfo &incidentInfo)
 	return dbMonitoring.updateIncidentInfo(incidentInfo);
 }
 
+HatoholError UnifiedDataStore::addIncidentStatusHistory(
+  IncidentStatusHistory &incidentStatusHistory)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	return dbMonitoring.addIncidentStatusHistory(incidentStatusHistory);
+}
+
+HatoholError UnifiedDataStore::getIncidentStatusHistories(
+  list<IncidentStatusHistory> &incidentStatusHistoryList,
+  const IncidentStatusHistoriesQueryOption &option)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	return dbMonitoring.getIncidentStatusHistory(incidentStatusHistoryList,
+	                                             option);
+}
+
 DataStoreVector UnifiedDataStore::getDataStoreVector(void)
 {
 	return m_impl->getDataStoreVector();

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -290,6 +290,12 @@ public:
 	void addIncidentInfo(IncidentInfo &incidentInfo);
 	HatoholError updateIncidentInfo(IncidentInfo &incidentInfo);
 
+	HatoholError addIncidentStatusHistory(
+	  IncidentStatusHistory &incidentStatusHistory);
+	HatoholError getIncidentStatusHistories(
+	  std::list<IncidentStatusHistory> &IncidentStatusHistoriesList,
+	  const IncidentStatusHistoriesQueryOption &option);
+
 	/**
 	 * get a vector of pointers of DataStore instance.
 	 * This method is a wrapper of DataStoreManager::getDataStoreManager().

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1583,6 +1583,7 @@ const IncidentStatusHistory testIncidentStatusHistory[] = {
 	3,                     // unifiedId
 	1,                     // userId
 	"NONE",                // status
+	"",                    // comment
 	{1412957260, 0},       // createdAt
 },
 {
@@ -1590,6 +1591,7 @@ const IncidentStatusHistory testIncidentStatusHistory[] = {
 	10,                    // unifiedId
 	2,                     // userId
 	"IN PROGRESS",         // status
+	"This is a comment.",  // comment
 	{1412957290, 0},       // createdAt
 },
 {
@@ -1597,6 +1599,7 @@ const IncidentStatusHistory testIncidentStatusHistory[] = {
 	20,                    // unifiedId
 	3,                     // userId
 	"HOLD",                // status
+	"Hold to operate.",    // comment
 	{1453451165, 0},       // createdAt
 },
 };

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1582,18 +1582,21 @@ const IncidentStatusHistory testIncidentStatusHistory[] = {
 	AUTO_INCREMENT_VALUE,  // id
 	3,                     // unifiedId
 	1,                     // userId
+	"NONE",                // status
 	{1412957260, 0},       // createdAt
 },
 {
 	AUTO_INCREMENT_VALUE,  // id
 	10,                    // unifiedId
 	2,                     // userId
+	"IN PROGRESS",         // status
 	{1412957290, 0},       // createdAt
 },
 {
 	AUTO_INCREMENT_VALUE,  // id
 	20,                    // unifiedId
 	3,                     // userId
+	"HOLD",                // status
 	{1453451165, 0},       // createdAt
 },
 };

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1577,6 +1577,28 @@ const CustomIncidentStatus testCustomIncidentStatus[] = {
 };
 const size_t NumTestCustomIncidentStatus = ARRAY_SIZE(testCustomIncidentStatus);
 
+const IncidentStatusHistory testIncidentStatusHistory[] = {
+{
+	AUTO_INCREMENT_VALUE,  // id
+	3,                     // unifiedId
+	1,                     // userId
+	{1412957260, 0},       // createdAt
+},
+{
+	AUTO_INCREMENT_VALUE,  // id
+	10,                    // unifiedId
+	2,                     // userId
+	{1412957290, 0},       // createdAt
+},
+{
+	AUTO_INCREMENT_VALUE,  // id
+	20,                    // unifiedId
+	3,                     // userId
+	{1453451165, 0},       // createdAt
+},
+};
+const size_t NumTestIncidentStatusHistory = ARRAY_SIZE(testIncidentStatusHistory);
+
 const TriggerInfo &searchTestTriggerInfo(const EventInfo &eventInfo)
 {
 	for (size_t i = 0; i < NumTestTriggerInfo; i++) {
@@ -2474,4 +2496,13 @@ void loadTestDBCustomIncidentStatusInfo(void)
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	for (auto customIncidentStatus : testCustomIncidentStatus)
 		dbConfig.upsertCustomIncidentStatus(customIncidentStatus, privilege);
+}
+
+void loadTestDBIncidentStatusHistory(void)
+{
+	ThreadLocalDBCache cache;
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+	OperationPrivilege privilege(USER_ID_SYSTEM);
+	for (auto incidentStatusHistory : testIncidentStatusHistory)
+		dbMonitoring.addIncidentStatusHistory(incidentStatusHistory);
 }

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -113,6 +113,9 @@ extern const size_t NumTestSeverityRankInfoDef;
 extern const CustomIncidentStatus testCustomIncidentStatus[];
 extern const size_t NumTestCustomIncidentStatus;
 
+extern const IncidentStatusHistory testIncidentStatusHistory[];
+extern const size_t NumTestIncidentStatusHistory;
+
 /**
  * get the test trigger data indexes whose serverId and hostId are
  * matched with the specified.
@@ -282,5 +285,6 @@ void loadTestDBLastInfo(void);
 void loadTestDBSeverityRankInfo(void);
 
 void loadTestDBCustomIncidentStatusInfo(void);
+void loadTestDBIncidentStatusHistory(void);
 
 #endif // DBClientTest_h

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -718,6 +718,17 @@ std::string makeCustomIncidentStatusOutput(const CustomIncidentStatus &customInc
 		 customIncidentStatus.label.c_str());
 }
 
+std::string makeIncidentStatusHistoryOutput(const IncidentStatusHistory &incidentStatusHistory)
+{
+	return StringUtils::sprintf(
+		 "%" FMT_INCIDENT_STATUS_HISTORY_ID "|%" FMT_UNIFIED_EVENT_ID
+		 "|%" FMT_USER_ID "|%" PRIu64 "\n",
+		 incidentStatusHistory.id,
+		 incidentStatusHistory.unifiedId,
+		 incidentStatusHistory.userId,
+		 incidentStatusHistory.createdAt.tv_sec);
+}
+
 static void assertDBContentForComponets(const string &expect,
                                         const string &actual,
                                         DBAgent *dbAgent)

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -722,10 +722,11 @@ std::string makeIncidentStatusHistoryOutput(const IncidentStatusHistory &inciden
 {
 	return StringUtils::sprintf(
 		 "%" FMT_INCIDENT_STATUS_HISTORY_ID "|%" FMT_UNIFIED_EVENT_ID
-		 "|%" FMT_USER_ID "|%" PRIu64 "|%" PRIu64 "\n",
+		 "|%" FMT_USER_ID "|%s|%" PRIu64 "|%" PRIu64 "\n",
 		 incidentStatusHistory.id,
 		 incidentStatusHistory.unifiedEventId,
 		 incidentStatusHistory.userId,
+		 incidentStatusHistory.status.c_str(),
 		 incidentStatusHistory.createdAt.tv_sec,
 		 incidentStatusHistory.createdAt.tv_nsec);
 }

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -722,11 +722,12 @@ std::string makeIncidentStatusHistoryOutput(const IncidentStatusHistory &inciden
 {
 	return StringUtils::sprintf(
 		 "%" FMT_INCIDENT_STATUS_HISTORY_ID "|%" FMT_UNIFIED_EVENT_ID
-		 "|%" FMT_USER_ID "|%" PRIu64 "\n",
+		 "|%" FMT_USER_ID "|%" PRIu64 "|%" PRIu64 "\n",
 		 incidentStatusHistory.id,
-		 incidentStatusHistory.unifiedId,
+		 incidentStatusHistory.unifiedEventId,
 		 incidentStatusHistory.userId,
-		 incidentStatusHistory.createdAt.tv_sec);
+		 incidentStatusHistory.createdAt.tv_sec,
+		 incidentStatusHistory.createdAt.tv_nsec);
 }
 
 static void assertDBContentForComponets(const string &expect,

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -722,11 +722,12 @@ std::string makeIncidentStatusHistoryOutput(const IncidentStatusHistory &inciden
 {
 	return StringUtils::sprintf(
 		 "%" FMT_INCIDENT_STATUS_HISTORY_ID "|%" FMT_UNIFIED_EVENT_ID
-		 "|%" FMT_USER_ID "|%s|%" PRIu64 "|%" PRIu64 "\n",
+		 "|%" FMT_USER_ID "|%s|%s|%" PRIu64 "|%" PRIu64 "\n",
 		 incidentStatusHistory.id,
 		 incidentStatusHistory.unifiedEventId,
 		 incidentStatusHistory.userId,
 		 incidentStatusHistory.status.c_str(),
+		 incidentStatusHistory.comment.c_str(),
 		 incidentStatusHistory.createdAt.tv_sec,
 		 incidentStatusHistory.createdAt.tv_nsec);
 }

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -123,6 +123,7 @@ std::string makeHostgroupsOutput(const Hostgroup &hostgrp, const size_t &id);
 std::string makeMapHostsHostgroupsOutput(const HostgroupMember &hostgrpMember, const size_t &id);
 std::string makeSeverityRankInfoOutput(const SeverityRankInfo &severityRankInfo);
 std::string makeCustomIncidentStatusOutput(const CustomIncidentStatus &customIncidentStatus);
+std::string makeIncidentStatusHistoryOutput(const IncidentStatusHistory &incidentStatusHistory);
 
 void _assertDatetime(int expectedClock, int actualClock);
 #define assertDatetime(E,A) cut_trace(_assertDatetime(E,A))

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1835,6 +1835,50 @@ void test_getSystemInfoByInvalidUser(void)
 	  DBTablesMonitoring::getSystemInfo(systemInfo, option));
 }
 
+void test_addIncidentStatusHistory(void)
+{
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+	DBAgent &dbAgent = dbMonitoring.getDBAgent();
+
+	string statement = "select * from incident_status_histories;";
+	for (size_t i = 0; i < NumTestIncidentStatusHistory; i++) {
+		IncidentStatusHistory expectedIncidentStatusHistory =
+		  testIncidentStatusHistory[i];
+		expectedIncidentStatusHistory.id = i + 1;
+		expected +=
+		  makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+		IncidentStatusHistory incidentStatusHistory =
+		  testIncidentStatusHistory[i];
+		dbMonitoring.addIncidentStatusHistory(incidentStatusHistory);
+	}
+	assertDBContent(&dbAgent, statement, expected);
+}
+
+void test_getIncidentStatusHistory(void)
+{
+	loadTestDBIncidentStatusHistory();
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+
+	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
+	option.setTargetUnifiedId(3);
+	option.setTargetUserId(1);
+
+	IncidentStatusHistory expectedIncidentStatusHistory =
+	  testIncidentStatusHistory[0];
+	expectedIncidentStatusHistory.id = 1;
+	expected = makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+
+	list<IncidentStatusHistory> incidentstatusHistoryList;
+	dbMonitoring.getIncidentStatusHistory(incidentstatusHistoryList, option);
+	for (auto incidentStatusHistory : incidentstatusHistoryList) {
+		actual += makeIncidentStatusHistoryOutput(incidentStatusHistory);
+	}
+
+	cppcut_assert_equal(expected, actual);
+}
+
 void test_getNumberOfEvents(void)
 {
 	loadTestDBEvents();

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1862,7 +1862,7 @@ void test_getIncidentStatusHistory(void)
 	string expected, actual;
 
 	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
-	option.setTargetUnifiedId(3);
+	option.setTargetUnifiedEventId(3);
 	option.setTargetUserId(1);
 
 	IncidentStatusHistory expectedIncidentStatusHistory =

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1944,7 +1944,6 @@ void test_getIncidentStatusHistoryWithSortUnifiedEventIdAscending(void)
 	option.setSortType(IncidentStatusHistoriesQueryOption::SORT_UNIFIED_EVENT_ID,
 			   DataQueryOption::SORT_ASCENDING);
 
-	// Reverse access
 	for (size_t i = 0; i < NumTestIncidentStatusHistory; i++) {
 		IncidentStatusHistory expectedIncidentStatusHistory =
 		  testIncidentStatusHistory[i];

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1879,6 +1879,61 @@ void test_getIncidentStatusHistory(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getIncidentStatusHistoryWithSortTimeAscending(void)
+{
+	loadTestDBIncidentStatusHistory();
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+
+	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
+	option.setSortType(IncidentStatusHistoriesQueryOption::SORT_TIME,
+			   DataQueryOption::SORT_ASCENDING);
+
+	for (size_t i = 0; i < NumTestIncidentStatusHistory; i++) {
+		IncidentStatusHistory expectedIncidentStatusHistory =
+		  testIncidentStatusHistory[i];
+		expectedIncidentStatusHistory.id = i + 1;
+		expected +=
+		  makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+	}
+
+	list<IncidentStatusHistory> incidentstatusHistoryList;
+	dbMonitoring.getIncidentStatusHistory(incidentstatusHistoryList, option);
+	for (auto incidentStatusHistory : incidentstatusHistoryList) {
+		actual += makeIncidentStatusHistoryOutput(incidentStatusHistory);
+	}
+
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getIncidentStatusHistoryWithSortTimeDescending(void)
+{
+	loadTestDBIncidentStatusHistory();
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+
+	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
+	option.setSortType(IncidentStatusHistoriesQueryOption::SORT_TIME,
+			   DataQueryOption::SORT_DESCENDING);
+
+	// Reverse access
+	for (size_t i = NumTestIncidentStatusHistory; i > 0; i--) {
+		IncidentStatusHistory expectedIncidentStatusHistory =
+		  testIncidentStatusHistory[i - 1];
+		expectedIncidentStatusHistory.id = i;
+		expected +=
+		  makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+	}
+
+	list<IncidentStatusHistory> incidentstatusHistoryList;
+	dbMonitoring.getIncidentStatusHistory(incidentstatusHistoryList, option);
+	for (auto incidentStatusHistory : incidentstatusHistoryList) {
+		actual += makeIncidentStatusHistoryOutput(incidentStatusHistory);
+	}
+
+	cppcut_assert_equal(expected, actual);
+}
+
 void test_getNumberOfEvents(void)
 {
 	loadTestDBEvents();

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1934,6 +1934,62 @@ void test_getIncidentStatusHistoryWithSortTimeDescending(void)
 	cppcut_assert_equal(expected, actual);
 }
 
+void test_getIncidentStatusHistoryWithSortUnifiedEventIdAscending(void)
+{
+	loadTestDBIncidentStatusHistory();
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+
+	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
+	option.setSortType(IncidentStatusHistoriesQueryOption::SORT_UNIFIED_EVENT_ID,
+			   DataQueryOption::SORT_ASCENDING);
+
+	// Reverse access
+	for (size_t i = 0; i < NumTestIncidentStatusHistory; i++) {
+		IncidentStatusHistory expectedIncidentStatusHistory =
+		  testIncidentStatusHistory[i];
+		expectedIncidentStatusHistory.id = i + 1;
+		expected +=
+		  makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+	}
+
+	list<IncidentStatusHistory> incidentstatusHistoryList;
+	dbMonitoring.getIncidentStatusHistory(incidentstatusHistoryList, option);
+	for (auto incidentStatusHistory : incidentstatusHistoryList) {
+		actual += makeIncidentStatusHistoryOutput(incidentStatusHistory);
+	}
+
+	cppcut_assert_equal(expected, actual);
+}
+
+void test_getIncidentStatusHistoryWithSortUnifiedEventIdDescending(void)
+{
+	loadTestDBIncidentStatusHistory();
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	string expected, actual;
+
+	IncidentStatusHistoriesQueryOption option(USER_ID_SYSTEM);
+	option.setSortType(IncidentStatusHistoriesQueryOption::SORT_UNIFIED_EVENT_ID,
+			   DataQueryOption::SORT_DESCENDING);
+
+	// Reverse access
+	for (size_t i = NumTestIncidentStatusHistory; i > 0; i--) {
+		IncidentStatusHistory expectedIncidentStatusHistory =
+		  testIncidentStatusHistory[i - 1];
+		expectedIncidentStatusHistory.id = i;
+		expected +=
+		  makeIncidentStatusHistoryOutput(expectedIncidentStatusHistory);
+	}
+
+	list<IncidentStatusHistory> incidentstatusHistoryList;
+	dbMonitoring.getIncidentStatusHistory(incidentstatusHistoryList, option);
+	for (auto incidentStatusHistory : incidentstatusHistoryList) {
+		actual += makeIncidentStatusHistoryOutput(incidentStatusHistory);
+	}
+
+	cppcut_assert_equal(expected, actual);
+}
+
 void test_getNumberOfEvents(void)
 {
 	loadTestDBEvents();

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1176,7 +1176,6 @@ void test_putIncident(void)
 	string actualIncidentStatusHistory =
 	  execSQL(&dbMonitoring.getDBAgent(),
 	          "select * from incident_status_histories");
-	// id: 1, unifiedEventId: 123, userId: 2
 	string expectedIncidentStatusHistory =
 		"^1\\|123\\|2\\|IN PROGRESS\\|\\|\\d+\\|\\d+$";
 	cut_assert_match(expectedIncidentStatusHistory.c_str(),

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1178,7 +1178,7 @@ void test_putIncident(void)
 	          "select * from incident_status_histories");
 	// id: 1, unifiedEventId: 123, userId: 2
 	string expectedIncidentStatusHistory =
-		"^1\\|123\\|2\\|IN PROGRESS\\|\\d+\\|\\d+$";
+		"^1\\|123\\|2\\|IN PROGRESS\\|\\|\\d+\\|\\d+$";
 	cut_assert_match(expectedIncidentStatusHistory.c_str(),
 			 actualIncidentStatusHistory.c_str());
 }

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -1172,6 +1172,15 @@ void test_putIncident(void)
 		"^5\\|2\\|2\\|3\\|123\\|\\|IN PROGRESS\\|taro\\|"
 		"1412957360\\|0\\|\\d+\\|\\d+\\|HIGH\\|30\\|123$";
 	cut_assert_match(expected.c_str(), actual.c_str());
+
+	string actualIncidentStatusHistory =
+	  execSQL(&dbMonitoring.getDBAgent(),
+	          "select * from incident_status_histories");
+	// id: 1, unifiedEventId: 123, userId: 2
+	string expectedIncidentStatusHistory =
+		"^1\\|123\\|2\\|IN PROGRESS\\|\\d+\\|\\d+$";
+	cut_assert_match(expectedIncidentStatusHistory.c_str(),
+			 actualIncidentStatusHistory.c_str());
 }
 
 void test_putInvalidIncident(void)


### PR DESCRIPTION
Note that  this feature is targeted for Hatohol 16.04 and server side only for now.
So, send this PR against master branch.

See: https://github.com/project-hatohol/hatohol/issues/1949#issuecomment-173415282 (2)

Incident status history is saved in DB like this:

```log
mysql> select * from incident_status_histories;
+----+------------------+---------+--------+---------+----------------+---------------+
| id | unified_event_id | user_id | status | comment | created_at_sec | created_at_ns |
+----+------------------+---------+--------+---------+----------------+---------------+
|  1 |             1062 |       1 | HOLD   |         |     1453708570 |     943985822 |
|  2 |             1062 |       1 | DONE   |         |     1453708581 |     325026171 |
+----+------------------+---------+--------+---------+----------------+---------------+
```

### Not yet

* Insert incidentStatusHistory columns when users or system create incident.