### PR TITLE
[RestResourceHost][Triggers] Retrive hostname param

### DIFF
--- a/server/src/RestResourceHost.cc
+++ b/server/src/RestResourceHost.cc
@@ -96,6 +96,13 @@ static HatoholError parseTriggerParameter(TriggersQueryOption &option,
 	if (err != HTERR_OK && err != HTERR_NOT_FOUND_PARAMETER)
 		return err;
 
+	// target hostname
+	const char *targetHostname =
+		static_cast<const char*>(g_hash_table_lookup(query, "hostname"));
+	if (targetHostname && *targetHostname) {
+		option.setHostnameList({targetHostname});
+	}
+
 	// minimum severity
 	TriggerSeverityType severity = TRIGGER_SEVERITY_UNKNOWN;
 	err = getParam<TriggerSeverityType>(query, "minimumSeverity",

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -582,6 +582,14 @@ void test_triggersWithTimeRange(void)
 		       beginTime, endTime, numExpectedTriggers);
 }
 
+void test_triggersWithTimeRangeAndHostname(void)
+{
+	timespec beginTime = {1362957197,0}, endTime = {1362957200,0};
+	size_t numExpectedTriggers = 3;
+	assertTriggers("/trigger", "foo", ALL_SERVERS, ALL_LOCAL_HOSTS,
+		       beginTime, endTime, numExpectedTriggers, "hostX1");
+}
+
 void test_events(void)
 {
 	assertEvents("/event");

--- a/server/test/testFaceRestHost.cc
+++ b/server/test/testFaceRestHost.cc
@@ -162,7 +162,8 @@ static void _assertTriggers(
   const LocalHostIdType &hostIdInServer = ALL_LOCAL_HOSTS,
   const timespec &beginTime = {0, 0},
   const timespec &endTime = {0, 0},
-  const size_t expectedNumTrigger = -1)
+  const size_t expectedNumTrigger = -1,
+  const string &hostname = "")
 {
 	loadTestDBArmPlugin();
 	loadTestDBTriggers();
@@ -209,6 +210,8 @@ static void _assertTriggers(
 	if (endTime.tv_sec != 0 || endTime.tv_nsec != 0) {
 		queryMap["endTime"] = StringUtils::sprintf("%ld", endTime.tv_sec);
 	}
+	if (!hostname.empty())
+		queryMap["hostname"] = hostname;
 	arg.parameters = queryMap;
 	JSONParser *parser = getResponseAsJSONParser(arg);
 	unique_ptr<JSONParser> parserPtr(parser);


### PR DESCRIPTION
This PR contains `hostname` version of beyond server filter.
But for now, it accept only one `hostname` in query.