### PR TITLE
[server] Remove unused options "--{enable,disable}-copy-on-demand"

### DIFF
--- a/server/src/ArmBase.cc
+++ b/server/src/ArmBase.cc
@@ -127,7 +127,6 @@ struct ArmBase::Impl
 	timespec             lastPollingTime;
 	sem_t                sleepSemaphore;
 	AtomicValue<bool>    exitRequest;
-	bool                 isCopyOnDemandEnabled;
 	ReadWriteLock        rwlock;
 	ArmStatus            armStatus;
 	string               lastFailureComment;
@@ -142,7 +141,6 @@ struct ArmBase::Impl
 	  serverInfo(_serverInfo),
 	  utils(serverInfo, armTriggers, NUM_COLLECT_NG_KIND),
 	  exitRequest(false),
-	  isCopyOnDemandEnabled(false),
 	  lastFailureStatus(ARM_WORK_STAT_FAILURE)
 	{
 		static const int PSHARED = 1;
@@ -369,16 +367,6 @@ retry:
 			MLPL_ERR("sem_timedwait(): errno: %d\n", errno);
 	}
 	// The up of the semaphore is done only from the destructor.
-}
-
-bool ArmBase::getCopyOnDemandEnabled(void) const
-{
-	return m_impl->isCopyOnDemandEnabled;
-}
-
-void ArmBase::setCopyOnDemandEnabled(bool enable)
-{
-	m_impl->isCopyOnDemandEnabled = enable;
 }
 
 void ArmBase::registerAvailableTrigger(const ArmPollingResult &type,

--- a/server/src/ArmBase.h
+++ b/server/src/ArmBase.h
@@ -62,9 +62,6 @@ public:
 	int getPollingInterval(void) const;
 	int getRetryInterval(void) const;
 
-	bool getCopyOnDemandEnabled(void) const;
-	void setCopyOnDemandEnabled(bool enable);
-
 	const std::string &getName(void) const;
 
 	void setServerConnectStatus(const ArmPollingResult &type);

--- a/server/src/ConfigManager.cc
+++ b/server/src/ConfigManager.cc
@@ -118,8 +118,6 @@ CommandLineOptions::CommandLineOptions(void)
   dbPassword(NULL),
   foreground(FALSE),
   testMode(FALSE),
-  enableCopyOnDemand(FALSE),
-  disableCopyOnDemand(FALSE),
   loadOldEvents(FALSE),
   faceRestPort(-1),
   faceRestNumWorkers(0)
@@ -140,7 +138,6 @@ struct ConfigManager::Impl {
 	string                dbServerAddress;
 	int                   dbServerPort;
 	bool                  testMode;
-	ConfigState           copyOnDemand;
 	AtomicValue<int>      faceRestPort;
 	string                user;
 	string                pidFilePath;
@@ -153,7 +150,6 @@ struct ConfigManager::Impl {
 	  dbServerAddress("localhost"),
 	  dbServerPort(0),
 	  testMode(false),
-	  copyOnDemand(UNKNOWN),
 	  faceRestPort(0),
 	  pidFilePath(DEFAULT_PID_FILE_PATH),
 	  loadOldEvents(false),
@@ -232,10 +228,6 @@ struct ConfigManager::Impl {
 			foreground = true;
 		if (cmdLineOpts.testMode)
 			testMode = true;
-		if (cmdLineOpts.enableCopyOnDemand)
-			copyOnDemand = ENABLE;
-		if (cmdLineOpts.disableCopyOnDemand)
-			copyOnDemand = DISABLE;
 		if (cmdLineOpts.faceRestPort >= 0)
 			faceRestPort = cmdLineOpts.faceRestPort;
 		if (cmdLineOpts.pidFilePath)
@@ -332,14 +324,6 @@ bool ConfigManager::parseCommandLine(gint *argc, gchar ***argv,
 		{"db-password",
 		 'w', 0, G_OPTION_ARG_STRING,
 		 &cmdLineOpts->dbPassword, "Database password", NULL},
-		{"enable-copy-on-demand",
-		 'e', 0, G_OPTION_ARG_NONE,
-		 &cmdLineOpts->enableCopyOnDemand,
-		 "Current monitoring values are obtained on demand.", NULL},
-		{"disable-copy-on-demand",
-		 'd', 0, G_OPTION_ARG_NONE,
-		 &cmdLineOpts->disableCopyOnDemand,
-		 "Current monitoring values are obtained periodically.", NULL},
 		{"face-rest-port",
 		 'r', 0, G_OPTION_ARG_CALLBACK, (gpointer)parseFaceRestPort,
 		 "Port of FaceRest", NULL},
@@ -491,11 +475,6 @@ void ConfigManager::setResidentYardDirectory(const string &dir)
 bool ConfigManager::isTestMode(void) const
 {
 	return m_impl->testMode;
-}
-
-ConfigManager::ConfigState ConfigManager::getCopyOnDemand(void) const
-{
-	return m_impl->copyOnDemand;
 }
 
 int ConfigManager::getFaceRestPort(void) const

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -33,8 +33,6 @@ struct CommandLineOptions {
 	gchar    *dbPassword;
 	gboolean  foreground;
 	gboolean  testMode;
-	gboolean  enableCopyOnDemand;
-	gboolean  disableCopyOnDemand;
 	gboolean  loadOldEvents;
 	gint      faceRestPort;
 	gint      faceRestNumWorkers;
@@ -101,16 +99,6 @@ public:
 	void setResidentYardDirectory(const std::string &dir);
 
 	bool isTestMode(void) const;
-
-	/**
-	 * Get the flag for copy-on-demand of items.
-	 *
-	 * @retrun
-	 * If --enable-copy-on-deman is specified, ENABLE is returned.
-	 * If --disable-copy-on-deman is specified, DISABLE is returned.
-	 * Otherwise, UNKNOWN is returned.
-	 */
-	ConfigState getCopyOnDemand(void) const;
 
 	/**
 	 * Get the port for FaceRest.

--- a/server/src/DBTablesConfig.cc
+++ b/server/src/DBTablesConfig.cc
@@ -87,6 +87,7 @@ static const ColumnDef COLUMN_DEF_SYSTEM[] = {
 	0,                                 // flags
 	"0",                               // defaultValue
 }, {
+	// obsolete
 	"enable_copy_on_demand",           // columnName
 	SQL_COLUMN_TYPE_INT,               // type
 	11,                                // columnLength
@@ -102,7 +103,7 @@ enum {
 	IDX_SYSTEM_DATABASE_DIR,
 	IDX_SYSTEM_ENABLE_FACE_MYSQL,
 	IDX_SYSTEM_FACE_REST_PORT,
-	IDX_SYSTEM_ENABLE_COPY_ON_DEMAND,
+	IDX_SYSTEM_ENABLE_COPY_ON_DEMAND, // obsolete
 	NUM_IDX_SYSTEM,
 };
 
@@ -1032,18 +1033,6 @@ void DBTablesConfig::setFaceRestPort(int port)
 	DBAgent::UpdateArg arg(tableProfileSystem);
 	arg.add(IDX_SYSTEM_FACE_REST_PORT, port);
 	getDBAgent().runTransaction(arg);
-}
-
-bool DBTablesConfig::isCopyOnDemandEnabled(void)
-{
-	DBAgent::SelectArg arg(tableProfileSystem);
-	arg.columnIndexes.push_back(IDX_SYSTEM_ENABLE_COPY_ON_DEMAND);
-	getDBAgent().runTransaction(arg);
-
-	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
-	HATOHOL_ASSERT(!grpList.empty(), "Obtained Table: empty");
-	ItemGroupStream itemGroupStream(*grpList.begin());
-	return itemGroupStream.read<int>();
 }
 
 void DBTablesConfig::registerServerType(const ServerTypeInfo &serverType)

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -183,7 +183,6 @@ public:
 	void setDatabaseDir(const std::string &dir);
 	int  getFaceRestPort(void);
 	void setFaceRestPort(int port);
-	bool isCopyOnDemandEnabled(void);
 
 	/**
 	 * Register the server type.

--- a/server/src/DataStore.cc
+++ b/server/src/DataStore.cc
@@ -26,10 +26,6 @@ DataStore::DataStore(void)
 {
 }
 
-void DataStore::setCopyOnDemandEnable(bool enable)
-{
-}
-
 bool DataStore::startOnDemandFetchItems(
   const LocalHostIdVector &hostIds, Closure0 *closure)
 {

--- a/server/src/DataStore.h
+++ b/server/src/DataStore.h
@@ -37,7 +37,6 @@ public:
 	virtual const MonitoringServerInfo
 	  &getMonitoringServerInfo(void) const = 0;
 	virtual const ArmStatus &getArmStatus(void) const = 0;
-	virtual void setCopyOnDemandEnable(bool enable);
 	virtual bool isFetchItemsSupported(void);
 	virtual bool startOnDemandFetchItems(
 	  const LocalHostIdVector &hostIds,

--- a/server/src/DataStoreFake.cc
+++ b/server/src/DataStoreFake.cc
@@ -57,11 +57,6 @@ const ArmStatus &DataStoreFake::getArmStatus(void) const
 	return m_impl->armFake.getArmStatus();
 }
 
-void DataStoreFake::setCopyOnDemandEnable(bool enable)
-{
-	m_impl->armFake.setCopyOnDemandEnabled(enable);
-}
-
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------

--- a/server/src/DataStoreFake.h
+++ b/server/src/DataStoreFake.h
@@ -32,7 +32,6 @@ public:
 	virtual const MonitoringServerInfo
 	  &getMonitoringServerInfo(void) const override;
 	virtual const ArmStatus &getArmStatus(void) const override;
-	virtual void setCopyOnDemandEnable(bool enable) override;
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -56,8 +56,6 @@ public:
 	void start(const bool &autoRun = true);
 
 	void stop(void);
-	bool getCopyOnDemandEnabled(void) const;
-	void setCopyOnDemandEnabled(bool enable);
 
 	/**
 	 * Add events in the Hatohol DB and executes action if needed.

--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -251,15 +251,6 @@ int mainRoutine(int argc, char *argv[])
 	rest.start();
 
 	ctx.unifiedDataStore = UnifiedDataStore::getInstance();
-	bool enableCopyOnDemand = true;
-	ConfigManager::ConfigState state = confMgr->getCopyOnDemand();
-	if (state == ConfigManager::ENABLE)
-		enableCopyOnDemand = true;
-	else if (state == ConfigManager::DISABLE)
-		enableCopyOnDemand = false;
-	else
-		enableCopyOnDemand = cache.getConfig().isCopyOnDemandEnabled();
-	ctx.unifiedDataStore->setCopyOnDemandEnabled(enableCopyOnDemand);
 	ctx.unifiedDataStore->start();
 
 	// main loop of GLIB

--- a/server/test/testConfigManager.cc
+++ b/server/test/testConfigManager.cc
@@ -121,33 +121,6 @@ void test_parseTestModeEnabled(void)
 	cppcut_assert_equal(true, ConfigManager::getInstance()->isTestMode());
 }
 
-void test_parseCopyOnDemandDefault(void)
-{
-	cppcut_assert_equal(
-	  ConfigManager::UNKNOWN,
-	  ConfigManager::getInstance()->getCopyOnDemand());
-}
-
-void test_parseEnableCopyOnDemand(void)
-{
-	CommandArgHelper cmds;
-	cmds << "--enable-copy-on-demand";
-	cmds.activate();
-	cppcut_assert_equal(
-	  ConfigManager::ENABLE,
-	  ConfigManager::getInstance()->getCopyOnDemand());
-}
-
-void test_parseDisableCopyOnDemand(void)
-{
-	CommandArgHelper cmds;
-	cmds << "--disable-copy-on-demand";
-	cmds.activate();
-	cppcut_assert_equal(
-	  ConfigManager::DISABLE,
-	  ConfigManager::getInstance()->getCopyOnDemand());
-}
-
 void test_parseFaceRestPortDefault(void)
 {
 	cppcut_assert_equal(

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -900,12 +900,6 @@ void test_setGetFaceRestPort(void)
 	cppcut_assert_equal(portNumber, dbConfig.getFaceRestPort());
 }
 
-void test_isCopyOnDemandEnabledDefault(void)
-{
-	DECLARE_DBTABLES_CONFIG(dbConfig);
-	cut_assert_true(dbConfig.isCopyOnDemandEnabled());
-}
-
 void test_serverQueryOptionForAdmin(void)
 {
 	ServerQueryOption option(USER_ID_SYSTEM);

--- a/server/test/testFaceRestIncident.cc
+++ b/server/test/testFaceRestIncident.cc
@@ -44,7 +44,6 @@ void cut_teardown(void)
 	stopFaceRest();
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	dataStore->setCopyOnDemandEnabled(false);
 }
 
 static void incidentInfo2StringMap(

--- a/server/test/testFaceRestMonitoring.cc
+++ b/server/test/testFaceRestMonitoring.cc
@@ -533,9 +533,6 @@ void cut_setup(void)
 void cut_teardown(void)
 {
 	stopFaceRest();
-
-	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	dataStore->setCopyOnDemandEnabled(false);
 }
 
 void test_hosts(void)
@@ -647,8 +644,6 @@ void test_items(void)
 
 void test_itemsAsyncWithNoArm(void)
 {
-	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	dataStore->setCopyOnDemandEnabled(true);
 	assertItems("/item");
 }
 
@@ -658,7 +653,6 @@ void test_itemsAsyncWithNonExistentServers(void)
 		 "timeout values of ArmZabbixAPI.\n");
 
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	dataStore->setCopyOnDemandEnabled(true);
 	dataStore->start();
 	assertItems("/item");
 	dataStore->stop();


### PR DESCRIPTION
It's not used in the current code.

This commit doesn't remove enable_copy_on_demand column in the DB
to avoid troublesome migration.

Fix #2142