### PR TITLE
[WebUI][test][feature] Use HAPI2 plugins as test targets.

### DIFF
--- a/client/test/feature/feature_test_utils.js
+++ b/client/test/feature/feature_test_utils.js
@@ -66,6 +66,8 @@ function registerMonitoringServer(test, params) {
     });
 
   // emulate actual inputs
+  // TODO: These can be use only for Zabbix (HAPI2). We should support
+  //       other types.
   casper.waitForSelector("input#server-edit-dialog-param-form-0",
     function success() {
       this.sendKeys("input#server-edit-dialog-param-form-0", params.nickName);
@@ -75,31 +77,31 @@ function registerMonitoringServer(test, params) {
     });
   casper.waitForSelector("input#server-edit-dialog-param-form-1",
     function success() {
-      this.sendKeys("input#server-edit-dialog-param-form-1", params.serverName);
+      this.sendKeys("input#server-edit-dialog-param-form-1", params.baseURL);
     },
     function fail() {
       test.assertExists("input#server-edit-dialog-param-form-1");
     });
   casper.waitForSelector("input#server-edit-dialog-param-form-2",
     function success() {
-      this.sendKeys("input#server-edit-dialog-param-form-2", params.ipAddress);
+      this.sendKeys("input#server-edit-dialog-param-form-2", params.userName);
     },
     function fail() {
       test.assertExists("input#server-edit-dialog-param-form-2");
     });
-  casper.waitForSelector("input#server-edit-dialog-param-form-4",
+  casper.waitForSelector("input#server-edit-dialog-param-form-3",
     function success() {
-      this.sendKeys("input#server-edit-dialog-param-form-4", params.userName);
+      this.sendKeys("input#server-edit-dialog-param-form-3", params.userPassword);
     },
     function fail() {
-      test.assertExists("input#server-edit-dialog-param-form-4");
+      test.assertExists("input#server-edit-dialog-param-form-3");
     });
-  casper.waitForSelector("input#server-edit-dialog-param-form-5",
+  casper.waitForSelector("input#server-edit-dialog-param-form-7",
     function success() {
-      this.sendKeys("input#server-edit-dialog-param-form-5", params.userPassword);
+      this.sendKeys("input#server-edit-dialog-param-form-7", params.brokerURL);
     },
     function fail() {
-      test.assertExists("input#server-edit-dialog-param-form-5");
+      test.assertExists("input#server-edit-dialog-param-form-7");
     });
 
   // close post confirmation dialog

--- a/client/test/feature/register_action_test.js
+++ b/client/test/feature/register_action_test.js
@@ -9,6 +9,10 @@ casper.on("page.error", function(msg, trace) {
   }
 });
 
+casper.on('remote.message', function(msg) {
+  this.echo(msg);
+});
+
 casper.test.begin('Register/Unregister action test', function(test) {
   var actionCommand = "getlog";
   var editActionCommand = "editlog";
@@ -17,13 +21,15 @@ casper.test.begin('Register/Unregister action test', function(test) {
   casper.then(function() {
     util.moveToServersPage(test);
     casper.then(function() {
-      util.registerMonitoringServer(test,
-                                    {serverType: 0,
-                                     nickName: "test",
-                                     serverName: "test",
-                                     ipAddress: "127.0.0.1",
-                                     userName: "admin",
-                                     userPassword: "zabbix-admin"});
+      util.registerMonitoringServer(test, {
+        serverType: "8e632c14-d1f7-11e4-8350-d43d7e3146fb",
+        baseURL: "http://127.0.0.1/zabbix/api_jsonrpc.php",
+        brokerURL: "amqp://test_user:test_password@localhost:5673/test",
+        nickName: "test",
+        serverName: "test",
+        userName: "admin",
+        userPassword: "zabbix-admin"
+      });
     });
   });
   // move to actions page

--- a/client/test/feature/register_incident_setting_test.js
+++ b/client/test/feature/register_incident_setting_test.js
@@ -10,12 +10,16 @@ casper.on("page.error", function(msg, trace) {
 });
 
 casper.test.begin('Register/Unregister incident settings test', function(test) {
-  var incidentSetting = {serverType: 0,
-                         nickName: "zabbix",
-                         serverName: "test-zabbix",
-                         ipAddress: "127.0.0.1",
-                         userName: "admin",
-                         userPassword: "zabbix-admin"};
+  var incidentSetting = {
+        serverType: "8e632c14-d1f7-11e4-8350-d43d7e3146fb",
+        baseURL: "http://127.0.0.1/zabbix/api_jsonrpc.php",
+        brokerURL: "amqp://test_user:test_password@localhost:5673/test",
+        nickName: "zabbix",
+        serverName: "test-zabbix",
+        ipAddress: "127.0.0.1",
+        userName: "admin",
+        userPassword: "zabbix-admin",
+  };
   casper.start('http://0.0.0.0:8000/ajax_dashboard');
   casper.then(function() {util.login(test);});
   casper.then(function() {

--- a/client/test/feature/register_user_access_info_test.js
+++ b/client/test/feature/register_user_access_info_test.js
@@ -10,12 +10,16 @@ casper.on("page.error", function(msg, trace) {
 });
 
 casper.test.begin('Register/Unregister access info list test', function(test) {
-  var monitoringServer = {serverType: 0,
-                         nickName: "zabbix",
-                         serverName: "test-zabbix",
-                         ipAddress: "127.0.0.1",
-                         userName: "admin",
-                         userPassword: "zabbix-admin"};
+  var monitoringServer = {
+        serverType: "8e632c14-d1f7-11e4-8350-d43d7e3146fb",
+        baseURL: "http://127.0.0.1/zabbix/api_jsonrpc.php",
+        brokerURL: "amqp://test_user:test_password@localhost:5673/test",
+        nickName: "zabbix",
+        serverName: "test-zabbix",
+        ipAddress: "127.0.0.1",
+        userName: "admin",
+        userPassword: "zabbix-admin",
+  };
   casper.start('http://0.0.0.0:8000/ajax_dashboard');
   casper.then(function() {util.login(test);});
   casper.then(function() {


### PR DESCRIPTION
This patch is one of preparations for addressing #1938, which
will remove legacy built-in Arms for Zabbix and nagios.
So the tests using them should be fixed to use those of HAPI2
version.