### PR TITLE
[client][utils] Validate plugin object

### DIFF
--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -121,6 +121,10 @@ function getPlugin(server) {
 
 function addPriority(server) {
   var plugin = getPlugin(server);
+  // Validate plugin object not to be undefined.
+  if (plugin === undefined)
+    return;
+
   server.priority = plugin.sortPriority;
 }
 


### PR DESCRIPTION
Because I get often following error in development environment:

```
TypeError: plugin is undefined
 addPriority() utils.js:128
 sortByPriority() hatohol_server_edit_dialog_parameterized.js:201
 replyCallback() hatohol_server_edit_dialog_parameterized.js:147
 request/<.success() hatohol_connector.js:197
 n.Callbacks/j()
 ...
```

Thus, we should validate `plugin` object not to be undefined.
`plugin` object has a possibility to be undefined.

How do you think of that, @Mnakagawa ?