### PR TITLE
[TriggersView] Refresh bootstrap-select's selectpickers correctly

### DIFF
--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -478,6 +478,15 @@ var TriggersView = function(userProfile, options) {
     $("#select-server").val("");
     $("#select-host-group").val("");
     $("#select-host").val("");
+    $("#select-hostname").val("");
+
+    // refresh bootstrap-select selectpickers
+    $("#select-severity").selectpicker('refresh');
+    $("#select-status").selectpicker('refresh');
+    $("#select-server").selectpicker('refresh');
+    $("#select-host-group").selectpicker('refresh');
+    $("#select-host").selectpicker('refresh');
+    $("#select-hostname").selectpicker('refresh');
   }
 
   function formatDateTimeWithZeroSecond(d) {


### PR DESCRIPTION
Refresh button has been broken since introducing `bootstrap-select` against selectboxes in triggers view.