### PR TITLE
[client] Simplify setting up test environment for JavaScript

### DIFF
--- a/client/HowToTest.md
+++ b/client/HowToTest.md
@@ -1,15 +1,11 @@
 Install packages (for Ubuntu 12.04)
 -----------------------------------
 
-    # apt-get install npm
-    # npm install -g mocha
-    # npm install -g expect.js
-    # npm install -g sinon
-    # apt-get install nodejs-legacy
-    # npm install -g mocha-phantomjs phantomjs
-    # npm install -g casperjs
+    # apt-get install npm nodejs-legacy
     # pip install django==1.5.4
     # pip install mysql-python
+    $ cd /path/to/hatohol-source-directory
+    $ npm install
 
 Install packages (for Debian 7)
 -------------------------------
@@ -23,11 +19,9 @@ Install packages (for Debian 7)
 
 The above instruction is an excerpt from https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
 
-    # npm install -g mocha
-    # npm install -g expect.js
-    # npm install -g mocha-phantomjs phantomjs
-    # npm install -g casperjs
     # pip install django==1.5.4
+    $ cd /path/to/hatohol-source-directory
+    $ npm install
 
 make symbolic links
 -------------------

--- a/client/test/Makefile.am
+++ b/client/test/Makefile.am
@@ -1,7 +1,6 @@
 if WITH_JS_TEST
 
 TARGET_FILES = \
-	node_modules \
 	browser/mocha.js browser/mocha.css browser/expect.js browser/sinon.js
 
 noinst_DATA = $(TARGET_FILES)
@@ -64,20 +63,17 @@ EXTRA_DIST = \
 	python/utils.py \
 	python/hatohol_server_emulator.py
 
-node_modules:
-	ln -sf `npm root`
-
 browser/mocha.js:
-	ln -sf ../node_modules/mocha/mocha.js $@
+	ln -sf `npm root`/mocha/mocha.js $@
 
 browser/mocha.css:
-	ln -sf ../node_modules/mocha/mocha.css $@
+	ln -sf `npm root`/mocha/mocha.css $@
 
 browser/expect.js:
-	ln -sf ../node_modules/expect.js/index.js $@
+	ln -sf `npm root`/expect.js/index.js $@
 
 browser/sinon.js:
-	ln -sf ../node_modules/sinon/pkg/sinon.js $@
+	ln -sf `npm root`/sinon/pkg/sinon.js $@
 
 clean-local:
 	-rm -fr $(TARGET_FILES)

--- a/configure.ac
+++ b/configure.ac
@@ -211,8 +211,9 @@ dnl **************************************************************
 dnl Mocha, expect.js, and npm (indirectly node.js)
 dnl **************************************************************
 have_js_test_tools=yes
-AC_CHECK_PROG([have_mocha], [mocha], [yes], [no])
+NODE_MODULES_PATH=$(npm bin)
 AC_CHECK_PROG([have_npm], [npm], [yes], [no])
+AC_CHECK_PROG([have_mocha], [mocha], [yes], [no], [$NODE_MODULES_PATH])
 have_expect_js=no
 if test "$have_npm" = "yes"; then
   expect_js_ver=`npm ls | grep expect.js | awk '{ print $2 }' FS=@`


### PR DESCRIPTION
Use package.json to install node modules.
You can install them by executing the following command at the top
directory:

  $ npm install

Fix #2008