### PR TITLE
[hap2_fluentd] Use -q instead of --suppress-config-dump (#1978)

### DIFF
--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -183,8 +183,7 @@ class Hap2Fluentd(standardhap.StandardHap):
         standardhap.StandardHap.__init__(self)
 
         parser = self.get_argument_parser()
-        parser.add_argument("--fluentd-launch",
-                            default="td-agent --suppress-config-dump",
+        parser.add_argument("--fluentd-launch", default="td-agent -q",
                             help="A command line to launch fluentd.")
         parser.add_argument("--tag", default="^hatohol\..*",
                             help="A regular expression of the target tag.")


### PR DESCRIPTION
-q option supresses more lines that are unnecessary for
the plugin (hap2_fluentd.py).