### PR TITLE
[RestMonitoring][DBTablesHost] Receive hostgroup name query in REST trigger API

### DIFF
--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -521,7 +521,8 @@ std::string HostgroupsQueryOption::getHostgroupColumnName(const size_t &idx) con
 				   IDX_HOSTGROUP_LIST_ID_IN_SERVER);
 }
 
-bool HostgroupsQueryOption::isHostgroupUsed(void) const {
+bool HostgroupsQueryOption::isHostgroupUsed(void) const
+{
 	return false;
 }
 

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -940,9 +940,8 @@ HatoholError DBTablesHost::getHostgroups(HostgroupVect &hostgroups,
 	return HTERR_OK;
 }
 
-HatoholError DBTablesHost::getServerHostGrpSetMapWithHostgroupName(
+HatoholError DBTablesHost::getServerHostGrpSetMap(
   ServerHostGrpSetMap &serverHostGrpSetMap,
-  const string &hostgroupName,
   const HostgroupsQueryOption &option)
 {
 	DBTermCStringProvider rhs(*getDBAgent().getDBTermCodec());
@@ -950,12 +949,7 @@ HatoholError DBTablesHost::getServerHostGrpSetMapWithHostgroupName(
 	arg.tableField = TABLE_NAME_HOSTGROUP_LIST;
 	arg.add(IDX_HOSTGROUP_LIST_SERVER_ID);
 	arg.add(IDX_HOSTGROUP_LIST_ID_IN_SERVER);
-	if (!hostgroupName.empty()) {
-		arg.condition = StringUtils::sprintf(
-		  "%s=%s",
-		  COLUMN_DEF_HOSTGROUP_LIST[IDX_HOSTGROUP_LIST_NAME].columnName,
-		  rhs(hostgroupName));
-	}
+	arg.condition = option.getCondition();
 	getDBAgent().runTransaction(arg);
 
 	// get the result

--- a/server/src/DBTablesHost.cc
+++ b/server/src/DBTablesHost.cc
@@ -463,20 +463,66 @@ static const HostResourceQueryOption::Synapse synapseHostgroupsQueryOption(
   IDX_HOSTGROUP_MEMBER_SERVER_ID, IDX_HOSTGROUP_MEMBER_HOST_ID_IN_SERVER,
   IDX_HOSTGROUP_MEMBER_GROUP_ID);
 
+struct HostgroupsQueryOption::Impl {
+	string hostgroupName;
+
+	Impl()
+	{
+	}
+
+	virtual ~Impl()
+	{
+	}
+};
+
 HostgroupsQueryOption::HostgroupsQueryOption(const UserIdType &userId)
-: HostResourceQueryOption(synapseHostgroupsQueryOption, userId)
+: HostResourceQueryOption(synapseHostgroupsQueryOption, userId),
+  m_impl(new Impl())
 {
 }
 
 HostgroupsQueryOption::HostgroupsQueryOption(DataQueryContext *dataQueryContext)
-: HostResourceQueryOption(synapseHostgroupsQueryOption, dataQueryContext)
+: HostResourceQueryOption(synapseHostgroupsQueryOption, dataQueryContext),
+  m_impl(new Impl())
 {
+}
+
+HostgroupsQueryOption::~HostgroupsQueryOption(void)
+{
+}
+
+void HostgroupsQueryOption::setTargetHostgroupName(const string &hostgroupName)
+{
+	m_impl->hostgroupName = hostgroupName;
+}
+
+string HostgroupsQueryOption::getTargetHostgroupName(void) const
+{
+	return m_impl->hostgroupName;
+}
+
+string HostgroupsQueryOption::getCondition(void) const
+{
+	string condition = HostResourceQueryOption::getCondition();
+	if (!m_impl->hostgroupName.empty()) {
+		DBTermCStringProvider rhs(*getDBTermCodec());
+		addCondition(condition,
+		  StringUtils::sprintf("%s=%s",
+		    COLUMN_DEF_HOSTGROUP_LIST[IDX_HOSTGROUP_LIST_NAME].columnName,
+		    rhs(m_impl->hostgroupName)));
+	}
+
+	return condition;
 }
 
 std::string HostgroupsQueryOption::getHostgroupColumnName(const size_t &idx) const
 {
 	return getColumnNameCommon(tableProfileHostgroupList,
 				   IDX_HOSTGROUP_LIST_ID_IN_SERVER);
+}
+
+bool HostgroupsQueryOption::isHostgroupUsed(void) const {
+	return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -168,8 +168,18 @@ class HostgroupsQueryOption : public HostResourceQueryOption {
 public:
 	HostgroupsQueryOption(const UserIdType &userId = INVALID_USER_ID);
 	HostgroupsQueryOption(DataQueryContext *dataQueryContext);
+	virtual ~HostgroupsQueryOption();
 
+	bool isHostgroupUsed(void) const override;
+
+	virtual std::string getCondition(void) const override;
+	void setTargetHostgroupName(const std::string &hostgroupName);
+	std::string getTargetHostgroupName(void) const;
 	std::string getHostgroupColumnName(const size_t &idx) const override;
+
+private:
+	struct Impl;
+	std::unique_ptr<Impl> m_impl;
 };
 
 class HostgroupMembersQueryOption: public HostResourceQueryOption {

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -305,6 +305,10 @@ public:
 	 */
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
+	HatoholError getServerHostGrpSetMapWithHostgroupName(
+	  ServerHostGrpSetMap &serverHostGrpSetMap,
+	  const std::string &hostgroupName,
+	  const HostgroupsQueryOption &option);
 	HatoholError deleteHostgroupList(const GenericIdList &idList);
 
 	/**

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -315,9 +315,8 @@ public:
 	 */
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
-	HatoholError getServerHostGrpSetMapWithHostgroupName(
+	HatoholError getServerHostGrpSetMap(
 	  ServerHostGrpSetMap &serverHostGrpSetMap,
-	  const std::string &hostgroupName,
 	  const HostgroupsQueryOption &option);
 	HatoholError deleteHostgroupList(const GenericIdList &idList);
 

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -377,17 +377,9 @@ void RestResourceMonitoring::handlerGetHost(void)
 	replyJSONData(agent);
 }
 
-void RestResourceMonitoring::handlerGetTrigger(void)
+void RestResourceMonitoring::parseHostgroupNameParameter(
+  TriggersQueryOption &option, GHashTable *query)
 {
-	TriggersQueryOption option(m_dataQueryContextPtr);
-	HatoholError err = parseTriggerParameter(option, m_query);
-	if (err != HTERR_OK) {
-		replyError(err);
-		return;
-	}
-
-	option.setExcludeFlags(EXCLUDE_INVALID_HOST);
-	TriggerInfoList triggerList;
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 	// Add constraints with hostgroup name
 	const char *targetHostgroupName =
@@ -401,6 +393,21 @@ void RestResourceMonitoring::handlerGetTrigger(void)
 						  hostgroupOption);
 		option.setSelectedHostgroupIds(serverHostGrpSetMap);
 	}
+}
+
+void RestResourceMonitoring::handlerGetTrigger(void)
+{
+	TriggersQueryOption option(m_dataQueryContextPtr);
+	HatoholError err = parseTriggerParameter(option, m_query);
+	if (err != HTERR_OK) {
+		replyError(err);
+		return;
+	}
+
+	option.setExcludeFlags(EXCLUDE_INVALID_HOST);
+	TriggerInfoList triggerList;
+	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+	parseHostgroupNameParameter(option, m_query);
 	dataStore->getTriggerList(triggerList, option);
 
 	JSONBuilder agent;

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -389,6 +389,18 @@ void RestResourceMonitoring::handlerGetTrigger(void)
 	option.setExcludeFlags(EXCLUDE_INVALID_HOST);
 	TriggerInfoList triggerList;
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+	// Add constraints with hostgroup name
+	const char *targetHostgroupName =
+	  static_cast<const char*>(g_hash_table_lookup(m_query, "hostgroupName"));
+	if (targetHostgroupName && *targetHostgroupName) {
+		string hostgroupName = targetHostgroupName;
+		ServerHostGrpSetMap serverHostGrpSetMap;
+		HostgroupsQueryOption hostgroupOption(m_dataQueryContextPtr);
+		dataStore->getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
+								   hostgroupName,
+								   hostgroupOption);
+		option.setSelectedHostgroupIds(serverHostGrpSetMap);
+	}
 	dataStore->getTriggerList(triggerList, option);
 
 	JSONBuilder agent;

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -396,9 +396,9 @@ void RestResourceMonitoring::handlerGetTrigger(void)
 		string hostgroupName = targetHostgroupName;
 		ServerHostGrpSetMap serverHostGrpSetMap;
 		HostgroupsQueryOption hostgroupOption(m_dataQueryContextPtr);
-		dataStore->getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
-								   hostgroupName,
-								   hostgroupOption);
+		hostgroupOption.setTargetHostgroupName(hostgroupName);
+		dataStore->getServerHostGrpSetMap(serverHostGrpSetMap,
+						  hostgroupOption);
 		option.setSelectedHostgroupIds(serverHostGrpSetMap);
 	}
 	dataStore->getTriggerList(triggerList, option);

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -377,24 +377,6 @@ void RestResourceMonitoring::handlerGetHost(void)
 	replyJSONData(agent);
 }
 
-void RestResourceMonitoring::parseHostgroupNameParameter(
-  TriggersQueryOption &option, GHashTable *query)
-{
-	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	// Add constraints with hostgroup name
-	const char *targetHostgroupName =
-	  static_cast<const char*>(g_hash_table_lookup(m_query, "hostgroupName"));
-	if (targetHostgroupName && *targetHostgroupName) {
-		string hostgroupName = targetHostgroupName;
-		ServerHostGrpSetMap serverHostGrpSetMap;
-		HostgroupsQueryOption hostgroupOption(m_dataQueryContextPtr);
-		hostgroupOption.setTargetHostgroupName(hostgroupName);
-		dataStore->getServerHostGrpSetMap(serverHostGrpSetMap,
-						  hostgroupOption);
-		option.setSelectedHostgroupIds(serverHostGrpSetMap);
-	}
-}
-
 void RestResourceMonitoring::handlerGetTrigger(void)
 {
 	TriggersQueryOption option(m_dataQueryContextPtr);
@@ -407,7 +389,8 @@ void RestResourceMonitoring::handlerGetTrigger(void)
 	option.setExcludeFlags(EXCLUDE_INVALID_HOST);
 	TriggerInfoList triggerList;
 	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
-	parseHostgroupNameParameter(option, m_query);
+	RestResourceUtils::parseHostgroupNameParameter(option, m_query,
+						       m_dataQueryContextPtr);
 	dataStore->getTriggerList(triggerList, option);
 
 	JSONBuilder agent;

--- a/server/src/RestResourceMonitoring.h
+++ b/server/src/RestResourceMonitoring.h
@@ -56,7 +56,6 @@ struct RestResourceMonitoring : public RestResourceMemberHandler
 	static const char *pathForItem;
 	static const char *pathForHistory;
 	static const char *pathForHostgroup;
-
 };
 
 #endif // RestResourceMonitoring_h

--- a/server/src/RestResourceMonitoring.h
+++ b/server/src/RestResourceMonitoring.h
@@ -56,6 +56,10 @@ struct RestResourceMonitoring : public RestResourceMemberHandler
 	static const char *pathForItem;
 	static const char *pathForHistory;
 	static const char *pathForHostgroup;
+
+protected:
+	void parseHostgroupNameParameter(
+	  TriggersQueryOption &option, GHashTable *query);
 };
 
 #endif // RestResourceMonitoring_h

--- a/server/src/RestResourceMonitoring.h
+++ b/server/src/RestResourceMonitoring.h
@@ -57,9 +57,6 @@ struct RestResourceMonitoring : public RestResourceMemberHandler
 	static const char *pathForHistory;
 	static const char *pathForHostgroup;
 
-protected:
-	void parseHostgroupNameParameter(
-	  TriggersQueryOption &option, GHashTable *query);
 };
 
 #endif // RestResourceMonitoring_h

--- a/server/src/RestResourceUtils.cc
+++ b/server/src/RestResourceUtils.cc
@@ -444,3 +444,23 @@ HatoholError RestResourceUtils::parseEventParameter(
 
 	return HatoholError(HTERR_OK);
 }
+
+HatoholError RestResourceUtils::parseHostgroupNameParameter(
+  HostResourceQueryOption &option, GHashTable *query, DataQueryContextPtr &dataQueryContextPtr)
+{
+	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
+	// Add constraints with hostgroup name
+	const char *targetHostgroupName =
+	  static_cast<const char*>(g_hash_table_lookup(query, "hostgroupName"));
+	if (targetHostgroupName && *targetHostgroupName) {
+		string hostgroupName = targetHostgroupName;
+		ServerHostGrpSetMap serverHostGrpSetMap;
+		HostgroupsQueryOption hostgroupOption(dataQueryContextPtr);
+		hostgroupOption.setTargetHostgroupName(hostgroupName);
+		dataStore->getServerHostGrpSetMap(serverHostGrpSetMap,
+						  hostgroupOption);
+		option.setSelectedHostgroupIds(serverHostGrpSetMap);
+	}
+
+	return HatoholError(HTERR_OK);
+}

--- a/server/src/RestResourceUtils.h
+++ b/server/src/RestResourceUtils.h
@@ -33,6 +33,9 @@ public:
 	static HatoholError parseEventParameter(
 	  EventsQueryOption &option, GHashTable *query,
 	  bool &isCountOnly);
+	static HatoholError parseHostgroupNameParameter(
+	  HostResourceQueryOption &option, GHashTable *query,
+	  DataQueryContextPtr &dataQueryContextPtr);
 };
 
 #endif // RestResourceUtils_h

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -529,14 +529,12 @@ HatoholError UnifiedDataStore::getHostgroups(
 	return cache.getHost().getHostgroups(hostgroups, option);
 }
 
-HatoholError UnifiedDataStore::getServerHostGrpSetMapWithHostgroupName(
-  ServerHostGrpSetMap &serverHostGrpSetMap, const string &hostgroupName,
+HatoholError UnifiedDataStore::getServerHostGrpSetMap(
+  ServerHostGrpSetMap &serverHostGrpSetMap,
   const HostgroupsQueryOption &option)
 {
 	ThreadLocalDBCache cache;
-	return cache.getHost()
-		.getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
-		                                         hostgroupName, option);
+	return cache.getHost().getServerHostGrpSetMap(serverHostGrpSetMap, option);
 }
 
 HatoholError UnifiedDataStore::upsertHosts(

--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -529,6 +529,16 @@ HatoholError UnifiedDataStore::getHostgroups(
 	return cache.getHost().getHostgroups(hostgroups, option);
 }
 
+HatoholError UnifiedDataStore::getServerHostGrpSetMapWithHostgroupName(
+  ServerHostGrpSetMap &serverHostGrpSetMap, const string &hostgroupName,
+  const HostgroupsQueryOption &option)
+{
+	ThreadLocalDBCache cache;
+	return cache.getHost()
+		.getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
+		                                         hostgroupName, option);
+}
+
 HatoholError UnifiedDataStore::upsertHosts(
   const ServerHostDefVect &serverHostDefs, HostHostIdMap *hostHostIdMapPtr,
   DBAgent::TransactionHooks *hooks)

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -123,6 +123,9 @@ public:
 
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
+	HatoholError getServerHostGrpSetMapWithHostgroupName(
+	  ServerHostGrpSetMap &serverHostGrpSetMap, const std::string &hostgroupName,
+	  const HostgroupsQueryOption &option);
 
 	/**
 	 * Add hosts. If there's hosts already exist, they will be updated.

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -123,8 +123,8 @@ public:
 
 	HatoholError getHostgroups(HostgroupVect &hostgroups,
 	                           const HostgroupsQueryOption &option);
-	HatoholError getServerHostGrpSetMapWithHostgroupName(
-	  ServerHostGrpSetMap &serverHostGrpSetMap, const std::string &hostgroupName,
+	HatoholError getServerHostGrpSetMap(
+	  ServerHostGrpSetMap &serverHostGrpSetMap,
 	  const HostgroupsQueryOption &option);
 
 	/**

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -436,6 +436,32 @@ void test_getHostgroups(void)
 	assertDBContent(&dbAgent, statement, expect);
 }
 
+void test_getServerHostGrpSetMapWithHostgroupName(void)
+{
+	loadTestDBServer();
+	loadTestDBHostgroup();
+
+	DECLARE_DBTABLES_HOST(dbHost);
+	HostgroupsQueryOption option(USER_ID_SYSTEM);
+	ServerHostGrpSetMap serverHostGrpSetMap;
+	const string targetHostgroupName = "Monitor Servers";
+	dbHost.getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
+	                                               targetHostgroupName,
+	                                               option);
+	ServerIdType expectedServerId = 1;
+	HostgroupIdType expectedHostgroupId = "1";
+	ServerHostGrpSetMapConstIterator it =
+	  serverHostGrpSetMap.find(expectedServerId);
+	cppcut_assert_equal(true, it != serverHostGrpSetMap.end(),
+			    cut_message("Failed to lookup: %" PRIu32,
+					expectedServerId));
+	const HostgroupIdSet &hostgroupIdSet = it->second;
+	HostgroupIdSetConstIterator jt = hostgroupIdSet.find(expectedHostgroupId);
+	cppcut_assert_equal(true, jt != hostgroupIdSet.end(),
+			    cut_message("Failed to lookup: %" FMT_HOST_GROUP_ID,
+					expectedHostgroupId.c_str()));
+}
+
 void test_deleteHostgroupList(void)
 {
 	DECLARE_DBTABLES_HOST(dbHost);

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -436,7 +436,7 @@ void test_getHostgroups(void)
 	assertDBContent(&dbAgent, statement, expect);
 }
 
-void test_getServerHostGrpSetMapWithHostgroupName(void)
+void test_getServerHostGrpSetMap(void)
 {
 	loadTestDBServer();
 	loadTestDBHostgroup();
@@ -445,9 +445,8 @@ void test_getServerHostGrpSetMapWithHostgroupName(void)
 	HostgroupsQueryOption option(USER_ID_SYSTEM);
 	ServerHostGrpSetMap serverHostGrpSetMap;
 	const string targetHostgroupName = "Monitor Servers";
-	dbHost.getServerHostGrpSetMapWithHostgroupName(serverHostGrpSetMap,
-	                                               targetHostgroupName,
-	                                               option);
+	option.setTargetHostgroupName(targetHostgroupName);
+	dbHost.getServerHostGrpSetMap(serverHostGrpSetMap, option);
 	ServerIdType expectedServerId = 1;
 	HostgroupIdType expectedHostgroupId = "1";
 	ServerHostGrpSetMapConstIterator it =

--- a/server/test/testFaceRestMonitoring.cc
+++ b/server/test/testFaceRestMonitoring.cc
@@ -162,7 +162,7 @@ static void _assertTriggers(
   const timespec &beginTime = {0, 0},
   const timespec &endTime = {0, 0},
   const size_t expectedNumTrigger = -1,
-  const string &hostname = "")
+  const StringMap query = StringMap())
 {
 	loadTestDBTriggers();
 	loadTestDBServerHostDef();
@@ -208,8 +208,12 @@ static void _assertTriggers(
 	if (endTime.tv_sec != 0 || endTime.tv_nsec != 0) {
 		queryMap["endTime"] = StringUtils::sprintf("%ld", endTime.tv_sec);
 	}
-	if (!hostname.empty())
-		queryMap["hostname"] = hostname;
+	StringMapConstIterator hostnameIt = query.find("hostname");
+	if (hostnameIt != query.end())
+		queryMap["hostname"] = hostnameIt->second;
+	StringMapConstIterator hostgrpNameIt = query.find("hostgroupName");
+	if (hostgrpNameIt != query.end())
+		queryMap["hostgroupName"] = hostgrpNameIt->second;
 	arg.parameters = queryMap;
 	JSONParser *parser = getResponseAsJSONParser(arg);
 	unique_ptr<JSONParser> parserPtr(parser);
@@ -582,8 +586,10 @@ void test_triggersWithTimeRangeAndHostname(void)
 {
 	timespec beginTime = {1362957197,0}, endTime = {1362957200,0};
 	size_t numExpectedTriggers = 3;
+	StringMap query;
+	query["hostname"] = "hostX1";
 	assertTriggers("/trigger", "foo", ALL_SERVERS, ALL_LOCAL_HOSTS,
-		       beginTime, endTime, numExpectedTriggers, "hostX1");
+		       beginTime, endTime, numExpectedTriggers, query);
 }
 
 void test_events(void)

--- a/server/test/testFaceRestMonitoring.cc
+++ b/server/test/testFaceRestMonitoring.cc
@@ -592,6 +592,18 @@ void test_triggersWithTimeRangeAndHostname(void)
 		       beginTime, endTime, numExpectedTriggers, query);
 }
 
+void test_triggersWithTimeRangeAndHostgroupName(void)
+{
+	loadTestDBHostgroup();
+	loadTestDBHostgroupMember();
+	timespec beginTime = {0,0}, endTime = {0,0};
+	size_t numExpectedTriggers = 4;
+	StringMap query;
+	query["hostgroupName"] = "Monitored Servers";
+	assertTriggers("/trigger", "foo", ALL_SERVERS, ALL_LOCAL_HOSTS,
+		       beginTime, endTime, numExpectedTriggers, query);
+}
+
 void test_events(void)
 {
 	assertEvents("/event");


### PR DESCRIPTION
* DBTablesHost
  * implement getServerHostGrpSetMap to get ServerHostGrpSetMap with specified option condition
* RestResourceMonitoring
  * retrieve `hostgroupName` option and use it for beyond monitoring server filter
* testFaceRestMonitoring
  * partially refactored with StringMap to reduce assertion static method arguments 
      - Let's prevent more and more adding arguments into `_assertTriggers`