### PR TITLE
[test][FaceRestTestUtils] Fix invalid memory reference

### DIFF
--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -85,8 +85,8 @@ static string makeQueryString(const StringMap &parameters,
 	cppcut_assert_not_null(hashTable);
 	StringMapConstIterator it = parameters.begin();
 	for (; it != parameters.end(); ++it) {
-		string key = it->first;
-		string val = it->second;
+		const string &key = it->first;
+		const string &val = it->second;
 		g_hash_table_insert(hashTable,
 		                    (void *)key.c_str(), (void *)val.c_str());
 	}


### PR DESCRIPTION
Many tests fail on Ubuntu 15.10 due to this bug.