### PR TITLE
Accept and stores multiple itemGroups (#1765).

### DIFF
--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -106,18 +106,18 @@ var LatestView = function(userProfile) {
 
   function parseData(replyData) {
     var parsedData = {};
-    var appNames = [];
+    var itemGrpNames = [];
     var x, item;
 
-    for (x = 0; x < replyData["applications"].length; ++x) {
-      item = replyData["applications"][x];
+    for (x = 0; x < replyData["itemGroups"].length; ++x) {
+      item = replyData["itemGroups"][x];
 
       if (item["name"].length === 0)
         item["name"] = "_non_";
       else
-        appNames.push(item["name"]);
+        itemGrpNames.push(item["name"]);
     }
-    parsedData.applications = appNames.uniq().sort();
+    parsedData.itemGroupNames = itemGrpNames.uniq().sort();
 
     return parsedData;
   }
@@ -154,9 +154,9 @@ var LatestView = function(userProfile) {
   }
 
   function drawTableBody(replyData) {
-    var nickName, hostName, clock, appName;
+    var nickName, hostName, clock, grpNames;
     var html = "", url, server, item, x;
-    var targetAppName = self.getTargetAppName();
+    var targetItemGrpName = self.getTargetAppName();
 
     html = "";
     for (x = 0; x < replyData["items"].length; ++x) {
@@ -166,14 +166,14 @@ var LatestView = function(userProfile) {
       nickName = getNickName(server, item["serverId"]);
       hostName   = getHostName(server, item["hostId"]);
       clock      = item["lastValueTime"];
-      appName    = item["itemGroupName"];
+      grpNames   = item["itemGroupNames"];
 
-      if (targetAppName && appName != targetAppName)
+      if (targetItemGrpName && (grpNames.indexOf(targetItemGrpName) < 0))
         continue;
 
       html += "<tr><td>" + escapeHTML(nickName) + "</td>";
       html += "<td>" + escapeHTML(hostName) + "</td>";
-      html += "<td>" + escapeHTML(appName) + "</td>";
+      html += "<td>" + escapeHTML(grpNames.join(", ")) + "</td>";
       if (url)
         html += "<td><a href='" + url + "' target='_blank'>" +
                 escapeHTML(item["brief"])  + "</a></td>";
@@ -197,7 +197,7 @@ var LatestView = function(userProfile) {
     rawData = reply;
     parsedData = parseData(rawData);
 
-    self.setApplicationFilterCandidates(parsedData.applications);
+    self.setApplicationFilterCandidates(parsedData.itemGroupNames);
 
     drawTableContents(rawData);
     self.pager.update({ numTotalRecords: rawData["totalNumberOfItems"] });
@@ -211,7 +211,7 @@ var LatestView = function(userProfile) {
   function getItemsQueryInURI() {
     var knownKeys = [
       "serverId", "hostgroupId", "hostId",
-      "limit", "offset", "appName",
+      "limit", "offset", "itemGroupName",
     ];
     var i, allParams = deparam(), query = {};
     for (i = 0; i < knownKeys.length; i++) {
@@ -230,7 +230,7 @@ var LatestView = function(userProfile) {
     });
     if (self.lastQuery) {
       $.extend(query, self.getHostFilterQuery());
-      $.extend(query, query, { appName: self.getTargetAppName() });
+      $.extend(query, query, {itemGroupName: self.getTargetAppName() });
     }
     self.lastQuery = query;
     return 'item?' + $.param(query);

--- a/client/test/browser/test_latest_view.js
+++ b/client/test/browser/test_latest_view.js
@@ -10,7 +10,7 @@ describe('LatestView', function() {
       "lastValueTime": 1415232279,
       "lastValue": "54.282349",
       "prevValue": "24.594534",
-      "itemGroupName": "group1",
+      "itemGroupNames": ["group1"],
       "unit": "%",
       "valueType": hatohol.ITEM_INFO_VALUE_TYPE_FLOAT,
     },
@@ -22,7 +22,7 @@ describe('LatestView', function() {
       "lastValueTime": 1415232279,
       "lastValue": "host1",
       "prevValue": "host1",
-      "itemGroupName": "group1",
+      "itemGroupNames": ["group1", "group2", "group3"],
       "unit": "",
       "valueType": hatohol.ITEM_INFO_VALUE_TYPE_STRING,
     },
@@ -51,13 +51,13 @@ describe('LatestView', function() {
     return new HatoholUserProfile(operator);
   }
 
-  function itemsJson(items, servers, applications) {
+  function itemsJson(items, servers, itemGroups) {
     return JSON.stringify({
       apiVersion: hatohol.FACE_REST_API_VERSION,
       errorCode: hatohol.HTERR_OK,
       items: items ? items : [],
       servers: servers ? servers : {},
-      applications: applications ? applications : []
+      itemGroups: itemGroups ? itemGroups : []
     });
   }
 
@@ -145,7 +145,7 @@ describe('LatestView', function() {
     var expected =
       '<td>Zabbix</td>' +
       '<td>Host1</td>' +
-      '<td>group1</td>' +
+      '<td>group1, group2, group3</td>' +
       '<td><a href="' + zabbixURL + '" target="_blank">host name</a></td>' +
       '<td data-sort-value="1415232279">' +
       formatDate(1415232279) +

--- a/doc/server/rest-api/items.rst
+++ b/doc/server/rest-api/items.rst
@@ -48,8 +48,8 @@ Parameters
    * - hostId
      - Specifies a host ID to retrieve items belong to it.
      - Optional
-   * - appName
-     - Specifies a name of `Application object`_ to retrieve items belong to it.
+   * - itemGroupName
+     - Specifies a name of the item group to retrieve items that belong to it.
      - Optional
    * - itemId
      - Specifies an ID of an item to retrieve.
@@ -92,9 +92,9 @@ Response structure
      - Array
      - Array of `Item object`_.
      - True
-   * - applications
+   * - itemGroups
      - Array
-     - Array of `Application object`_.
+     - Array of `ItemGroup object`_.
      - True
    * - servers
      - Object
@@ -135,9 +135,9 @@ Zabbix.
    * - lastValue
      - String
      - The last value.
-   * - itemGroupName
-     - String
-     - The item group name.
+   * - itemGroupNames
+     - Array of string
+     - The item group names.
    * - unit
      - String
      - The unit of the item.
@@ -161,10 +161,10 @@ An item can be one of these types.
    * - 3
      - ITEM_INFO_VALUE_TYPE_STRING
 
-Application object
+ItemGroup object
 ~~~~~~~~~~~~~~~~~~
 
-`Application object`_ represents a group of items.
+`ItemGroup object`_ represents a group of items.
 
 .. list-table::
    :header-rows: 1
@@ -174,7 +174,7 @@ Application object
      - Brief
    * - name
      - String
-     - A name of the application.
+     - A name of the item group.
 
 Example
 -------------
@@ -191,7 +191,7 @@ Example
         "brief":"Processor load (15 min average per core)",
         "lastValueTime":1453713375,
         "lastValue":"0.0500",
-        "itemGroupName":"CPU",
+        "itemGroupNames":["CPU"],
         "unit":"",
         "valueType":1
       },
@@ -202,7 +202,7 @@ Example
         "brief":"Processor load (1 min average per core)",
         "lastValueTime":1453713376,
         "lastValue":"0.0000",
-        "itemGroupName":"CPU",
+        "itemGroupNames":[],
         "unit":"",
         "valueType":1
       },
@@ -213,7 +213,7 @@ Example
         "brief":"Processor load (5 min average per core)",
         "lastValueTime":1453713377,
         "lastValue":"0.0200",
-        "itemGroupName":"CPU",
+        "itemGroupNames":["CPU","Memory"],
         "unit":"",
         "valueType":1
       },
@@ -224,7 +224,7 @@ Example
         "brief":"Context switches per second",
         "lastValueTime":1453713378,
         "lastValue":"145",
-        "itemGroupName":"CPU",
+        "itemGroupNames":["CPU","Performance","Process"],
         "unit":"sps",
         "valueType":2
       },
@@ -235,12 +235,12 @@ Example
         "brief":"CPU idle time",
         "lastValueTime":1453713379,
         "lastValue":"99.6800",
-        "itemGroupName":"CPU",
+        "itemGroupNames":["CPU"],
         "unit":"%",
         "valueType":1
       },
     ],
-    "applications":[
+    "itemGroups":[
       {
         "name":"Zabbix server"
       },

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -254,8 +254,6 @@ rm -rf %{buildroot}
 %{_tmpfilesdir}/hatohol.conf
 %endif
 %{_datadir}/hatohol/sql/init-user.sql
-%{_datadir}/hatohol/sql/server-type-zabbix.sql
-%{_datadir}/hatohol/sql/server-type-nagios.sql
 %{_datadir}/hatohol/sql/server-type-hapi-json.sql
 %{_datadir}/hatohol/sql/severity-ranks.sql
 %{_datadir}/hatohol/sql/custom-incident-statuses.sql

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -152,6 +152,7 @@ enum ItemInfoValueType {
 };
 
 struct ItemInfo {
+	GenericIdType       globalId;
 	ServerIdType        serverId;
 	ItemIdType          id;
 	HostIdType          globalHostId;
@@ -160,7 +161,7 @@ struct ItemInfo {
 	timespec            lastValueTime;
 	std::string         lastValue;
 	std::string         prevValue;
-	std::string         itemGroupName;
+	std::vector<std::string> categoryNames;
 	int                 delay;
 	ItemInfoValueType   valueType;
 	std::string         unit;
@@ -170,13 +171,15 @@ typedef std::list<ItemInfo>          ItemInfoList;
 typedef ItemInfoList::iterator       ItemInfoListIterator;
 typedef ItemInfoList::const_iterator ItemInfoListConstIterator;
 
-struct ApplicationInfo {
-	std::string           applicationName;
+struct ItemCategory {
+	GenericIdType         id;
+	GenericIdType         globalItemId;
+	std::string           name;
 };
 
-typedef std::vector<ApplicationInfo>        ApplicationInfoVect;
-typedef ApplicationInfoVect::iterator       ApplicationInfoVectIterator;
-typedef ApplicationInfoVect::const_iterator ApplicationInfoVectConstIterator;
+typedef std::vector<ItemCategory>        ItemCategoryVect;
+typedef ItemCategoryVect::iterator       ItemCategoryVectIterator;
+typedef ItemCategoryVect::const_iterator ItemCategoryVectConstIterator;
 
 struct HistoryInfo {
 	ServerIdType serverId;

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -251,6 +251,15 @@ public:
 	virtual bool lastUpsertDidUpdate(void) = 0;
 
 	/**
+	 * Check wheter the last upsert did update or not.
+	 *
+	 * @return
+	 * true if the last insert() with upsertOnDuplicate = true
+	 * did insert.
+	 */
+	virtual bool lastUpsertDidInsert(void) = 0;
+
+	/**
 	 * Create and drop indexes if needed.
 	 *
 	 * @param tableProfile

--- a/server/src/DBAgentMySQL.cc
+++ b/server/src/DBAgentMySQL.cc
@@ -513,6 +513,14 @@ bool DBAgentMySQL::lastUpsertDidUpdate(void)
 	return numAffectedRows == 2;
 }
 
+bool DBAgentMySQL::lastUpsertDidInsert(void)
+{
+	uint64_t numAffectedRows = getNumberOfAffectedRows();
+	HATOHOL_ASSERT(numAffectedRows >= 0 && numAffectedRows <= 2,
+	               "numAffectedRows: %" PRIu64, numAffectedRows);
+	return numAffectedRows == 1;
+}
+
 void DBAgentMySQL::addColumns(const AddColumnsArg &addColumnsArg)
 {
 	string query = "ALTER TABLE ";

--- a/server/src/DBAgentMySQL.h
+++ b/server/src/DBAgentMySQL.h
@@ -70,6 +70,7 @@ public:
 	virtual uint64_t getLastInsertId(void);
 	virtual uint64_t getNumberOfAffectedRows(void);
 	virtual bool lastUpsertDidUpdate(void) override;
+	virtual bool lastUpsertDidInsert(void) override;
 	/**
 	 * Dispose DBAgentMySQL object and stop retrying connection to MySQL.
 	 *

--- a/server/src/DBAgentSQLite3.cc
+++ b/server/src/DBAgentSQLite3.cc
@@ -833,6 +833,12 @@ bool DBAgentSQLite3::lastUpsertDidUpdate(void)
 	return tls_lastUpsertDidUpdate;
 }
 
+bool DBAgentSQLite3::lastUpsertDidInsert(void)
+{
+	HATOHOL_ASSERT(false, "Not implemented.");
+	return false;
+}
+
 ItemDataPtr DBAgentSQLite3::getValue(sqlite3_stmt *stmt,
                                      size_t index, SQLColumnType columnType)
 {

--- a/server/src/DBAgentSQLite3.h
+++ b/server/src/DBAgentSQLite3.h
@@ -72,6 +72,7 @@ public:
 	virtual uint64_t getLastInsertId(void);
 	virtual uint64_t getNumberOfAffectedRows(void);
 	virtual bool lastUpsertDidUpdate(void) override;
+	virtual bool lastUpsertDidInsert(void) override;
 
 	std::string getDBPath(void) const;
 

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -138,11 +138,9 @@ public:
 
 	void setTargetId(const ItemIdType &id);
 	ItemIdType getTargetId(void) const;
-	void setTargetItemGroupName(const std::string &itemGroupName);
-	const std::string &getTargetItemGroupName(void);
-	void setAppName(const std::string &appName) const;
+	void setTargetItemCategoryName(const std::string &categoryName);
+	const std::string &getTargetItemCategoryName(void);
 	void setExcludeFlags(const ExcludeFlags &flg);
-	const std::string &getAppName(void) const;
 
 private:
 	struct Impl;
@@ -210,6 +208,7 @@ public:
 	static const char *TABLE_NAME_TRIGGERS;
 	static const char *TABLE_NAME_EVENTS;
 	static const char *TABLE_NAME_ITEMS;
+	static const char *TABLE_NAME_ITEM_CATEGORIES;
 	static const char *TABLE_NAME_SERVER_STATUS;
 	static const char *TABLE_NAME_INCIDENTS;
 	static const char *TABLE_NAME_INCIDENT_STATUS_HISTORIES;
@@ -293,8 +292,8 @@ public:
 	void addItemInfoList(const ItemInfoList &itemInfoList);
 	void getItemInfoList(ItemInfoList &itemInfoList,
 			     const ItemsQueryOption &option);
-	void getApplicationInfoVect(ApplicationInfoVect &applicationInfoVect,
-			     const ItemsQueryOption &option);
+	void getItemCategoryNames(std::vector<std::string> &itemCategoryNames,
+	                          const ItemsQueryOption &option);
 	void addMonitoringServerStatus(
 	  const MonitoringServerStatus &serverStatus);
 
@@ -374,6 +373,8 @@ protected:
 	  DBAgent &dbAgent, EventInfo &eventInfo);
 	static void addItemInfoWithoutTransaction(
 	  DBAgent &dbAgent, const ItemInfo &itemInfo);
+	static void addItemCategoryWithoutTransaction(
+	  DBAgent &dbAgent, const ItemCategory &category);
 	static void addMonitoringServerStatusWithoutTransaction(
 	  DBAgent &dbAgent, const MonitoringServerStatus &serverStatus);
 	static void addIncidentInfoWithoutTransaction(

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1236,19 +1236,15 @@ static bool parseItemParams(JSONParser &parser, ItemInfoList &itemInfoList,
 	 * is assigned.
 	 * @return true if successful. Otherwise false.
 	 */
-	auto getItemGroupName = [&](string &name) {
+	auto getItemGroupName = [&](vector<string> &names) {
 		CHECK_MANDATORY_ARRAY_EXISTENCE("itemGroupName", errObj);
 		parser.startObject("itemGroupName");
 		size_t num = parser.countElements();
-		if (num == 0)
-			name.clear();
-		else
-			parser.read(0, name);
-		// TODO: Don't ignore 2nd and the later itemGroupName.
-		if (num > 1) {
-			MLPL_WARN("Ignore 2nd and later itemGroups. This is "
-			          "a limitation of the current version of "
-			          "Hatohol (#1721).\n");
+		names.clear();
+		for (size_t i = 0; i < num; i++) {
+			string name;
+			parser.read(i, name);
+			names.push_back(name);
 		}
 		parser.endObject();
 		return true;
@@ -1274,7 +1270,7 @@ static bool parseItemParams(JSONParser &parser, ItemInfoList &itemInfoList,
 		PARSE_AS_MANDATORY("brief", itemInfo.brief, errObj);
 		parseTimeStamp(parser, "lastValueTime", itemInfo.lastValueTime, errObj);
 		PARSE_AS_MANDATORY("lastValue", itemInfo.lastValue, errObj);
-		if (!getItemGroupName(itemInfo.itemGroupName))
+		if (!getItemGroupName(itemInfo.categoryNames))
 			return false;
 		PARSE_AS_MANDATORY("unit", itemInfo.unit, errObj);
 		parser.endElement();

--- a/server/src/HatoholDBUtils.cc
+++ b/server/src/HatoholDBUtils.cc
@@ -481,9 +481,7 @@ bool HatoholDBUtils::transformItemItemGroupToItemInfo(
 	itemGroupStream.seek(ITEM_ID_ZBX_ITEMS_APPLICATIONID);
 	itemGroupStream >> itemCategoryId;
 
-	if (itemCategoryId == NO_ITEM_CATEGORY_ID) {
-		itemInfo.itemGroupName = "N/A";
-	} else {
+	if (itemCategoryId != NO_ITEM_CATEGORY_ID) {
 		ItemCategoryNameMapConstIterator it =
 		  itemCategoryNameMap.find(itemCategoryId);
 		if (it == itemCategoryNameMap.end()) {
@@ -492,7 +490,7 @@ bool HatoholDBUtils::transformItemItemGroupToItemInfo(
 			         itemCategoryId.c_str());
 			return false;
 		}
-		itemInfo.itemGroupName = it->second;
+		itemInfo.categoryNames.push_back(it->second);
 	}
 
 	return true;

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -450,11 +450,11 @@ void UnifiedDataStore::getItemList(ItemInfoList &itemList,
 	cache.getMonitoring().getItemInfoList(itemList, option);
 }
 
-void UnifiedDataStore::getApplicationVect(ApplicationInfoVect &ApplicationInfoVect,
-                                          const ItemsQueryOption &option)
+void UnifiedDataStore::getItemCategoryNames(
+  vector<string> &categoryNames, const ItemsQueryOption &option)
 {
 	ThreadLocalDBCache cache;
-	cache.getMonitoring().getApplicationInfoVect(ApplicationInfoVect, option);
+	cache.getMonitoring().getItemCategoryNames(categoryNames, option);
 }
 
 bool UnifiedDataStore::fetchItemsAsync(Closure0 *closure,

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -97,8 +97,8 @@ public:
 	void getItemList(ItemInfoList &itemList,
 	                 const ItemsQueryOption &option,
 	                 bool fetchItemsSynchronously = false);
-	void getApplicationVect(ApplicationInfoVect &applicationInfoVect,
-	                        const ItemsQueryOption &option);
+	void getItemCategoryNames(std::vector<std::string> &itemCategoryNames,
+	                          const ItemsQueryOption &option);
 	bool fetchItemsAsync(Closure0 *closure,
 	                     const ItemsQueryOption &option);
 	bool fetchTriggerAsync(Closure0 *closure,

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -574,6 +574,7 @@ const size_t NumTestDupEventInfo = ARRAY_SIZE(testDupEventInfo);
 
 const ItemInfo testItemInfo[] = {
 {
+	1,                        // globalId
 	1,                        // serverId
 	"2",                      // id
 	30,                       // globalHostId
@@ -582,11 +583,12 @@ const ItemInfo testItemInfo[] = {
 	{1362951129,0},           // lastValueTime
 	"Fukuoka",                // lastValue
 	"Sapporo",                // prevValue
-	"City",                   // itemGroupName,
+	{"City"},                 // categoryNames;
 	0,                        // delay
 	ITEM_INFO_VALUE_TYPE_STRING, // valueType
 	"",                       // unit
 }, {
+	2,                        // globalId
 	3,                        // serverId
 	"1",                      // id
 	42,                       // globalHostId
@@ -595,11 +597,12 @@ const ItemInfo testItemInfo[] = {
 	{1362957200,0},           // lastValueTime
 	"1",                      // lastValue
 	"5",                      // prevValue
-	"number",                 // itemGroupName,
+	{"number"},               // categoryNames;
 	0,                        // delay
 	ITEM_INFO_VALUE_TYPE_INTEGER, // valueType
 	"age",                    // unit
 }, {
+	3,                        // globalId
 	3,                        // serverId
 	"2",                      // id
 	45,                       // globalHostId
@@ -608,11 +611,12 @@ const ItemInfo testItemInfo[] = {
 	{1362951000,0},           // lastValueTime
 	"Osaka",                  // lastValue
 	"Ichikawa",               // prevValue
-	"City",                   // itemGroupName,
+	{"City"},                 // categoryNames;
 	0,                        // delay
 	ITEM_INFO_VALUE_TYPE_STRING, // valueType
 	"",                       // unit
 }, {
+	4,                        // globalId
 	4,                        // serverId
 	"1",                      // id
 	100,                      // globalHostId
@@ -621,7 +625,35 @@ const ItemInfo testItemInfo[] = {
 	{1362951000,0},           // lastValueTime
 	"Osaka",                  // lastValue
 	"Ichikawa",               // prevValue
-	"City",                   // itemGroupName,
+	{"City"},                 // categoryNames;
+	0,                        // delay
+	ITEM_INFO_VALUE_TYPE_STRING, // valueType
+	"",                       // unit
+}, {
+	5,                        // globalId
+	211,                      // serverId
+	"12345",                  // id
+	1050,                     // globalHostId
+	"200",                    // hostIdInServer
+	"Multiple item group (category).", // brief
+	{1362951444,123},         // lastValueTime
+	"@n1m@l",                 // lastValue
+	"animal",                 // prevValue
+	{"DOG", "ABC", "I'm a perfect human."}, // categoryNames;
+	0,                        // delay
+	ITEM_INFO_VALUE_TYPE_STRING, // valueType
+	"",                       // unit
+}, {
+	6,                        // globalId
+	211,                      // serverId
+	"abcde",                  // id
+	2111,                     // globalHostId
+	"12111",                  // hostIdInServer
+	"No item group (category)", // brief
+	{1362988899,456},         // lastValueTime
+	"imo",                    // lastValue
+	"arai",                   // prevValue
+	{},                       // categoryNames;
 	0,                        // delay
 	ITEM_INFO_VALUE_TYPE_STRING, // valueType
 	"",                       // unit

--- a/server/test/testDBAgent.cc
+++ b/server/test/testDBAgent.cc
@@ -381,6 +381,11 @@ private:
 		return false;
 	}
 
+	bool lastUpsertDidInsert(void) override
+	{
+		return false;
+	}
+
 	virtual string
 	makeCreateIndexStatement(const TableProfile &tableProfile,
 	                         const IndexDef &indexDef) override

--- a/server/test/testHatoholArmPluginGateHAPI2.cc
+++ b/server/test/testHatoholArmPluginGateHAPI2.cc
@@ -398,7 +398,7 @@ void test_procedureHandlerPutItems(void)
 		" {\"itemId\":\"2\", \"hostId\":\"1\","
 		" \"brief\":\"example brief\", \"lastValueTime\":\"20150410175531\","
 		" \"lastValue\":\"example value\","
-		" \"itemGroupName\":[\"example name\", \"example2\"], \"unit\":\"example unit\"},"
+		" \"itemGroupName\":[\"example name\", \"category2\", \"category3\"], \"unit\":\"example unit\"},"
 		// 3rd item
 		" {\"itemId\":\"3\", \"hostId\":\"1\","
 		" \"brief\":\"example wiht empty itemGroupName array\","
@@ -434,7 +434,7 @@ void test_procedureHandlerPutItems(void)
 	item1.brief          = "example brief";
 	item1.lastValueTime  = timeStamp;
 	item1.lastValue      = "example value";
-	item1.itemGroupName  = "example name";
+	item1.categoryNames  = {"example name"};
 	item1.valueType      = ITEM_INFO_VALUE_TYPE_UNKNOWN;
 	item1.delay          = 0;
 	item1.unit           = "example unit";
@@ -449,7 +449,7 @@ void test_procedureHandlerPutItems(void)
 	item2.brief          = "example brief";
 	item2.lastValueTime  = timeStamp;
 	item2.lastValue      = "example value";
-	item2.itemGroupName  = "example name";
+	item2.categoryNames  = {"example name", "category2", "category3"};
 	item2.valueType      = ITEM_INFO_VALUE_TYPE_UNKNOWN;
 	item2.delay          = 0;
 	item2.unit           = "example unit";
@@ -464,7 +464,7 @@ void test_procedureHandlerPutItems(void)
 	item3.brief          = "example wiht empty itemGroupName array";
 	item3.lastValueTime  = timeStamp;
 	item3.lastValue      = "Alpha Beta Gamma";
-	item3.itemGroupName  = "";
+	item3.categoryNames.clear();
 	item3.valueType      = ITEM_INFO_VALUE_TYPE_UNKNOWN;
 	item3.delay          = 0;
 	item3.unit           = "Kelvin";

--- a/server/test/testHatoholDBUtils.cc
+++ b/server/test/testHatoholDBUtils.cc
@@ -59,9 +59,9 @@ public:
 		ItemCategoryNameMap itemCategoryNameMap;
 		if (useItemCategoryNameMap) {
 			itemCategoryNameMap[itemCategoryId] =
-			  expect.itemGroupName;
+			  expect.categoryNames[0];
 		} else {
-			expect.itemGroupName = "N/A";
+			expect.categoryNames.clear();
 		}
 
 		HostInfoCache hostInfoCache;
@@ -84,7 +84,7 @@ public:
 		                    actual.lastValueTime.tv_nsec);
 		cppcut_assert_equal(expect.lastValue, actual.lastValue);
 		cppcut_assert_equal(expect.prevValue, actual.prevValue);
-		cppcut_assert_equal(expect.itemGroupName, actual.itemGroupName);
+		assertStringVector(expect.categoryNames, actual.categoryNames);
 		cppcut_assert_equal(expect.delay, actual.delay);
 	}
 };

--- a/server/test/testHostResourceQueryOptionSubClasses.cc
+++ b/server/test/testHostResourceQueryOptionSubClasses.cc
@@ -668,19 +668,19 @@ void test_itemsQueryOptionWithTargetId(gconstpointer data)
 	cppcut_assert_equal(expected, option.getCondition());
 }
 
-void data_itemsQueryOptionWithItemGroupName(void)
+void data_itemsQueryOptionWithItemCategoryName(void)
 {
 	prepareTestDataExcludeDefunctServers();
 }
 
-void test_itemsQueryOptionWithItemGroupName(gconstpointer data)
+void test_itemsQueryOptionWithItemCategoryName(gconstpointer data)
 {
 	ItemsQueryOption option(USER_ID_SYSTEM);
-	string itemGroupName = "It's test items";
-	option.setTargetItemGroupName(itemGroupName);
-	string expected = "items.item_group_name='It''s test items'";
+	string categoryName = "It's test items";
+	option.setTargetItemCategoryName(categoryName);
+	string expected = "item_categories.name='It''s test items'";
 	fixupForFilteringDefunctServer(data, expected, option);
-	cppcut_assert_equal(itemGroupName, option.getTargetItemGroupName());
+	cppcut_assert_equal(categoryName, option.getTargetItemCategoryName());
 	cppcut_assert_equal(expected, option.getCondition());
 }
 

--- a/server/test/testUnifiedDataStore.cc
+++ b/server/test/testUnifiedDataStore.cc
@@ -87,7 +87,7 @@ static string dumpItemInfo(const ItemInfo &info)
 {
 	return StringUtils::sprintf(
 		"%" FMT_SERVER_ID "|%" FMT_ITEM_ID "|%" FMT_HOST_ID
-		"|%" FMT_LOCAL_HOST_ID "|%s|%lu|%ld|%s|%s|%s\n",
+		"|%" FMT_LOCAL_HOST_ID "|%s|%lu|%ld|%s|%s\n",
 		info.serverId,
 		info.id.c_str(),
 		info.globalHostId,
@@ -96,8 +96,7 @@ static string dumpItemInfo(const ItemInfo &info)
 		info.lastValueTime.tv_sec,
 		info.lastValueTime.tv_nsec,
 		info.lastValue.c_str(),
-		info.prevValue.c_str(),
-		info.itemGroupName.c_str());
+		info.prevValue.c_str());
 }
 
 template<class T>


### PR DESCRIPTION
Previosly, the HAPI2.0 interface implementation of Hatohol server
has accepted only the first item group (which calls it application in
ZABBIX) and drops the followed ones. This patch enables multiple
item groups to be handled properly.

To realize this feature, this patch adds the followings.

- adds a new table: item_categories instead of items.item_group_name
  which can have only one group name.

- 'itemGroupName' and 'applications' in FaceREST request are replaced
  'itemGroupNames' and 'ItemGroups' respectively for improving readability.

Note: The item groups (itemGroups) is called item categroy (itemCategory)
in Hatohol sever code to avoid confusion with the class ItemGroup already
existing, which is a generic container for ItemData.