### PR TITLE
[EventsView] Use a magic comment to suppress lint too long line error

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -837,10 +837,12 @@ var EventsView = function(userProfile, options) {
         errors.push(message);
       },
       connectErrorCallback: function() {
+        /* Permit a long line for I18N message....*/
+        /*jshint ignore:start*/
         var message =
-          gettext("Failed to connect to Hatohol server on \
-                  changing handling of an event with ID: ") +
+          gettext("Failed to connect to Hatohol server on changing handling of an event with ID: ") +
           eventId;
+        /*jshint ignore:end*/
         errors.push(message);
       },
       completionCallback: function() {


### PR DESCRIPTION
Related to #2044.
Take 2 #2086.