### PR TITLE
[configure] Remove "--enable-cpp11" switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,16 +196,8 @@ AC_SUBST(COVERAGE_LIBS)
 dnl **************************************************************
 dnl enable C++11
 dnl **************************************************************
-AC_ARG_ENABLE([cpp11],
-  [AS_HELP_STRING([--enable-cpp11], [Enable C++11 features (default is yes)])],
-  [],
-  [enable_cpp11=yes])
-
-if test "$enable_cpp11" == "yes"; then
-  AC_DEFINE(USE_CPP11, 1, [Define to 1 if you use C++11])
-  OPT_CXXFLAGS+=" -std=c++11"
-  AC_SUBST(OPT_CXXFLAGS)
-fi
+OPT_CXXFLAGS+=" -std=c++11"
+AC_SUBST(OPT_CXXFLAGS)
 
 dnl **************************************************************
 dnl Mocha, expect.js, and npm (indirectly node.js)

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -28,11 +28,6 @@
 #include <string>
 #include "config.h"
 
-#ifndef USE_CPP11
-#define override
-#define unique_ptr auto_ptr
-#endif
-
 typedef int DBTablesId;
 
 static const DBTablesId DB_TABLES_ID_CONFIG     = 0x0010;

--- a/server/mlpl/src/Reaper.h
+++ b/server/mlpl/src/Reaper.h
@@ -19,9 +19,6 @@
 
 #ifndef Reaper_h
 #define Reaper_h
-#ifndef USE_CPP11
-#define override
-#endif
 
 namespace mlpl {
 


### PR DESCRIPTION
Because --disable-cpp11 doesn't work anymore.
We alywas use C++11.