### PR TITLE
[TriggersView] Use user-defined severity rank labels

### DIFF
--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -31,6 +31,7 @@ var TriggersView = function(userProfile) {
   self.showToggleAutoRefreshButton();
   self.setupToggleAutoRefreshButtonHandler(load, self.reloadIntervalSeconds);
   self.rawSeverityRankData = {};
+  self.severityRanksMap = {};
   var triggerPropertyChoices = {
     severity: [
       { value: "0", label: gettext("Not classified") },
@@ -85,8 +86,21 @@ var TriggersView = function(userProfile) {
       url: "/severity-rank",
       request: "GET",
       replyCallback: function(reply, parser) {
-        var severityRanks;
+        var i, severityRanks, rank;
+        var choices = triggerPropertyChoices.severity;
         self.rawSeverityRankData = reply;
+        self.severityRanksMap = {};
+        severityRanks = self.rawSeverityRankData["SeverityRanks"];
+        if (severityRanks) {
+          for (i = 0; i < severityRanks.length; i++) {
+            self.severityRanksMap[severityRanks[i].status] = severityRanks[i];
+          }
+          for (i = 0; i < choices.length; i++) {
+            rank = self.severityRanksMap[choices[i].value];
+            if (rank && rank.label)
+              choices[i].label = rank.label;
+          }
+        }
         deferred.resolve();
       },
       parseErrorCallback: function() {
@@ -235,7 +249,7 @@ var TriggersView = function(userProfile) {
         + escapeHTML(nickName) + "</td>";
       html += "<td class='" + severityClass +
         "' data-sort-value='" + escapeHTML(severity) + "'>" +
-        severity_choices[Number(severity)] + "</td>";
+        triggerPropertyChoices.severity[Number(severity)].label + "</td>";
       html += "<td class='status" + escapeHTML(status);
       if (severityClass) {
         html += " " + severityClass;

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -32,6 +32,7 @@ var TriggersView = function(userProfile) {
   self.setupToggleAutoRefreshButtonHandler(load, self.reloadIntervalSeconds);
   self.rawSeverityRankData = {};
   self.severityRanksMap = {};
+  self.defaultMinimumSeverity = "0";
   var triggerPropertyChoices = {
     severity: [
       { value: "0", label: gettext("Not classified") },
@@ -145,6 +146,25 @@ var TriggersView = function(userProfile) {
     });
   }
 
+  function resetTriggerPropertyFilter(type) {
+    var candidates = triggerPropertyChoices[type];
+    var option;
+    var currentId = $("#select-" + type).val();
+
+    $("#select-" + type).empty();
+
+    $.map(candidates, function(candidate) {
+      var option;
+
+      option = $("<option/>", {
+        text: candidate.label,
+        value: candidate.value
+      }).appendTo("#select-" + type);
+    });
+
+    $("#select-" + type).val(currentId);
+  }
+
   var status_choices = [
     gettext("OK"),
     gettext("Problem"),
@@ -159,6 +179,7 @@ var TriggersView = function(userProfile) {
       query = self.lastQuery ? self.lastQuery : self.baseQuery;
 
     self.setupHostFilters(servers, query);
+    resetTriggerPropertyFilter("severity");
 
     if ("minimumSeverity" in query)
       $("#select-severity").val(query.minimumSeverity);
@@ -302,11 +323,20 @@ var TriggersView = function(userProfile) {
     return query;
   }
 
+  function getMinimumSeverityQuery() {
+    var severity = $("#select-severity").val();
+    if (severity) {
+      return severity;
+    } else {
+      return self.defaultMinimumSeverity;
+    }
+  }
+
   function getQuery(page) {
     if (isNaN(page))
       page = 0;
     var query = $.extend({}, self.baseQuery, {
-      minimumSeverity: $("#select-severity").val(),
+      minimumSeverity: getMinimumSeverityQuery(),
       status:          $("#select-status").val(),
       offset:          self.baseQuery.limit * page
     });

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -31,6 +31,16 @@ var TriggersView = function(userProfile) {
   self.showToggleAutoRefreshButton();
   self.setupToggleAutoRefreshButtonHandler(load, self.reloadIntervalSeconds);
   self.rawSeverityRankData = {};
+  var triggerPropertyChoices = {
+    severity: [
+      { value: "0", label: gettext("Not classified") },
+      { value: "1", label: gettext("Information") },
+      { value: "2", label: gettext("Warning") },
+      { value: "3", label: gettext("Average") },
+      { value: "4", label: gettext("High") },
+      { value: "5", label: gettext("Disaster") },
+    ],
+  };
 
   // call the constructor of the super class
   HatoholMonitoringView.apply(this, [userProfile]);
@@ -125,14 +135,6 @@ var TriggersView = function(userProfile) {
     gettext("OK"),
     gettext("Problem"),
     gettext("Unknown")
-  ];
-  var severity_choices = [
-    gettext("Not classified"),
-    gettext("Information"),
-    gettext("Warning"),
-    gettext("Average"),
-    gettext("High"),
-    gettext("Disaster")
   ];
 
   function setupFilterValues(servers, query) {

--- a/client/viewer/triggers_ajax.html
+++ b/client/viewer/triggers_ajax.html
@@ -31,12 +31,6 @@
   <form class="form-inline hatohol-filter-toolbar">
     <label>{% trans "Minimum Severity:" %}</label>
     <select id="select-severity" class="form-control">
-      <option value="0">0</option>
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
-      <option value="4">4</option>
-      <option value="5">5</option>
     </select>
     <label>{% trans "Status:" %}</label>
     <select id="select-status" class="form-control">


### PR DESCRIPTION
It would be nice to use user-defined severity rank labels in TriggersView.

By default: 

![screenshot from 2016-02-02 18 33 23](https://cloud.githubusercontent.com/assets/700876/12745231/97d81cfa-c9db-11e5-9ff5-d69f46568eae.png)

Also displaying user-defined severity ranks labels:

![screenshot from 2016-02-02 18 35 54](https://cloud.githubusercontent.com/assets/700876/12745289/e252eb5c-c9db-11e5-80d0-53b7370d8347.png)

