### PR TITLE
[hap2][fluentd] Tidy up fluentd hap2 plugin

### DIFF
--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -92,7 +92,7 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
                 time.sleep(self.__ms_info.retry_interval_sec)
 
     def __fluentd_manager_main_in_try_block(self):
-        logger.info("Started fluentd manger process.")
+        logger.info("Started fluentd manager process.")
         fluentd = subprocess.Popen(self.__launch_args, stdout=subprocess.PIPE)
         while True:
             line = fluentd.stdout.readline()

--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -86,7 +86,8 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
         while True:
             try:
                 self.__fluentd_manager_main_in_try_block()
-            except:
+            except Exception as e:
+                logger.error(e)
                 hap.handle_exception()
                 self.__arm_info.fail()
                 time.sleep(self.__ms_info.retry_interval_sec)


### PR DESCRIPTION
* Fix a typo
* Print exception stack trace while td-agent launching
  * HAP2 Fluentd does not generate exception messages when it causes exception, for now. We should display exception stack trace when exception occurred.