### PR TITLE
[WebUI][TriggersView][BeyondMonitoringServerFilter] Add beyond monitoring server filter for hostname

### DIFF
--- a/client/static/js/hatohol_monitoring_view.js
+++ b/client/static/js/hatohol_monitoring_view.js
@@ -57,6 +57,13 @@ HatoholMonitoringView.prototype.getTargetHostId = function() {
   return id;
 };
 
+HatoholMonitoringView.prototype.getTargetHostname = function() {
+  var name = $("#select-hostname").val();
+  if (name == "---------")
+    name = "";
+  return name;
+};
+
 HatoholMonitoringView.prototype.getTargetAppName = function() {
   var name = $("#select-application").val();
   if (name == "---------")
@@ -176,6 +183,35 @@ HatoholMonitoringView.prototype.setHostFilterCandidates =
   hostSelector.val(current);
 };
 
+HatoholMonitoringView.prototype.setHostnameFilterCandidates =
+  function(servers, withoutSelfMonitor)
+{
+  var id, server, hosts, hostLabels = [], current;
+  var hostnameSelector = $('#select-hostname');
+
+  current = hostnameSelector.val();
+
+  this.setFilterCandidates(hostnameSelector);
+
+  if (!servers)
+    return;
+
+  for (var serverId in servers) {
+    server = servers[serverId];
+    for (id in server.hosts) {
+      if (withoutSelfMonitor && (withoutSelfMonitor === true) && (id == "__SELF_MONITOR"))
+        continue;
+      hostLabels.push({
+        label: getHostName(server, id),
+        value: getHostName(server, id)
+      });
+    }
+  }
+  hostLabels.sort(this.compareFilterLabel);
+  this.setFilterCandidates(hostnameSelector, hostLabels);
+  hostnameSelector.val(current);
+};
+
 HatoholMonitoringView.prototype.setApplicationFilterCandidates =
 function(candidates)
 {
@@ -190,9 +226,11 @@ HatoholMonitoringView.prototype.getHostFilterQuery = function() {
   var serverId = this.getTargetServerId();
   var hostgroupId = this.getTargetHostgroupId();
   var hostId = this.getTargetHostId();
+  var hostname = this.getTargetHostname();
   query.serverId = serverId ? serverId : "-1";
   query.hostgroupId = hostgroupId ? hostgroupId : "*";
   query.hostId = hostId ? hostId : "*";
+  query.hostname = hostname;
   return query;
 };
 
@@ -384,6 +422,16 @@ HatoholMonitoringView.prototype.setupHostFilters = function(servers, query, with
       $("#select-host").val("");
     } else {
       $("#select-host").val(query.hostId);
+    }
+  }
+
+  this.setHostnameFilterCandidates(servers, withoutSelfMonitor);
+
+  if (query && ("hostname" in query)) {
+    if (query.hostname === "") {
+      $("#select-hostname").val("");
+    } else {
+      $("#select-hostname").val(query.hostName);
     }
   }
 };

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -299,6 +299,7 @@ var TriggersView = function(userProfile, options) {
     $("#select-status").selectpicker();
     $("#select-host").selectpicker();
     $("#select-host-group").selectpicker();
+    $("#select-hostname").selectpicker();
   }
 
   function setLoading(loading) {
@@ -310,6 +311,7 @@ var TriggersView = function(userProfile, options) {
       $("#select-server").attr("disabled", "disabled");
       $("#select-host-group").attr("disabled", "disabled");
       $("#select-host").attr("disabled", "disabled");
+      $("#select-hostname").attr("disabled", "disabled");
       $(".latest-button").attr("disabled", "disabled");
     } else {
       $("#begin-time").removeAttr("disabled");
@@ -321,6 +323,7 @@ var TriggersView = function(userProfile, options) {
         $("#select-host-group").removeAttr("disabled");
       if ($("#select-host option").length > 1)
         $("#select-host").removeAttr("disabled");
+      $("#select-hostname").removeAttr("disabled");
       $(".latest-button").removeAttr("disabled");
 
       setupSelectPickers();
@@ -413,7 +416,7 @@ var TriggersView = function(userProfile, options) {
 
   function getTriggersQueryInURI() {
     var knownKeys = [
-      "serverId", "hostgroupId", "hostId",
+      "serverId", "hostgroupId", "hostId", "hostname",
       "limit", "offset",
       "minimumSeverity", "status",
     ];

--- a/client/viewer/triggers_ajax.html
+++ b/client/viewer/triggers_ajax.html
@@ -82,6 +82,12 @@
 	  <option value="2">{% trans "Unknown" %}</option>
 	</select>
       </div>
+      <div class="filter-element">
+	<p><label>{% trans "Hostname:" %}</label></p>
+	<select id="select-hostname" class="form-control"  data-live-search="true">
+	  <option value="">---------</option>
+	</select>
+      </div>
 
       <div style="text-align:center;">
         <button id="reset-all-filter" type="button" class="btn btn-default reset-apply-all-filter">


### PR DESCRIPTION
This PR adds a feature which is the initial implementation beyond monitoring server filter for hostname.

`hostname` select box is newly added like this:

![screenshot from 2016-03-01 16 33 07](https://cloud.githubusercontent.com/assets/700876/13420664/7036b0e8-dfcb-11e5-8886-8813d68138a6.png)

And this select box is always selectable:

![screenshot from 2016-03-01 16 33 11](https://cloud.githubusercontent.com/assets/700876/13420673/7ef84eca-dfcb-11e5-9f16-27c530bf4901.png)
