### PR TITLE
[setup-by-ansible] Install aptitude first.

### DIFF
--- a/setup-with-ansible/roles/upgrade-server/ubuntu/tasks/main.yml
+++ b/setup-with-ansible/roles/upgrade-server/ubuntu/tasks/main.yml
@@ -1,3 +1,5 @@
+- name: install aptitude
+  apt: name=aptitude
 - name: update a server
   apt: update_cache=yes
 - name: upgrade a server


### PR DESCRIPTION
Some simple environment such as a container soon after created
is required to have 'aptitude' to progress this setup.