### PR TITLE
[DBTablesMonitoring] Implement retriving trigger briefs

### DIFF
--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2188,6 +2188,32 @@ void DBTablesMonitoring::setTriggerInfoList(
 	getDBAgent().runTransaction(trx);
 }
 
+HatoholError DBTablesMonitoring::getTriggerBriefList(
+  list<string> &triggerBriefList, const TriggersQueryOption &option)
+{
+	DBTermCStringProvider rhs(*getDBAgent().getDBTermCodec());
+	DBAgent::SelectExArg arg(tableProfileTriggers);
+	arg.add(IDX_TRIGGERS_BRIEF);
+
+	arg.condition = option.getCondition();
+	if (DBHatohol::isAlwaysFalseCondition(arg.condition))
+		return HatoholError(HTERR_OK);
+
+	getDBAgent().runTransaction(arg);
+
+	// check the result and copy
+	const ItemGroupList &grpList = arg.dataTable->getItemGroupList();
+	for (auto itemGrp : grpList) {
+		ItemGroupStream itemGroupStream(itemGrp);
+		string brief;
+
+		itemGroupStream >> brief;
+		triggerBriefList.push_back(brief);
+	}
+
+	return HatoholError(HTERR_OK);
+}
+
 int DBTablesMonitoring::getLastChangeTimeOfTrigger(const ServerIdType &serverId)
 {
 	DBTermCStringProvider rhs(*getDBAgent().getDBTermCodec());

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2196,7 +2196,10 @@ HatoholError DBTablesMonitoring::getTriggerBriefList(
 	arg.add(IDX_TRIGGERS_BRIEF);
 
 	arg.useDistinct = true;
+
 	arg.condition = option.getCondition();
+	// Order By
+	arg.orderBy = option.getOrderBy();
 	if (DBHatohol::isAlwaysFalseCondition(arg.condition))
 		return HatoholError(HTERR_OK);
 

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -2195,6 +2195,7 @@ HatoholError DBTablesMonitoring::getTriggerBriefList(
 	DBAgent::SelectExArg arg(tableProfileTriggers);
 	arg.add(IDX_TRIGGERS_BRIEF);
 
+	arg.useDistinct = true;
 	arg.condition = option.getCondition();
 	if (DBHatohol::isAlwaysFalseCondition(arg.condition))
 		return HatoholError(HTERR_OK);

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -251,6 +251,8 @@ public:
 				const TriggersQueryOption &option);
 	void setTriggerInfoList(const TriggerInfoList &triggerInfoList,
 	                        const ServerIdType &serverId);
+	HatoholError getTriggerBriefList(std::list<std::string> &triggerBriefList,
+	                                 const TriggersQueryOption &option);
 	/**
 	 * get the last change time of the trigger that belongs to
 	 * the specified server

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -791,7 +791,7 @@ void test_getTriggerWithInvalidUserId(gconstpointer data)
 	assertGetTriggersWithFilter(arg);
 }
 
-void test_getTriggerBriefListWithoutOption(void)
+void test_getTriggerBriefListOnlyWithOrderOption(void)
 {
 	loadTestDBTriggers();
 	loadTestDBServerHostDef();
@@ -800,12 +800,26 @@ void test_getTriggerBriefListWithoutOption(void)
 	list<string> triggerBriefList;
 	DECLARE_DBTABLES_MONITORING(dbMonitoring);
 	TriggersQueryOption option(USER_ID_SYSTEM);
+	option.setSortType(TriggersQueryOption::SORT_TIME,
+	                   DataQueryOption::SORT_ASCENDING);
 	dbMonitoring.getTriggerBriefList(triggerBriefList, option);
 	cppcut_assert_equal((size_t)10, triggerBriefList.size());
+	vector<string> expectedBriefs = {
+		"TEST Trigger Action",
+		"TEST Trigger 3",
+		"Status:Unknown, Severity:Critical",
+		"TEST Trigger Action 2",
+		"TEST Trigger 1b",
+		"TEST Trigger 1",
+		"TEST Trigger 1c",
+		"TEST Trigger 1a",
+		"TEST Trigger 1d",
+		"TEST Trigger 2",
+	};
 	{
 		size_t i = 0;
 		for (auto triggerBrief : triggerBriefList) {
-			cppcut_assert_equal(testTriggerInfo[i].brief, triggerBrief);
+			cppcut_assert_equal(expectedBriefs.at(i), triggerBrief);
 			i++;
 		}
 	}

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -791,6 +791,24 @@ void test_getTriggerWithInvalidUserId(gconstpointer data)
 	assertGetTriggersWithFilter(arg);
 }
 
+void test_getTriggerBriefListWithOption(void)
+{
+	loadTestDBTriggers();
+	loadTestDBServerHostDef();
+	loadTestDBHostgroupMember();
+
+	int targetIdx = 2;
+	const TriggerInfo &targetTriggerInfo = testTriggerInfo[targetIdx];
+	list<string> triggerBriefList;
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	TriggersQueryOption option(USER_ID_SYSTEM);
+	option.setTargetServerId(targetTriggerInfo.serverId);
+	option.setTargetId(targetTriggerInfo.id);
+	dbMonitoring.getTriggerBriefList(triggerBriefList, option);
+	cppcut_assert_equal((size_t)1, triggerBriefList.size());
+	cppcut_assert_equal(targetTriggerInfo.brief, *triggerBriefList.begin());
+}
+
 void data_itemInfoList(void)
 {
 	prepareTestDataExcludeDefunctServers();

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -791,6 +791,26 @@ void test_getTriggerWithInvalidUserId(gconstpointer data)
 	assertGetTriggersWithFilter(arg);
 }
 
+void test_getTriggerBriefListWithoutOption(void)
+{
+	loadTestDBTriggers();
+	loadTestDBServerHostDef();
+	loadTestDBHostgroupMember();
+
+	list<string> triggerBriefList;
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	TriggersQueryOption option(USER_ID_SYSTEM);
+	dbMonitoring.getTriggerBriefList(triggerBriefList, option);
+	cppcut_assert_equal((size_t)10, triggerBriefList.size());
+	{
+		size_t i = 0;
+		for (auto triggerBrief : triggerBriefList) {
+			cppcut_assert_equal(testTriggerInfo[i].brief, triggerBrief);
+			i++;
+		}
+	}
+}
+
 void test_getTriggerBriefListWithOption(void)
 {
 	loadTestDBTriggers();

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -824,6 +824,7 @@ void test_getTriggerBriefListWithOption(void)
 	TriggersQueryOption option(USER_ID_SYSTEM);
 	option.setTargetServerId(targetTriggerInfo.serverId);
 	option.setTargetId(targetTriggerInfo.id);
+	option.setExcludeFlags(EXCLUDE_SELF_MONITORING);
 	dbMonitoring.getTriggerBriefList(triggerBriefList, option);
 	cppcut_assert_equal((size_t)1, triggerBriefList.size());
 	cppcut_assert_equal(targetTriggerInfo.brief, *triggerBriefList.begin());


### PR DESCRIPTION
* Add DBTablesMonitoring::getTriggerBriefList readonly DB API to retrieve trigger briefs