### PR TITLE
[HatoholAddActionDialog] Fix trigger status bug in incident setting d…

### DIFF
--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -890,12 +890,6 @@ HatoholAddActionDialog.prototype.onAppendMainElement = function() {
     else
       self.setApplyButtonState(false);
   }
-
-  if (self.forIncidentSetting) {
-    self.setupIncidentTrackersEditor();
-    $("#selectTriggerStatus").val("TRIGGER_STATUS_PROBLEM");
-    $("#selectTriggerSeverityCompType").val("CMP_EQ_GT");
-  }
 };
 
 HatoholAddActionDialog.prototype.setApplyButtonState = function(state) {


### PR DESCRIPTION
…ialog

In the previous code the trigger status is always set to "ANY"
when a user edit an existing incident setting.
This commit fixes the issue by discarding the special treatment
for the incident setting.

Fix #2007