### PR TITLE
[Gulp] A part of migrating gulp task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -54,3 +54,6 @@ gulp.task('copy', function() {
 });
 
 gulp.task('default', ['lint']);
+gulp.task('test', ['copy', 'browsertest'], function(){
+  verbose: true;
+});

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -30,4 +30,27 @@ gulp.task("lint", function() {
     .pipe(jshint.reporter("fail"));
 });
 
+gulp.task('copy', function() {
+  // Copy external JavaScript files
+  gulp.src([
+    'node_modules/bootstrap/dist/js/bootstrap.min.js',
+    'node_modules/bootstrap-select/dist/js/bootstrap-select.js',
+    'node_modules/jquery/dist/jquery.min.js',
+    'node_modules/jquery-flot/jquery.flot.js',
+    'node_modules/jquery-flot/jquery.flot.selection.js',
+    'node_modules/jquery-flot/jquery.flot.time.js',
+    'node_modules/spectrum-colorpicker/spectrum.js',
+  ])
+  .pipe(gulp.dest('client/static/js.external'));
+  // Copy external CSS files
+  gulp.src([
+    'node_modules/bootstrap/dist/css/bootstrap.min.css',
+    'node_modules/bootstrap-select/dist/css/bootstrap-select.css',
+  ])
+  .pipe(gulp.dest('client/static/css.external'));
+  // Copy external fonts files
+  gulp.src(['node_modules/bootstrap/dist/fonts/*'])
+  .pipe(gulp.dest('client/static/fonts'));
+});
+
 gulp.task('default', ['lint']);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "gulp-mocha-phantomjs": "~0.11.0"
   },
   "dependencies": {
-    "npm-check-updates": "~1.5.1"
+    "npm-check-updates": "~1.5.1",
+    "bootstrap-select": "~1.10.0",
+    "jquery": "~2.2.1",
+    "bootstrap": "~3.3.6",
+    "jquery-flot": "~0.8.3",
+    "spectrum-colorpicker": "~1.8.0",
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "jquery": "~2.2.1",
     "bootstrap": "~3.3.6",
     "jquery-flot": "~0.8.3",
-    "spectrum-colorpicker": "~1.8.0",
+    "spectrum-colorpicker": "~1.8.0"
   }
 }


### PR DESCRIPTION
This is a part of migrating to use npm packaged files instead of {js,css}.external committed files.

Related to #2057.

But this PR contains experimental feature which is using gulp task to avoid special directory called {js, css}.external.