### PR TITLE
[hap2_fluentd] Use more simple notation.

### DIFF
--- a/server/hap2/hatohol/hap2_fluentd.py
+++ b/server/hap2/hatohol/hap2_fluentd.py
@@ -37,8 +37,7 @@ class Hap2FluentdMain(haplib.BaseMainPlugin):
 
     # Ex.) 2016-03-03 12:11:17 +0900 hatohol.hoge
     __re_expected_msg = re.compile(
-      "^\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d " +
-      "\\+\\d\\d\\d\\d [^\\[]+:")
+      r"^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d \+\d\d\d\d [^\[]+:")
 
     def __init__(self, *args, **kwargs):
         haplib.BaseMainPlugin.__init__(self)


### PR DESCRIPTION
Using raw string makes the regular expression very short.