### PR TITLE
[EventsView] Use concatinating operator instead of '\'

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -838,9 +838,8 @@ var EventsView = function(userProfile, options) {
       },
       connectErrorCallback: function() {
         var message =
-          /*jshint multistr: true */
-          gettext("Failed to connect to Hatohol server on \
-                  changing handling of an event with ID: ") +
+          gettext("Failed to connect to Hatohol server on " +
+                  "changing handling of an event with ID: ") +
           eventId;
         errors.push(message);
       },

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -837,9 +837,10 @@ var EventsView = function(userProfile, options) {
         errors.push(message);
       },
       connectErrorCallback: function() {
+        var errorMsg ="Failed to connect to Hatohol server on" +
+              "changing handling of an event with ID: ";
         var message =
-          gettext("Failed to connect to Hatohol server on " +
-                  "changing handling of an event with ID: ") +
+          gettext(errorMsg) +
           eventId;
         errors.push(message);
       },

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -838,6 +838,7 @@ var EventsView = function(userProfile, options) {
       },
       connectErrorCallback: function() {
         var message =
+          /*jshint multistr: true */
           gettext("Failed to connect to Hatohol server on \
                   changing handling of an event with ID: ") +
           eventId;


### PR DESCRIPTION
Related to #2044.
Follows up https://github.com/project-hatohol/hatohol/pull/2036