### PR TITLE
[HatoholAddActionDialog] Fix trigger status bug in incident setting dialog

### DIFF
--- a/client/static/js/hatohol_add_action_dialog.js
+++ b/client/static/js/hatohol_add_action_dialog.js
@@ -891,11 +891,8 @@ HatoholAddActionDialog.prototype.onAppendMainElement = function() {
       self.setApplyButtonState(false);
   }
 
-  if (self.forIncidentSetting) {
+  if (self.forIncidentSetting)
     self.setupIncidentTrackersEditor();
-    $("#selectTriggerStatus").val("TRIGGER_STATUS_PROBLEM");
-    $("#selectTriggerSeverityCompType").val("CMP_EQ_GT");
-  }
 };
 
 HatoholAddActionDialog.prototype.setApplyButtonState = function(state) {


### PR DESCRIPTION
Revise #2146

In the previous code the trigger status is always set to "ANY"
when a user edit an existing incident setting.
This commit fixes the issue by discarding the special treatment
for the incident setting.

Fix #2007 
