### PR TITLE
[gulp][lint][js] Start to use gulp lint task

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "indent" : 2,  // インデントの深さ
+  "maxlen" : 100,  // 一行の最大長
+  "sub": true,
+  "eqeqeq": false,
+  "lastsemic": true,
+
+  // Relaxing Options
+  "eqnull" : true,  // == null を許可
+  "expr" : true  // x || (x = 1); とかができるようにする
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,12 +1,12 @@
 {
-  "indent" : 2,  // インデントの深さ
-  "maxlen" : 100,  // 一行の最大長
+  "indent" : 2,  // indent depth
+  "maxlen" : 100,  // max length of line
   "sub": true,
   "eqeqeq": false,
   "lastsemic": true,
 
   // Relaxing Options
-  "eqnull" : true,  // == null を許可
-  "expr" : true,  // x || (x = 1); とかができるようにする
+  "eqnull" : true,  // permit "== null" comparison
+  "expr" : true,  // permit x || (x = 1); expression
   "loopfunc": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -7,5 +7,6 @@
 
   // Relaxing Options
   "eqnull" : true,  // == null を許可
-  "expr" : true  // x || (x = 1); とかができるようにする
+  "expr" : true,  // x || (x = 1); とかができるようにする
+  "loopfunc": true
 }

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -2,7 +2,8 @@ var gulp = require("gulp");
 var jshint = require("gulp-jshint");
 
 gulp.task("lint", function() {
-  gulp.src(["./client/static/js/*.js", "!./client/static/js/hatohol_def.js"])
+  gulp.src(["./client/static/js/*.js", "./client/static/js.plugins/*.js",
+            "!./client/static/js/hatohol_def.js"])
     .pipe(jshint())
     .pipe(jshint.reporter("default"));
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -7,3 +7,5 @@ gulp.task("lint", function() {
     .pipe(jshint())
     .pipe(jshint.reporter("default"));
 });
+
+gulp.task('default', ['lint']);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require("gulp");
 var jshint = require("gulp-jshint");
 
 gulp.task("lint", function() {
-  gulp.src(["./client/static/js/*.js", "!./client/static/js/hatohol_connector.js"])
+  gulp.src(["./client/static/js/*.js", "!./client/static/js/hatohol_def.js"])
     .pipe(jshint())
     .pipe(jshint.reporter("default"));
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,8 @@
+var gulp = require("gulp");
+var jshint = require("gulp-jshint");
+
+gulp.task("lint", function() {
+  gulp.src("./client/static/js/*.js")
+    .pipe(jshint())
+    .pipe(jshint.reporter("default"));
+});

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require("gulp");
 var jshint = require("gulp-jshint");
 
 gulp.task("lint", function() {
-  gulp.src("./client/static/js/*.js")
+  gulp.src(["./client/static/js/*.js", "!./client/static/js/hatohol_connector.js"])
     .pipe(jshint())
     .pipe(jshint.reporter("default"));
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "sinon": "~1.15.4",
     "phantomjs": "1.9.7-15",
     "mocha-phantomjs": "~3.6.0",
-    "casperjs": "~1.1.0-beta4"
+    "casperjs": "~1.1.0-beta4",
+    "gulp": "~3.9.1",
+    "gulp-jshint": "~2.0.0"
   },
   "dependencies": {
     "npm-check-updates": "~1.5.1"


### PR DESCRIPTION
I've tried to add gulp lint task.
This task will be invoked by `$(npm bin)/gulp lint` after executing `npm install`.

How about start to use Gulp?

Related to https://github.com/project-hatohol/hatohol/pull/2026#issuecomment-183178893.