### PR TITLE
[npm] Use caperjs 1.1.0-beta4 explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sinon": "~1.15.4",
     "phantomjs": "1.9.7-15",
     "mocha-phantomjs": "~3.6.0",
-    "casperjs": "~1.1.0-beta3"
+    "casperjs": "~1.1.0-beta4"
   },
   "dependencies": {
     "npm-check-updates": "~1.5.1"


### PR DESCRIPTION
Bump up casperjs semantic version to 1.1.0-beta4.