### PR TITLE
Webui use conf file for settings #2152 5

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -143,6 +143,13 @@ nobase_dist_hatohol_client_DATA = \
 	viewer/severity_ranks_ajax.html \
 	viewer/tests.py
 
+pkgsysconf_DATA = \
+	conf/webui.conf
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
+
+EXTRA_DIST = \
+	$(pkgsysconf_DATA)
+
 MO_FILES = \
 	conf/locale/ja/LC_MESSAGES/django.mo \
 	conf/locale/ja/LC_MESSAGES/djangojs.mo

--- a/client/conf/webui.conf
+++ b/client/conf/webui.conf
@@ -1,0 +1,12 @@
+[generic]
+#allowed_hosts = *
+#allowed_hosts = localhost 192.168.15.* *.example.com
+#time_zone = 'America/Chicago'
+
+[database]
+#name = hatohol_client
+#user = hatohol
+
+[server]
+#host = localhost
+#port = 33194

--- a/client/hatohol/autotools_vars.py.in
+++ b/client/hatohol/autotools_vars.py.in
@@ -1,0 +1,19 @@
+# Copyright (C) 2016 Project Hatohol
+#
+# This file is part of Hatohol.
+#
+# Hatohol is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License, version 3
+# as published by the Free Software Foundation.
+#
+# Hatohol is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Hatohol. If not, see
+# <http://www.gnu.org/licenses/>.
+
+SYSCONFDIR = '@expanded_sysconfdir@'
+

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013,2015 Project Hatohol
+# Copyright (C) 2013,2015-2016 Project Hatohol
 #
 # This file is part of Hatohol.
 #
@@ -19,6 +19,8 @@
 # Django settings for hatohol project.
 import os
 import logging
+import ConfigParser
+import autotools_vars as av
 from branding_settings import *
 
 PROJECT_HOME = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -229,3 +231,42 @@ ENABLED_PAGES = (
     #"http://www.hatohol.org/docs"
     #"#version"
 )
+
+def get_config_lines_from_file():
+    conf_lines = []
+
+    config = ConfigParser.ConfigParser()
+    selected = config.read(['webui.conf',
+                            av.SYSCONFDIR + '/hatohol/webui.conf'])
+    if len(selected) == 0:
+        return conf_lines
+
+    config_defs = (
+        ('generic', {
+            'allowed_hosts': lambda v: 'ALLOWED_HOSTS = %s' % v.split(),
+            'time_zone':     lambda v: 'TIME_ZONE = "%s"' % v.split(),
+        }),
+        ('database', {
+            'name': lambda v: 'DATABASES["default"]["NAME"] = "%s"' % v,
+            'user': lambda v: 'DATABASES["default"]["USER"] = "%s"' % v,
+            'password': lambda v: 'DATABASES["default"]["PASSWORD"] = "%s"' % v,
+            'host': lambda v: 'DATABASES["default"]["HOST""] = "%s"' % v,
+            'port': lambda v: 'DATABASES["default"]["PORT""] = "%s"' % v,
+        }),
+        ('server', {
+            'host': lambda v: 'DEFAULT_SERVER_ADDR = "%s"' % v,
+            'port': lambda v: 'DEFAULT_SERVER_PORT = %s' % v,
+        }),
+    )
+
+    for section, handlers in config_defs:
+        for (key, val) in config.items(section):
+            handler = handlers.get(key)
+            if handler:
+                conf_lines.append(handler(val))
+            else:
+                print 'Unknown keyword: [%s] %s (%s)' % (section, key, val)
+    return conf_lines
+
+for line in get_config_lines_from_file():
+    exec(line)

--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -254,8 +254,8 @@ def get_config_lines_from_file():
             'port': lambda v: 'DATABASES["default"]["PORT""] = "%s"' % v,
         }),
         ('server', {
-            'host': lambda v: 'DEFAULT_SERVER_ADDR = "%s"' % v,
-            'port': lambda v: 'DEFAULT_SERVER_PORT = %s' % v,
+            'host': lambda v: 'HATOHOL_SERVER_ADDR = "%s"' % v,
+            'port': lambda v: 'HATOHOL_SERVER_PORT = %s' % v,
         }),
     )
 

--- a/client/hatohol/hatoholserver.py
+++ b/client/hatohol/hatoholserver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2013 Project Hatohol
+# Copyright (C) 2013,2016 Project Hatohol
 #
 # This file is part of Hatohol.
 #
@@ -17,38 +17,54 @@
 
 import os
 import logging
-
-DEFAULT_SERVER_ADDR = 'localhost'
-DEFAULT_SERVER_PORT = 33194
-
-SERVER_ADDR = DEFAULT_SERVER_ADDR
-SERVER_PORT = DEFAULT_SERVER_PORT
+from django.conf import settings
 
 SESSION_NAME_META = 'HTTP_X_HATOHOL_SESSION'
-logger = logging.getLogger(__name__)
+
+# As the following source code, priority of the way to select
+# the Hatohol server is the following.
+#
+# 1. Environment variable
+# 2. settings (webui.conf)
+# 3. This module's default
+#
+DEFAULT_SERVER_ADDR = 'localhost'
+DEFAULT_SERVER_PORT = 33194
 
 SERVER_ADDR_ENV_NAME = 'HATOHOL_SERVER_ADDR'
 SERVER_PORT_ENV_NAME = 'HATOHOL_SERVER_PORT'
 
+SERVER_ADDR = None
+SERVER_PORT = None
 
-def _setup():
-    # server
-    global SERVER_ADDR
-    server_addr = os.getenv(SERVER_ADDR_ENV_NAME)
-    if server_addr:
-        SERVER_ADDR = server_addr
-        logger.info('Server addr: %s' % SERVER_ADDR)
-    else:
-        SERVER_ADDR = DEFAULT_SERVER_ADDR
+# 1. Env. var.
+if SERVER_ADDR is None:
+    addr = os.getenv(SERVER_ADDR_ENV_NAME)
+    if addr:
+        SERVER_ADDR = addr
 
-    # port
-    global SERVER_PORT
-    server_port = os.getenv(SERVER_PORT_ENV_NAME)
-    if server_port:
-        SERVER_PORT = int(server_port)
-        logger.info('Server port: %d' % SERVER_PORT)
-    else:
-        SERVER_PORT = DEFAULT_SERVER_PORT
+if SERVER_PORT is None:
+    port = os.getenv(SERVER_PORT_ENV_NAME)
+    if port:
+        SERVER_PORT = int(port)
+
+# 2. settings.HATOHOL_SERVER_ADDR and PORT are read from 'webui.conf'
+if SERVER_ADDR is None:
+    if hasattr(settings, 'HATOHOL_SERVER_ADDR'):
+        SERVER_ADDR = settings.HATOHOL_SERVER_ADDR
+
+if SERVER_PORT is None:
+    if hasattr(settings, 'HATOHOL_SERVER_PORT'):
+        SERVER_PORT = settings.HATOHOL_SERVER_PORT
+
+# 3. Default
+if SERVER_ADDR is None:
+    SERVER_ADDR = DEFAULT_SERVER_ADDR
+if SERVER_PORT is None:
+    SERVER_PORT = DEFAULT_SERVER_PORT
+
+logger = logging.getLogger(__name__)
+logger.info('Hatohol server addr: %s, port: %d' % (SERVER_ADDR, SERVER_PORT))
 
 
 def get_address():
@@ -57,6 +73,3 @@ def get_address():
 
 def get_port():
     return SERVER_PORT
-
-
-_setup()

--- a/client/test/python/TestHatoholserver.py
+++ b/client/test/python/TestHatoholserver.py
@@ -52,27 +52,26 @@ class TestHatoholserver(unittest.TestCase):
             self._orig_server_port = None
         elif hatoholserver.SERVER_PORT_ENV_NAME in os.environ:
             del os.environ[hatoholserver.SERVER_PORT_ENV_NAME]
-        hatoholserver._setup()  # Update the internal information
 
     def test_get_default_address(self):
         if os.getenv(hatoholserver.SERVER_ADDR_ENV_NAME):
             del os.environ[hatoholserver.SERVER_ADDR_ENV_NAME]
-        hatoholserver._setup()  # Update the internal information
+        reload(hatoholserver) # Update the internal information
         addr = self.assertEqual(hatoholserver.get_address(), 'localhost')
 
     def test_get_address_with_env(self):
         os.environ[hatoholserver.SERVER_ADDR_ENV_NAME] = 'foo.example.com'
-        hatoholserver._setup()  # Update the internal information
+        reload(hatoholserver) # Update the internal information
         addr = self.assertEqual(hatoholserver.get_address(), 'foo.example.com')
 
     def test_get_default_port(self):
         if os.getenv(hatoholserver.SERVER_PORT_ENV_NAME):
             del os.environ[hatoholserver.SERVER_PORT_ENV_NAME]
-        hatoholserver._setup()  # Update the internal information
+        reload(hatoholserver) # Update the internal information
         addr = self.assertEqual(hatoholserver.get_port(),
                                 hatoholserver.DEFAULT_SERVER_PORT)
 
     def test_get_port_with_env(self):
         os.environ[hatoholserver.SERVER_PORT_ENV_NAME] = '12345'
-        hatoholserver._setup()  # Update the internal information
+        reload(hatoholserver) # Update the internal information
         addr = self.assertEqual(hatoholserver.get_port(), 12345)

--- a/client/test/python/TestHatoholserver.py
+++ b/client/test/python/TestHatoholserver.py
@@ -72,7 +72,7 @@ class TestHatoholserver(unittest.TestCase):
         addr = self.assertEqual(hatoholserver.get_port(),
                                 hatoholserver.DEFAULT_SERVER_PORT)
 
-    def test_get_address_with_env(self):
+    def test_get_port_with_env(self):
         os.environ[hatoholserver.SERVER_PORT_ENV_NAME] = '12345'
         hatoholserver._setup()  # Update the internal information
         addr = self.assertEqual(hatoholserver.get_port(), 12345)

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ AC_OUTPUT([
 Makefile
 hatohol.spec
 client/static/js/hatohol_version.js
+client/hatohol/autotools_vars.py
 data/Makefile
 data/init.d/Makefile
 data/init.d/debian/hatohol.debian

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -268,6 +268,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_libexecdir}/hatohol/client/*
 %config %{_sysconfdir}/httpd/conf.d/hatohol.conf
+%config %{_sysconfdir}/hatohol/webui.conf
 
 %files devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
*** This is a fixed version of #2174 ***

Django framework provides a way to set some parameters such as
database server and the port. However, it's a python file and
hard to be edited by users.

So this patch adds a mechanism to try to read a configuration file
under the sysconfdir given by autoconf.
