### PR TITLE
[WebUI:events] Description Shorten

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -754,26 +754,26 @@ td[id^="severity-rank-color"]:after {
 }
 
 .eventDescription div {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	word-break: keep-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    word-break: keep-all;
 }
 
 .descriptionFull .eventDescription div {
-	white-space: normal;
-	word-break: break-all;
+    white-space: normal;
+    word-break: break-all;
 }
 
 #column_description label {
-	margin: 0;
-	font-weight: normal;
-	color: #666666;
-	cursor: pointer;
+    margin: 0;
+    font-weight: normal;
+    color: #666666;
+    cursor: pointer;
 }
 
 #column_description label input {
     margin: 0 3px 0 10px;
-	vertical-align: -0.11em;
-	cursor: pointer;
+    vertical-align: -0.11em;
+    cursor: pointer;
 }

--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -752,3 +752,19 @@ td[id^="severity-rank-color"]:after {
     font-size: 14px;
     color: #ffffff;
 }
+
+.eventDescription div {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	word-break: keep-all;
+}
+
+.descriptionFull .eventDescription div {
+	white-space: normal;
+	word-break: break-all;
+}
+
+#column_description label {
+    margin: 0 0 0 5px;
+}

--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -766,5 +766,14 @@ td[id^="severity-rank-color"]:after {
 }
 
 #column_description label {
-    margin: 0 0 0 5px;
+	margin: 0;
+	font-weight: normal;
+	color: #666666;
+	cursor: pointer;
+}
+
+#column_description label input {
+    margin: 0 3px 0 10px;
+	vertical-align: -0.11em;
+	cursor: pointer;
 }

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1048,9 +1048,15 @@ var EventsView = function(userProfile, options) {
   function setDescriptionWidth() {
 	  var descriptionWidth = $('.event-table-content table:eq(0)').width() / 4;
 	  if(!$('#descriptionWidthStyle').is('div')){
-	    $('body').append('<div id="descriptionWidthStyle" style="display:none;position:absolute;"></div>');
+	    $('body').append(
+          '<div id="descriptionWidthStyle" style="display:none;position:absolute;"></div>'
+		);
 	  }
-	  $('#descriptionWidthStyle').html('<style>.eventDescription,.eventDescription div {width:'+descriptionWidth+'px!important;}</style>');
+	  $('#descriptionWidthStyle').html(
+        '<style>.eventDescription,.eventDescription div {width:'+
+        descriptionWidth+
+        'px!important;}</style>'
+      );
   }
 
   function getEventDescription(event) {
@@ -1309,7 +1315,9 @@ var EventsView = function(userProfile, options) {
       header += '>';
       header += definition.header;
 	  if (columnName == 'description')
-        header += '<label><input type="checkbox" class="toggleDescriptionFull"'+($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull')?' checked':'')+'>'+gettext("Show Full Text")+'</label>';
+        header += '<label><input type="checkbox" class="toggleDescriptionFull"'+
+		($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull')?' checked':'')+
+		'>'+gettext("Show Full Text")+'</label>';
       header += '</th>';
     }
 

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -700,14 +700,14 @@ var EventsView = function(userProfile, options) {
       resetQuickFilter();
     });
 
-    $(document).on("change",".toggleDescriptionFull",function() {
+    $(document).on("change",".toggleDescriptionFull", function() {
       var $this = $(this);
-	  var $table = $this.parents('table');
-	  if($this.is(':checked')){
-		  $table.addClass('descriptionFull');
-	  } else {
-		  $table.removeClass('descriptionFull');
-	  }
+      var $table = $this.parents('table');
+      if ($this.is(':checked')) {
+          $table.addClass('descriptionFull');
+      } else {
+        $table.removeClass('descriptionFull');
+      }
     });
 
     $(window).on('resize',setDescriptionWidth);

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -704,7 +704,7 @@ var EventsView = function(userProfile, options) {
       var $this = $(this);
       var $table = $this.parents('table');
       if ($this.is(':checked')) {
-          $table.addClass('descriptionFull');
+        $table.addClass('descriptionFull');
       } else {
         $table.removeClass('descriptionFull');
       }
@@ -1046,17 +1046,17 @@ var EventsView = function(userProfile, options) {
   }
 
   function setDescriptionWidth() {
-	  var descriptionWidth = $('.event-table-content table:eq(0)').width() / 4;
-	  if(!$('#descriptionWidthStyle').is('div')){
-	    $('body').append(
-          '<div id="descriptionWidthStyle" style="display:none;position:absolute;"></div>'
-		);
-	  }
-	  $('#descriptionWidthStyle').html(
-        '<style>.eventDescription,.eventDescription div {width:'+
-        descriptionWidth+
-        'px!important;}</style>'
+    var descriptionWidth = $('.event-table-content table:eq(0)').width() / 4;
+    if(!$('#descriptionWidthStyle').is('div')){
+      $('body').append(
+        '<div id="descriptionWidthStyle" style="display:none;position:absolute;"></div>'
       );
+    }
+    $('#descriptionWidthStyle').html(
+      '<style>.eventDescription,.eventDescription div {width:' +
+        descriptionWidth +
+        'px!important;}</style>'
+    );
   }
 
   function getEventDescription(event) {
@@ -1314,10 +1314,10 @@ var EventsView = function(userProfile, options) {
         header += ' class="incident" style="display:none;"';
       header += '>';
       header += definition.header;
-	  if (columnName == 'description')
-        header += '<label><input type="checkbox" class="toggleDescriptionFull"'+
-		($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull')?' checked':'')+
-		'>'+gettext("Show Full Text")+'</label>';
+      if (columnName == 'description')
+        header += '<label><input type="checkbox" class="toggleDescriptionFull"' +
+	($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull') ? ' checked' : '') +
+	'>' + gettext("Show Full Text") + '</label>';
       header += '</th>';
     }
 

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1297,6 +1297,7 @@ var EventsView = function(userProfile, options) {
   function drawTableHeader() {
     var i, definition, columnName, isIncident = false;
     var header = '<tr>';
+    var isFullDescription;
 
     for (i = 0; i < self.columnNames.length; i++) {
       columnName = self.columnNames[i];
@@ -1314,10 +1315,13 @@ var EventsView = function(userProfile, options) {
         header += ' class="incident" style="display:none;"';
       header += '>';
       header += definition.header;
-      if (columnName == 'description')
-        header += '<label><input type="checkbox" class="toggleDescriptionFull"' +
-	($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull') ? ' checked' : '') +
-	'>' + gettext("Show Full Text") + '</label>';
+      if (columnName == 'description') {
+        isFullDescription = $('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull');
+        header += '<label><input type="checkbox" class="toggleDescriptionFull"';
+        header += isFullDescription ? ' checked' : '';
+        header += '>';
+        header += gettext("Show Full Text") + '</label>';
+      }
       header += '</th>';
     }
 

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -700,10 +700,18 @@ var EventsView = function(userProfile, options) {
       resetQuickFilter();
     });
 
-    $("#toggle-abbreviating-event-descriptions").attr("checked", false);
-    $("#toggle-abbreviating-event-descriptions").change(function() {
-      load();
+    $(document).on("change",".toggleDescriptionFull",function() {
+      var $this = $(this);
+	  var $table = $this.parents('table');
+	  if($this.is(':checked')){
+		  $table.addClass('descriptionFull');
+	  } else {
+		  $table.removeClass('descriptionFull');
+	  }
     });
+
+    $(window).on('resize',setDescriptionWidth);
+    setDescriptionWidth();
   }
 
   function updateIncidentStatus() {
@@ -1037,6 +1045,14 @@ var EventsView = function(userProfile, options) {
       return description;
   }
 
+  function setDescriptionWidth() {
+	  var descriptionWidth = $('.event-table-content table:eq(0)').width() / 4;
+	  if(!$('#descriptionWidthStyle').is('div')){
+	    $('body').append('<div id="descriptionWidthStyle" style="display:none;position:absolute;"></div>');
+	  }
+	  $('#descriptionWidthStyle').html('<style>.eventDescription,.eventDescription div {width:'+descriptionWidth+'px!important;}</style>');
+  }
+
   function getEventDescription(event) {
     var extendedInfo, name;
 
@@ -1143,9 +1159,9 @@ var EventsView = function(userProfile, options) {
   function renderTableDataEventDescription(event, server) {
     var description = getEventDescription(event);
 
-    return "<td class='" + getSeverityClass(event) +
-      "' title='" + escapeHTML(description) + "'>" +
-      escapeHTML(description) + "</td>";
+    return "<td class='eventDescription " + getSeverityClass(event) +
+      "' title='" + escapeHTML(description) + "'><div>" +
+      escapeHTML(description) + "</div></td>";
   }
 
   function renderTableDataEventType(event, server) {
@@ -1292,6 +1308,8 @@ var EventsView = function(userProfile, options) {
         header += ' class="incident" style="display:none;"';
       header += '>';
       header += definition.header;
+	  if (columnName == 'description')
+        header += '<label><input type="checkbox" class="toggleDescriptionFull"'+($('#event-table-area .event-table-content table:eq(0)').is('.descriptionFull')?' checked':'')+'>'+gettext("Show Full Text")+'</label>';
       header += '</th>';
     }
 

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -261,7 +261,9 @@ describe('EventsView', function() {
       expected += '<td class="severity1">Host</td>';
     }
 
-    expected += '<td class="severity1" title="Test description.">Test description.</td>';
+    expected += '<td class="eventDescription severity1" title="Test description.">';
+    expected += '<div>Test description.</div>';
+    expected += '</td>';
 
     respond(eventsJson(dummyEventInfo, dummyServerInfo));
     expect($('#table')).to.have.length(1);
@@ -293,8 +295,8 @@ describe('EventsView', function() {
       ' target="_blank">Server</a></td>';
     expected += '<td class="severity1"><a href="' + escapeHTML(hostURL) +
                 '" target="_blank">Host2</a></td>';
-    expected += '<td class="severity1" title="Expanded test description 2.">';
-    expected += 'Expanded test description 2.</td>';
+    expected += '<td class="eventDescription severity1" title="Expanded test description 2.">';
+    expected += '<div>Expanded test description 2.</div></td>';
 
     respond(eventsJson(dummyEventInfo, dummyServerInfo));
     expect($('#table')).to.have.length(1);
@@ -398,7 +400,7 @@ describe('EventsView', function() {
       '</a></td>' +
       '<td class=""><a href="' + escapeHTML(serverURL) + '" target="_blank">Server</a></td>' +
       '<td class=""><a href="' + escapeHTML(hostURL) + '" target="_blank">Host</a></td>' +
-      '<td class="" title="Test description.">Test description.</td>';
+      '<td class="eventDescription " title="Test description."><div>Test description.</div></td>';
     var events = [
       $.extend({}, dummyEventInfo[0], {
 	  type: hatohol.EVENT_TYPE_GOOD,
@@ -415,7 +417,7 @@ describe('EventsView', function() {
     var view = new EventsView(getOperator(), testOptions);
     respond(eventsJson(dummyEventInfo, getDummyHAPI2ZabbixServerInfo()));
     expect($('tr').eq(0).text()).to.be(
-      "HandlingStatusSeverityPeriod Monitoring ServerHostBrief");
+      "HandlingStatusSeverityPeriod Monitoring ServerHostBriefShow Full Text");
     expect($('tr').eq(1).text()).to.be(
       " ProblemInformation" + getEventTimeString(dummyEventInfo[0]) +
       "ServerHostTest description.");
@@ -429,7 +431,7 @@ describe('EventsView', function() {
     respond(eventsJson(dummyEventInfo, getDummyHAPI2ZabbixServerInfo()),
 	    configJson);
     expect($('tr').eq(0).text()).to.be(
-      "DurationSeverityStatusBriefHostPeriod Monitoring Server");
+      "DurationSeverityStatusBriefShow Full TextHostPeriod Monitoring Server");
     expect($('tr').eq(1).text()).to.be(
       "02:46:40Information ProblemTest description.Host" +
       getEventTimeString(dummyEventInfo[0]) +

--- a/client/viewer/events_ajax.html
+++ b/client/viewer/events_ajax.html
@@ -177,15 +177,6 @@
       	  </form>
 	</div>
 
-	<div id="abbreviating-event-descriptions-container">
-	  <form class="form-inline hatohol-filter-toolbar">
-	    <div class="filter-element">
-	      <p><input class="form-control abbreviate-checkbox" type="checkbox" id="toggle-abbreviating-event-descriptions">
-              <label for="toggle-abbreviating-event-descriptions">{% trans "Abbreviate Event Descriptions" %}</label></p>
-	    </div>
-      	  </form>
-	</div>
-
 	    <div class="pull-right">
               <button type="button" class="btn btn-info latest-button">
                 <span class="glyphicon glyphicon-refresh"></span>


### PR DESCRIPTION
#1991 【イベント画面で概要を短縮した時、他の行が折り返されない範囲で、概要になるべく列幅を割り当てたい】
フロントエンド実装です。