### PR TITLE
[RestResourceMonitoring][DBTablesMonitoring] Add "commentCount" property to indeint object

### DIFF
--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -254,6 +254,9 @@ struct IncidentInfo {
 
 	/* fetched from a monitoring system (since 14.12) */
 	uint64_t           unifiedEventId;
+
+	/* since 16.04 */
+	int                commentCount;
 };
 
 typedef std::vector<IncidentInfo>        IncidentInfoVect;

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -372,6 +372,8 @@ public:
 	HatoholError getIncidentHistory(
 	  std::list<IncidentHistory> &IncidentHistoriesList,
 	  const IncidentHistoriesQueryOption &option);
+	size_t getIncidentCommentCount(UnifiedEventIdType unifiedEventId);
+	HatoholError updateIncidentCommentCount(UnifiedEventIdType unifiedEventId);
 
 protected:
 	static SetupInfo &getSetupInfo(void);

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -93,6 +93,7 @@ struct IncidentSenderHatohol::Impl
 		incidentInfo.priority = "";
 		incidentInfo.assignee = "";
 		incidentInfo.doneRatio = 0;
+		incidentInfo.commentCount = 0;
 		incidentInfo.createdAt.tv_sec = currentTime.tv_sec;
 		incidentInfo.createdAt.tv_nsec = currentTime.tv_nsec;
 		incidentInfo.updatedAt = incidentInfo.createdAt;

--- a/server/src/RedmineAPI.cc
+++ b/server/src/RedmineAPI.cc
@@ -115,6 +115,9 @@ bool parseIssue(JSONParser &agent, IncidentInfo &incidentInfo)
 	agent.read("done_ratio", doneRatio);
 	incidentInfo.doneRatio = doneRatio;
 
+	// TODO
+	incidentInfo.commentCount = 0;
+
 	if (!parseDateTime(agent, "created_on", incidentInfo.createdAt))
 		return false;
 	if (!parseDateTime(agent, "updated_on", incidentInfo.updatedAt))

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -452,6 +452,7 @@ static void addIncident(FaceRest::ResourceHandler *job, JSONBuilder &agent,
 	agent.add("priority", incident.priority);
 	agent.add("assignee", incident.assignee);
 	agent.add("doneRatio", incident.doneRatio);
+	agent.add("commentCount", incident.commentCount);
 	agent.add("createdAt", incident.createdAt.tv_sec);
 	agent.add("updatedAt", incident.updatedAt.tv_sec);
 	agent.endObject();

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1151,6 +1151,7 @@ const IncidentInfo testIncidentInfo[] = {
 	{1412957260, 0},          // updatedAt
 	IncidentInfo::STATUS_OPENED,// statusCode
 	3,                        // unifiedId
+	0,                        // commentCount
 },
 {
 	3,                        // trackerId
@@ -1167,6 +1168,7 @@ const IncidentInfo testIncidentInfo[] = {
 	{1412957290, 0},          // updatedAt
 	IncidentInfo::STATUS_OPENED,// statusCode
 	4,                        // unifiedId
+	0,                        // commentCount
 },
 {
 	5,                        // trackerId
@@ -1183,6 +1185,7 @@ const IncidentInfo testIncidentInfo[] = {
 	{1412957360, 0},          // updatedAt
 	IncidentInfo::STATUS_OPENED,// statusCode
 	123,                      // unifiedId
+	0,                        // commentCount
 },
 };
 const size_t NumTestIncidentInfo = ARRAY_SIZE(testIncidentInfo);

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -638,7 +638,7 @@ string makeIncidentOutput(const IncidentInfo &incidentInfo)
 	    "%" FMT_INCIDENT_TRACKER_ID "|%" FMT_SERVER_ID "|%" FMT_EVENT_ID
 	    "|%" FMT_TRIGGER_ID "|%s|%s|%s|%s"
 	    "|%" PRIu64 "|%" PRIu64 "|%" PRIu64 "|%" PRIu64
-	    "|%s|%d|%" PRIu64 "\n",
+	    "|%s|%d|%" PRIu64 "|%d\n",
 	    incidentInfo.trackerId,
 	    incidentInfo.serverId,
 	    incidentInfo.eventId.c_str(),
@@ -653,7 +653,8 @@ string makeIncidentOutput(const IncidentInfo &incidentInfo)
 	    incidentInfo.updatedAt.tv_nsec,
 	    incidentInfo.priority.c_str(),
 	    incidentInfo.doneRatio,
-	    incidentInfo.unifiedEventId);
+	    incidentInfo.unifiedEventId,
+	    incidentInfo.commentCount);
 	return output;
 }
 

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -2055,7 +2055,7 @@ static const IncidentInfo *findIncidentInfoWithUnifiedEventId(
 		if (testIncidentInfo[i].unifiedEventId == unifiedEventId)
 			return &testIncidentInfo[i];
 	}
-	return NULL;
+	return nullptr;
 }
 
 void test_incremaentIncidentCommentCount(void)

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -2058,7 +2058,7 @@ static const IncidentInfo *findIncidentInfoWithUnifiedEventId(
 	return nullptr;
 }
 
-void test_incremaentIncidentCommentCount(void)
+void test_incrementIncidentCommentCount(void)
 {
 	loadTestDBIncidents();
 
@@ -2082,7 +2082,7 @@ void test_incremaentIncidentCommentCount(void)
 	assertDBContent(&dbAgent, statement, expected);
 }
 
-void test_notIncremaentIncidentCommentCount(void)
+void test_notIncrementIncidentCommentCount(void)
 {
 	loadTestDBIncidents();
 

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -2048,6 +2048,60 @@ void test_addIncidentHistory(void)
 	assertDBContent(&dbAgent, statement, expected);
 }
 
+static const IncidentInfo *findIncidentInfoWithUnifiedEventId(
+  const UnifiedEventIdType unifiedEventId)
+{
+	for (size_t i = 0; i < NumTestIncidentInfo; i++) {
+		if (testIncidentInfo[i].unifiedEventId == unifiedEventId)
+			return &testIncidentInfo[i];
+	}
+	return NULL;
+}
+
+void test_incremaentIncidentCommentCount(void)
+{
+	loadTestDBIncidents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	IncidentHistory history = testIncidentHistory[1];
+	dbMonitoring.addIncidentHistory(history);
+	history.status = "DONE";
+	history.comment = "Done.";
+	history.createdAt.tv_sec += 60;
+	dbMonitoring.addIncidentHistory(history);
+
+	IncidentInfo incident =
+	  *findIncidentInfoWithUnifiedEventId(history.unifiedEventId);
+	incident.commentCount = 2;
+	string statement =
+	  StringUtils::sprintf(
+	    "select * from incidents where unified_event_id=%"
+	    FMT_UNIFIED_EVENT_ID, history.unifiedEventId);
+	string expected = makeIncidentOutput(incident);
+	DBAgent &dbAgent = dbMonitoring.getDBAgent();
+	assertDBContent(&dbAgent, statement, expected);
+}
+
+void test_notIncremaentIncidentCommentCount(void)
+{
+	loadTestDBIncidents();
+
+	DECLARE_DBTABLES_MONITORING(dbMonitoring);
+	IncidentHistory history = testIncidentHistory[1];
+	history.comment = "";
+	dbMonitoring.addIncidentHistory(history);
+
+	IncidentInfo incident =
+	  *findIncidentInfoWithUnifiedEventId(history.unifiedEventId);
+	string statement =
+	  StringUtils::sprintf(
+	    "select * from incidents where unified_event_id=%"
+	    FMT_UNIFIED_EVENT_ID, history.unifiedEventId);
+	string expected = makeIncidentOutput(incident);
+	DBAgent &dbAgent = dbMonitoring.getDBAgent();
+	assertDBContent(&dbAgent, statement, expected);
+}
+
 void test_updateIncidentHistory(void)
 {
 	loadTestDBIncidentHistory();

--- a/server/test/testDBTablesMonitoring.h
+++ b/server/test/testDBTablesMonitoring.h
@@ -343,6 +343,8 @@ struct AssertGetEventsArg
 			incident.createdAt.tv_nsec = 0;
 			incident.updatedAt.tv_sec  = 0;
 			incident.updatedAt.tv_nsec = 0;
+			incident.unifiedEventId = 0;
+			incident.commentCount = 0;
 			return incident;
 		} else {
 			return *eventIncidentMap[key];

--- a/server/test/testFaceRestIncident.cc
+++ b/server/test/testFaceRestIncident.cc
@@ -107,7 +107,7 @@ void test_putIncident(void)
 				" where unified_event_id=123");
 	string expected =
 		"^5\\|2\\|2\\|3\\|123\\|\\|IN PROGRESS\\|taro\\|"
-		"1412957360\\|0\\|\\d+\\|\\d+\\|HIGH\\|30\\|123$";
+		"1412957360\\|0\\|\\d+\\|\\d+\\|HIGH\\|30\\|123\\|0$";
 	cut_assert_match(expected.c_str(), actual.c_str());
 
 	// check history

--- a/server/test/testFaceRestMonitoring.cc
+++ b/server/test/testFaceRestMonitoring.cc
@@ -295,8 +295,26 @@ static void _assertEvents(const string &path,
 			assertStartObject(parser, "incident");
 			const IncidentInfo incident
 			  = expectedEventsArg.getExpectedIncidentInfo(eventInfo);
+			assertValueInParser(parser, "trackerId",
+					    incident.trackerId);
+			assertValueInParser(parser, "identifier",
+					    incident.identifier);
 			assertValueInParser(parser, "location",
 					    incident.location);
+			assertValueInParser(parser, "status",
+					    incident.status);
+			assertValueInParser(parser, "priority",
+					    incident.priority);
+			assertValueInParser(parser, "assignee",
+					    incident.assignee);
+			assertValueInParser(parser, "doneRatio",
+					    incident.doneRatio);
+			assertValueInParser(parser, "commentCount",
+					    incident.commentCount);
+			assertValueInParser(parser, "createdAt",
+					    incident.createdAt.tv_sec);
+			assertValueInParser(parser, "updatedAt",
+					    incident.updatedAt.tv_sec);
 			parser->endElement();
 		} else {
 			assertNoValueInParser(parser, "incident");

--- a/server/test/testFaceRestSummary.cc
+++ b/server/test/testFaceRestSummary.cc
@@ -55,6 +55,7 @@ const IncidentInfo unAssignedIncidentInfo[] = {
 	{1412957360, 0},          // updatedAt
 	IncidentInfo::STATUS_UNKNOWN, // statusCode
 	7,                        // unifiedId
+	0,                        // commentCount
 },
 };
 const size_t NumUnAssginedTestIncidentInfo = ARRAY_SIZE(unAssignedIncidentInfo);

--- a/server/test/testIncidentSenderHatohol.cc
+++ b/server/test/testIncidentSenderHatohol.cc
@@ -67,7 +67,7 @@ void test_send(void)
 	cppcut_assert_equal(HTERR_OK, err.getCode());
 
 	string expected =
-	  "^1\\|3\\|1\\|2\\|931\\|\\|NONE\\|\\|\\d+\\|\\d+\\|\\d+\\|\\d+\\|\\|0\\|931$";
+	  "^1\\|3\\|1\\|2\\|931\\|\\|NONE\\|\\|\\d+\\|\\d+\\|\\d+\\|\\d+\\|\\|0\\|931|0$";
 	DBHatohol dbHatohol;
 	DBTablesMonitoring &dbMonitoring = dbHatohol.getDBTablesMonitoring();
 	string actual = execSQL(&dbMonitoring.getDBAgent(),
@@ -106,7 +106,7 @@ void test_updateStatus(gconstpointer data)
 	string expected(
 	  string("^5\\|2\\|2\\|3\\|123\\|\\|") +
 	  string(status) +
-	  string ("\\|\\|1412957360\\|0\\|\\d+\\|\\d+\\|\\|0\\|123$"));
+	  string ("\\|\\|1412957360\\|0\\|\\d+\\|\\d+\\|\\|0\\|123|0$"));
 	DBHatohol dbHatohol;
 	DBTablesMonitoring &dbMonitoring = dbHatohol.getDBTablesMonitoring();
 	string actual = execSQL(&dbMonitoring.getDBAgent(),
@@ -179,7 +179,7 @@ void test_userDefinedStatus(gconstpointer data)
 	string expected(
 	  string("^5\\|2\\|2\\|3\\|123\\|\\|") +
 	  string(incidentInfo.status) +
-	  string ("\\|\\|1412957360\\|0\\|\\d+\\|\\d+\\|\\|0\\|123$"));
+	  string ("\\|\\|1412957360\\|0\\|\\d+\\|\\d+\\|\\|0\\|123|0$"));
 	DBHatohol dbHatohol;
 	DBTablesMonitoring &dbMonitoring = dbHatohol.getDBTablesMonitoring();
 	string actual = execSQL(&dbMonitoring.getDBAgent(),

--- a/server/test/testIncidentSenderManager.cc
+++ b/server/test/testIncidentSenderManager.cc
@@ -123,7 +123,7 @@ void test_sendHatholIncident(void)
 	cppcut_assert_equal(true, succeeded);
 
 	string expected =
-	  "^5\\|3\\|1\\|2\\|193\\|\\|NONE\\|\\|\\d+\\|\\d+\\|\\d+\\|\\d+\\|\\|0\\|193$";
+	  "^5\\|3\\|1\\|2\\|193\\|\\|NONE\\|\\|\\d+\\|\\d+\\|\\d+\\|\\d+\\|\\|0\\|193\\|0$";
 	DBHatohol dbHatohol;
 	DBTablesMonitoring &dbMonitoring = dbHatohol.getDBTablesMonitoring();
 	string actual = execSQL(&dbMonitoring.getDBAgent(),

--- a/server/test/testIncidentSenderRedmine.cc
+++ b/server/test/testIncidentSenderRedmine.cc
@@ -247,6 +247,7 @@ static void makeExpectedIncidentInfo(IncidentInfo &incident,
 	incident.updatedAt.tv_sec = postedIssue.updatedOn;
 	incident.updatedAt.tv_nsec = 0;
 	incident.unifiedEventId = event.unifiedId;
+	incident.commentCount = 0;
 }
 
 void _assertSend(const HatoholErrorCode &expected,


### PR DESCRIPTION
It makes easy to get number of comments belongs to an incident.

https://github.com/project-hatohol/hatohol/issues/2119#issuecomment-195845731
