### PR TITLE
Revert "[test][client] Use gulp to run client test"

### DIFF
--- a/test/run-client-test.sh
+++ b/test/run-client-test.sh
@@ -9,7 +9,7 @@ ${TOP_DIR}/client/test/python/run-test.sh || FAILED=1
 export PIDS_FILE=`pwd`/pids_file
 rm -fr $PIDS_FILE
 ${TOP_DIR}/test/launch-hatohol-for-test.sh || exit 1
-$(npm bin)/gulp browsertest || FAILED=1
+$(npm bin)/mocha-phantomjs http://localhost:8000/test/index.html || FAILED=1
 # manage.py has a child process. We have to kill it too.
 cat $PIDS_FILE | awk '{ print "ps h -p " $1 " --ppid " $1 " -o pid" }' | sh | awk '{ print "kill " $1 }' | sh
 


### PR DESCRIPTION
Revert #2056 partially.
This reverts commit 8bdb6823739a51e6e303c4cc278cf79fbc795dab.

In Travis CI, `gulp browsertest` is too fragile.
We should use mocha-phantomjs directly.