### PR TITLE
[WebUI][test][browser] Use HAPI2 plugins as test targets.

### DIFF
--- a/client/test/browser/index.html
+++ b/client/test/browser/index.html
@@ -68,6 +68,7 @@
 <script src="../../static/js.plugins/nagios.js"></script>
 <script src="../../static/js.plugins/hapi-json.js"></script>
 <script src="../../static/js.plugins/hap2-fluentd.js"></script>
+<script src="../../static/js.plugins/hap2-nagios-ndoutils.js"></script>
 <script src="../../static/js.plugins/hap2-ceilometer.js"></script>
 <script src="../../static/js.plugins/hap2-zabbix.js"></script>
 <script src="test_hatohol_session_manager.js"></script>

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -451,7 +451,7 @@ describe('EventsView', function() {
     var configJson =
       '{"events.columns":"eventId,' +
       'incidentStatus,incidentPriority,incidentAssignee,incidentDoneRatio"}';
-    respond(eventsJson(events,getDummyHAPI2ZabbixServerInfo()),
+    respond(eventsJson(events, getDummyHAPI2ZabbixServerInfo()),
 	    configJson);
     expect($('tr').eq(0).text()).to.be(
       "Event IDHandlingPriorityAssignee% Done");
@@ -474,7 +474,7 @@ describe('EventsView', function() {
     var configJson =
       '{"events.columns":"eventId,' +
       'incidentStatus,incidentPriority,incidentAssignee,incidentDoneRatio"}';
-    respond(eventsJson(events,getDummyHAPI2ZabbixServerInfo()), configJson);
+    respond(eventsJson(events, getDummyHAPI2ZabbixServerInfo()), configJson);
     expect($('tr').eq(0).text()).to.be(
       "Event IDHandlingPriorityAssignee% Done");
     expect($('tr').eq(1).text()).to.be(

--- a/client/test/browser/test_latest_view.js
+++ b/client/test/browser/test_latest_view.js
@@ -29,9 +29,11 @@ describe('LatestView', function() {
   ];
   var defaultServers = {
     "1": {
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb",
+      "baseURL": "http://192.168.1.100/zabbix/api_jsonrpc.php",
       "nickname": "Zabbix",
-      "type": 0,
-      "ipAddress": "192.168.1.100",
+      "ipAddress": "",
       "hosts": {
         "10101": {
           "name": "Host1",

--- a/client/test/browser/test_server_view.js
+++ b/client/test/browser/test_server_view.js
@@ -4,45 +4,68 @@ describe('ServerView', function() {
   var defaultServers = [
     {
       "id": 1,
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
       "hostName": "Test Zabbix",
-      "ipAddress": "127.0.0.1",
+      "ipAddress": "",
       "nickname": "Test Zabbix",
-      "port": 80,
+      "port": 0,
       "pollinInterval": 30,
       "retryInterval": 10,
       "userName": "TestZabbixUser",
       "passowrd": "zabbix",
       "dbName": "",
-      "baseURL": ""
+      "passiveMode": false,
+      "baseURL": "http://127.0.1.1/zabbix/api_jsonrpc.php",
+      "brokerURL": "amqp://test_user:test_password@localhost:5673/test",
+      "staticQueueAddress": "",
+      "tlsCertificatePath": "",
+      "tlsKeyPath": "",
+      "tlsCACertificatePath": "",
+      "tlsEnableVerify": "",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     },
     {
       "id": 2,
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
       "hostName": "Test Nagios",
-      "ipAddress": "127.0.1.1",
+      "ipAddress": "",
       "nickname": "Test Nagios",
-      "port": 3306,
+      "port": 0,
       "pollinInterval": 60,
       "retryInterval": 10,
       "userName": "TestNagiosUser",
       "passowrd": "nagiosadministrator",
-      "dbName": "nagiosndoutils",
-      "baseURL": "http://127.0.1.1/nagios3"
+      "dbName": "",
+      "passiveMode": false,
+      "baseURL": "127.0.1.1/ndoutils",
+      "brokerURL": "amqp://test_user:test_password@localhost:5673/test",
+      "staticQueueAddress": "",
+      "tlsCertificatePath": "",
+      "tlsKeyPath": "",
+      "tlsCACertificatePath": "",
+      "tlsEnableVerify": "",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     },
     {
       "id": 3,
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
       "hostName": "Test Nagios2",
-      "ipAddress": "10.0.0.10",
+      "ipAddress": "",
       "nickname": "Test Nagios2",
-      "port": 3306,
+      "port": 0,
       "pollinInterval": 60,
       "retryInterval": 10,
       "userName": "TestNagiosUser2",
       "passowrd": "nagiosadministrator",
-      "dbName": "nagios-ndoutils",
-      "baseURL": ""
+      "dbName": "",
+      "passiveMode": false,
+      "baseURL": "10.0.0.1/ndoutils",
+      "staticQueueAddress": "",
+      "tlsCertificatePath": "",
+      "tlsKeyPath": "",
+      "tlsCACertificatePath": "",
+      "tlsEnableVerify": "",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     },
   ];
 
@@ -327,7 +350,7 @@ describe('ServerView', function() {
     expectEditButtonVisibility(operator, expected);
   });
 
-  it('without update privilege', function() {
+  it('without update privilege: edit button visibility', function() {
     var operator = {
       "userId": 2,
       "name": "guest",
@@ -337,13 +360,15 @@ describe('ServerView', function() {
     expectEditButtonVisibility(operator, expected);
   });
 
-  it('without update privilege', function() {
+  it('without update privilege: link visibility', function() {
     var operator = {
       "userId": 2,
       "name": "guest",
       "flags": 0
     };
-    var expectedVisibleLinkNums = 2;
+    // Currently js.plugins/hap2-nagios-ndoutils.js doesn't have getTopURL()
+    // So only the first server makes a link.
+    var expectedVisibleLinkNums = 1;
     expectLinkVisibility(operator, expectedVisibleLinkNums);
   });
 });

--- a/client/test/browser/test_triggers_view.js
+++ b/client/test/browser/test_triggers_view.js
@@ -44,9 +44,11 @@ describe('TriggersView', function() {
   ];
   var defaultServers = {
     "1": {
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb",
+      "baseURL": "http://192.168.1.100/zabbix/api_jsonrpc.php",
       "nickname": "Zabbix",
-      "type": 0,
-      "ipAddress": "192.168.1.100",
+      "ipAddress": "",
       "hosts": {
         "10101": {
           "name": "Host1"

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -43,10 +43,9 @@ describe('isInt', function() {
 describe('getServerLocation', function() {
   it('with valid zabbix server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost",
-      "port": 80
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "http://127.0.0.1/zabbix/api_jsonrpc.php",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
     var expected = "http://127.0.0.1/zabbix/";
     expect(getServerLocation(server)).to.be(expected);
@@ -54,10 +53,9 @@ describe('getServerLocation', function() {
 
   it('zabbix server with port', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost",
-      "port": 8080
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "http://127.0.0.1:8080/zabbix/api_jsonrpc.php",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
     var expected = "http://127.0.0.1:8080/zabbix/";
     expect(getServerLocation(server)).to.be(expected);
@@ -65,10 +63,9 @@ describe('getServerLocation', function() {
 
   it('ipv6 zabbix server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
-      "ipAddress": "::1",
-      "name": "localhost",
-      "port": 8080
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "http://[::1]:8080/zabbix/api_jsonrpc.php",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
     var expected = "http://[::1]:8080/zabbix/";
     expect(getServerLocation(server)).to.be(expected);
@@ -76,11 +73,12 @@ describe('getServerLocation', function() {
 
   it('with valid nagios server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "ipAddress": "",
+      "baseURL": "127.0.0.1/ndoutils",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
-    // issue #839
+    // Currently Naigos JS plugin doesn't have getTopURL()
     //var expected = "http://127.0.0.1/nagios/";
     var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
@@ -88,36 +86,27 @@ describe('getServerLocation', function() {
 
   it('nagios server with port', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost",
-      "port": 8080
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "ipAddress": "",
+      "port": 8080,
+      "ipAddress": "",
+      "baseURL": "127.0.0.1/ndoutils",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
-    // issue #839
+    // Currently Naigos JS plugin doesn't have getTopURL()
     //var expected = "http://127.0.0.1:8080/nagios/";
     var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
   });
 
-  it('nagios server with baseURL', function() {
-    var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost",
-      "port": 8080,
-      "baseURL": "http://127.0.0.1/nagios3/"
-    };
-    var expected = "http://127.0.0.1/nagios3/";
-    expect(getServerLocation(server)).to.be(expected);
-  });
-
   it('ipv6 nagios server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "::1",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "ipAddress": "",
+      "baseURL": "127.0.0.1/ndoutils",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
-    // issue #839
+    // Currently Naigos JS plugin doesn't have getTopURL()
     //var expected = "http://[::1]/nagios/";
     var expected = undefined;
     expect(getServerLocation(server)).to.be(expected);
@@ -145,9 +134,9 @@ describe('getServerLocation', function() {
 describe('getItemGraphLocation', function() {
   it('with valid zabbix server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "http://127.0.0.1/zabbix/api_jsonrpc.php",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
     var itemId = 1129;
     var expected =
@@ -157,9 +146,10 @@ describe('getItemGraphLocation', function() {
 
   it('with valid nagios server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "127.0.0.1",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "ipAddress": "",
+      "baseURL": "127.0.0.1/ndoutils",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
     var itemId = 1129;
     expect(getItemGraphLocation(server, itemId)).to.be(undefined);
@@ -189,9 +179,9 @@ describe('getItemGraphLocation', function() {
 describe('getMapsLocation', function() {
   it('with valid zabbix server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_ZABBIX,
-      "ipAddress": "192.168.23.119",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "http://192.168.23.119/zabbix/api_jsonrpc.php",
+      "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
     var expected = "http://192.168.23.119/zabbix/maps.php";
     expect(getMapsLocation(server)).to.be(expected);
@@ -199,9 +189,9 @@ describe('getMapsLocation', function() {
 
   it('with valid nagios server', function() {
     var server = {
-      "type": hatohol.MONITORING_SYSTEM_NAGIOS,
-      "ipAddress": "192.168.22.118",
-      "name": "localhost"
+      "type": hatohol.MONITORING_SYSTEM_HAPI2,
+      "baseURL": "127.0.1.1/ndoutils",
+      "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
     expect(getMapsLocation(server)).to.be(undefined);
   });
@@ -219,17 +209,19 @@ describe('getMapsLocation', function() {
 describe('makeMonitoringSystemTypeLabel', function() {
   it('with valid zabbix server', function() {
     var server = {
-        "type": hatohol.MONITORING_SYSTEM_ZABBIX
+        "type": hatohol.MONITORING_SYSTEM_HAPI2,
+        "uuid": "8e632c14-d1f7-11e4-8350-d43d7e3146fb"
     };
-    var expected = "Zabbix";
+    var expected = "Zabbix (HAPI2)";
     expect(makeMonitoringSystemTypeLabel(server)).to.be(expected);
   });
 
   it('with valid nagios server', function() {
     var server = {
-        "type": hatohol.MONITORING_SYSTEM_NAGIOS
+        "type": hatohol.MONITORING_SYSTEM_HAPI2,
+        "uuid": "902d955c-d1f7-11e4-80f9-d43d7e3146fb",
     };
-    var expected = "Nagios";
+    var expected = "Nagios NDOUtils (HAPI2)";
     expect(makeMonitoringSystemTypeLabel(server)).to.be(expected);
   });
 


### PR DESCRIPTION
This patch is one of preparations for addressing #1938, which
will remove legacy built-in Arms for Zabbix and nagios.
So the tests using them should be fixed to use those of HAPI2
version.