### PR TITLE
[hap2] Log message w/ unexpected formats. (#2010)

### DIFF
--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -35,6 +35,11 @@ logger = getLogger("hatohol.hap2_fluentd:%s" % hapcommon.get_top_file_name())
 
 class Hap2FluentdMain(haplib.BaseMainPlugin):
 
+    # Ex.) 2016-03-03 12:11:17 +0900 hatohol.hoge
+    __re_expected_msg = re.compile(
+      "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d " +
+      "\\+\\d\\d\\d\\d [^\\[]+:")
+
     def __init__(self, *args, **kwargs):
         haplib.BaseMainPlugin.__init__(self)
 
@@ -151,6 +156,9 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
 
     def __parse_line(self, line):
         try:
+            if not self.__re_expected_msg.search(line):
+                logger.error("%% " + line.rstrip("\n"))
+                return None, None, None
             header, msg = line.split(": ", 1)
             timestamp, tag = self.__parse_header(header)
         except:

--- a/server/hap2/hatohol/test/TestHap2Fluentd.py
+++ b/server/hap2/hatohol/test/TestHap2Fluentd.py
@@ -157,8 +157,8 @@ class Hap2FluentdMain__parse_line(unittest.TestCase):
     def test_normal(self):
         expect_ts = datetime.datetime(2015, 7, 2, 9, 20, 20)
         self.__assert(
-            "2015-07-02 18:20:20 +0900 [warn]: process died",
-            (expect_ts, "[warn]", "process died"))
+            "2015-07-02 18:20:20 +0900 hatohol.test.msg: process died",
+            (expect_ts, "hatohol.test.msg", "process died"))
 
     def test_unexpected_date_format(self):
         self.__assert(


### PR DESCRIPTION
This major purpose of this patch is to log the message from
fluentd (td-agent) itself including error information.

This is an example of logging result. The messages w/ an unxpected
format are marked with '%%'.
<pre>
2016-03-03 13:35:20,352    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %% 2016-03-03 13:35:20 +0900 [info]: adding filter pattern="hatohol.**" type="record_transformer"
2016-03-03 13:35:20,352    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %% 2016-03-03 13:35:20 +0900 [info]: adding match pattern="hatohol.**" type="stdout"
2016-03-03 13:35:20,352    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %% 2016-03-03 13:35:20 +0900 [info]: adding source type="tail"
2016-03-03 13:35:20,353    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %% 2016-03-03 13:35:20 +0900 [error]: unexpected error error_class=Errno::EACCES error=#<Errno::EACCES: Permission denied @ rb_sysopen - messages.pos>
2016-03-03 13:35:20,353    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %%   2016-03-03 13:35:20 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/plugin/in_tail.rb:78:in `initialize'
2016-03-03 13:35:20,353    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %%   2016-03-03 13:35:20 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/plugin/in_tail.rb:78:in `open'
2016-03-03 13:35:20,353    ERROR [23289] hatohol.hap2_fluentd:hap2_fluentd.py:160:  %%   2016-03-03 13:35:20 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/plugin/in_tail.rb:78:in `start'
</pre>