### PR TITLE
[Gulp][client][browsertest] Use gulp-phantomjs to unify testing/linting task interface

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,7 +10,10 @@ gulp.task('browsertest', function () {
         width: 1024,
         height: 768
       },
-      useColors:true
+      useColors:true,
+      suppressStdout: false,
+      suppressStderr: false,
+      verbose: true
     }
   };
   var stream = mochaPhantomJS(phantomJSConfig);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,5 +1,23 @@
 var gulp = require("gulp");
 var jshint = require("gulp-jshint");
+var mochaPhantomJS = require('gulp-mocha-phantomjs');
+
+gulp.task('browsertest', function () {
+  var phantomJSConfig = {
+    reporter: 'spec',
+    phantomjs: {
+      viewportSize: {
+        width: 1024,
+        height: 768
+      },
+      useColors:true
+    }
+  };
+  var stream = mochaPhantomJS(phantomJSConfig);
+  stream.write({path: 'http://localhost:8000/test/index.html'});
+  stream.end();
+  return stream;
+});
 
 gulp.task("lint", function() {
   gulp.src(["./client/static/js/*.js", "./client/static/js.plugins/*.js",

--- a/client/test/browser/index.html
+++ b/client/test/browser/index.html
@@ -13,7 +13,12 @@
 <script src="../../static/js.external/spectrum.js"></script>
 <script src="mocha.js"></script>
 <script src="expect.js"></script>
-<script>mocha.setup('bdd');</script>
+<script>
+  if (window.initMochaPhantomJS) {
+    window.initMochaPhantomJS();
+  }
+  mocha.setup('bdd');
+</script>
 <script src="sinon.js"></script>
 <script>
   if (typeof(HATOHOL_PROJECT_TOP_PATH) == "undefined")

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "mocha-phantomjs": "~3.6.0",
     "casperjs": "~1.1.0-beta4",
     "gulp": "~3.9.1",
-    "gulp-jshint": "~2.0.0"
+    "gulp-jshint": "~2.0.0",
+    "gulp-mocha-phantomjs": "~0.11.0"
   },
   "dependencies": {
     "npm-check-updates": "~1.5.1"

--- a/test/run-client-test.sh
+++ b/test/run-client-test.sh
@@ -9,7 +9,7 @@ ${TOP_DIR}/client/test/python/run-test.sh || FAILED=1
 export PIDS_FILE=`pwd`/pids_file
 rm -fr $PIDS_FILE
 ${TOP_DIR}/test/launch-hatohol-for-test.sh || exit 1
-$(npm bin)/mocha-phantomjs http://localhost:8000/test/index.html || FAILED=1
+$(npm bin)/gulp browsertest || FAILED=1
 # manage.py has a child process. We have to kill it too.
 cat $PIDS_FILE | awk '{ print "ps h -p " $1 " --ppid " $1 " -o pid" }' | sh | awk '{ print "kill " $1 }' | sh
 


### PR DESCRIPTION
This PR makes to be able to run client test through gulp with `$(npm bin)/gulp browsertest`.
It would be nice to unify executing testing/linting interface.