### PR TITLE
[WebUI:events] adjust filter box line-height

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -639,12 +639,20 @@ html {
 }
 
 #hideDiv .filter-element {
-    width: 33%;
-    margin: 0;
-    padding: 0 0 12px 0;
-    box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
+  display: inline-table;
+  width: 33%;
+  margin: 0;
+  padding: 0 0 12px 0;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+
+#hideDiv .filter-element p {
+  display: table-cell;
+  vertical-align: middle;
+  height: auto;
+  line-height: 100%;
 }
 
 #hideDiv .bootstrap-select.btn-group > .disabled {


### PR DESCRIPTION
#2005 
『フィルタの絞り込みエリアがもう少し小さくてもよいのではないか？』
項目名行間調整。
CSSのみ。

項目名要素のpタグの行間を文字サイズの１倍（line-height:100%）とし、上下揃えを中央（vertical-align:middle）とした。
vertical-alignはtable-cell要素内のみ適用されるため、当該pタグをtable-cellとした。
table-cellはtableまたはinline-table内のみtable-cellとして振る舞うため、pタグの親である.filter-elementをinline-tableとした。

本来ならば#hideDivそのものをdisplay:tableとしてしまうのが安定するが、イベント・トリガーともにHTML構造が大きく変わってしまうこと、.filter-elementがdisplay:inlineで表示が安定していることから、display:inline-tableを採用している。