### PR TITLE
[All page] Mistake window-close defender

### DIFF
--- a/client/static/js/before_close.js
+++ b/client/static/js/before_close.js
@@ -2,17 +2,18 @@
 
 (function(){
 	"use strict";
-	var beforeunloadFlug = true;
-	function beforeunloadFlgToggle(){
-		beforeunloadFlug = false;
-		setTimeout(function(){beforeunloadFlug = true;},1);
+	var beforeUnloadFlag = true;
+	function hookUnloadFlagAsync(){
+		beforeUnloadFlag = false;
+		setTimeout(function(){beforeUnloadFlag = true;},1);
 	}
 	if(!/^\/$/.test(location.pathname)){
-		$(document).on('click',beforeunloadFlgToggle);
+		$(document).on('click',hookUnloadFlagAsync);
 		
 		$(window).on("beforeunload",function(){
-		   if(beforeunloadFlug && !$('#hatohol_login_dialog').is(':visible')){
-			   return gettext("Hatohol is in system monitoring.\nYou are trying to transition or close this page.");
+		   if(beforeUnloadFlag && !$('#hatohol_login_dialog').is(':visible')){
+				return gettext("Hatohol is running to monitor system(s).\n" +
+				"You are trying to transition or close this page.");
 		   }
 		});
 	}

--- a/client/static/js/before_close.js
+++ b/client/static/js/before_close.js
@@ -2,17 +2,17 @@
 
 (function(){
 	"use strict";
-	var f = true;
+	var beforeunloadFlug = true;
 	function beforeunloadFlgToggle(){
-		f = false;
-		setTimeout(function(){f = true;},100);
+		beforeunloadFlug = false;
+		setTimeout(function(){beforeunloadFlug = true;},1);
 	}
 	if(!/^\/$/.test(location.pathname)){
 		$(document).on('click',beforeunloadFlgToggle);
 		
 		$(window).on("beforeunload",function(){
-		   if(f && !$('#hatohol_login_dialog').is(':visible')){
-			   return "Hatoholがシステム監視中です。\nこのページを移動、または閉じようとしています。";
+		   if(beforeunloadFlug && !$('#hatohol_login_dialog').is(':visible')){
+			   return gettext("Hatohol is in system monitoring.\nYou are trying to transition or close this page.");
 		   }
 		});
 	}

--- a/client/static/js/before_close.js
+++ b/client/static/js/before_close.js
@@ -1,0 +1,19 @@
+// before_close.js
+
+(function(){
+	"use strict";
+	var f = true;
+	function beforeunloadFlgToggle(){
+		f = false;
+		setTimeout(function(){f = true;},100);
+	}
+	if(!/^\/$/.test(location.pathname)){
+		$(document).on('click',beforeunloadFlgToggle);
+		
+		$(window).on("beforeunload",function(){
+		   if(f && !$('#hatohol_login_dialog').is(':visible')){
+			   return "Hatoholがシステム監視中です。\nこのページを移動、または閉じようとしています。";
+		   }
+		});
+	}
+})();

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -133,6 +133,7 @@
     <script src="{{ STATIC_URL }}js/hatohol_pager.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_version.js"></script>
     <script src="{{ STATIC_URL }}js/utils.js"></script>
+    <script src="{{ STATIC_URL }}js/before_close.js"></script>
     {% for file in plugin_js_files %}
     <script src="{{ STATIC_URL }}js.plugins/{{ file }}"></script>
     {% endfor %}


### PR DESCRIPTION
#2052 『誤操作の抑止』
のフロントエンド側実装です。

以下のような仕様になっています。
-サイト全体が対象。
-ページ内のリンク要素などでの遷移は警告なし。
-非ログイン時は警告なし。
-ウインドウを閉じる、F5やCtrl+R（リロード）、戻る、進むに反応。

よろしくおねがいします。