### PR TITLE
Allow a little difference due to platform #2009

### DIFF
--- a/client/test/browser/test_triggers_view.js
+++ b/client/test/browser/test_triggers_view.js
@@ -256,14 +256,16 @@ describe('TriggersView', function() {
     var eventURL = "ajax_events\\?serverId=1&amp;triggerId=18446744073709550616";
     var color = 'style="background-color: rgb\\(255, 0, 0\\); ?"';
     var expected =
-      '<td class="severity5" ' + color + '>Zabbix</td>' +
-      '<td class="severity5" data-sort-value="5" ' + color + '>Emergency!</td>' +
-      '<td class="status1 severity5" data-sort-value="1" ' + color + '>Problem</td>' +
+      '<td class="severity5" '+ color + '>Zabbix</td>' +
+      '<td class="severity5" data-sort-value="5" ' +
+        color + '>Emergency!</td>' +
+      '<td class="status1 severity5" data-sort-value="1" ' +
+        color + '>Problem</td>' +
       '<td class="severity5" data-sort-value="1422584694" ' + color + '>' +
-      formatDate(1422584694) +
-      '</td>' +
+        formatDate(1422584694) + '</td>' +
       '<td class="severity5" ' + color + '>Zabbix_SELF</td>' +
-      '<td class="severity5" ' + color + '><a href="' + eventURL + '">Failed in connecting to Zabbix.</a></td>';
+      '<td class="severity5" ' + color +
+        '><a href="' + eventURL + '">Failed in connecting to Zabbix.</a></td>';
     var triggers = [$.extend({}, defaultTriggers[0])];
     triggers[0].status = hatohol.TRIGGER_STATUS_PROBLEM;
     respond('{}', triggersJson(triggers, defaultServers), severityRanksJson(defaultSeverityRanks));

--- a/client/test/browser/test_triggers_view.js
+++ b/client/test/browser/test_triggers_view.js
@@ -249,8 +249,12 @@ describe('TriggersView', function() {
 
   it('With a problem trigger', function() {
     var view = new TriggersView(getOperator(), testOptions);
-    var eventURL = "ajax_events?serverId=1&amp;triggerId=18446744073709550616";
-    var color = 'style="background-color: rgb(255, 0, 0); "';
+
+    // Some platofrom such as Ubuntu 14.04.2, the obtained string has a space
+    // at the tail of the following style line. However, other platform
+    // such as TravisCI doesn't. So we use regular expression here.
+    var eventURL = "ajax_events\\?serverId=1&amp;triggerId=18446744073709550616";
+    var color = 'style="background-color: rgb\\(255, 0, 0\\); ?"';
     var expected =
       '<td class="severity5" ' + color + '>Zabbix</td>' +
       '<td class="severity5" data-sort-value="5" ' + color + '>Emergency!</td>' +
@@ -265,6 +269,6 @@ describe('TriggersView', function() {
     respond('{}', triggersJson(triggers, defaultServers), severityRanksJson(defaultSeverityRanks));
     expect($('#table')).to.have.length(1);
     expect($('tr')).to.have.length(triggers.length + 1);
-    expect($('tr').eq(1).html()).to.be(expected);
+    expect($('tr').eq(1).html()).to.match(new RegExp(expected));
   });
 });


### PR DESCRIPTION
As the comment in the patch, some platform generates a space
character just after a sytle property in a tag. This patch
address the problem by comparing a HTML generated by the testee
code with the expected string by match() method based on
regular expression.

In addition, the send patch clean up the position of line breaks.