### PR TITLE
[Gulpfile] Add fail reporter to report lint errors

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -5,7 +5,8 @@ gulp.task("lint", function() {
   gulp.src(["./client/static/js/*.js", "./client/static/js.plugins/*.js",
             "!./client/static/js/hatohol_def.js"])
     .pipe(jshint())
-    .pipe(jshint.reporter("default"));
+    .pipe(jshint.reporter("default"))
+    .pipe(jshint.reporter("fail"));
 });
 
 gulp.task('default', ['lint']);


### PR DESCRIPTION
Currently, default reporter does not return non zero exit status even if there are lint errors.
This PR introduces fail reporter to report them with exit status.
Because exit status is useful for CI task.