### PR TITLE
[client] Fix Period to 'Date and time'

### DIFF
--- a/client/conf/locale/ja/LC_MESSAGES/djangojs.po
+++ b/client/conf/locale/ja/LC_MESSAGES/djangojs.po
@@ -269,8 +269,8 @@ msgid "Severity"
 msgstr "深刻度"
 
 #: static/js/events_view.js:114
-msgid "Period"
-msgstr "期間"
+msgid "Date and Time"
+msgstr "日付"
 
 #: static/js/events_view.js:118 static/js/hatohol_trigger_selector.js:49
 msgid "Brief"

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -112,7 +112,7 @@ var EventsView = function(userProfile, options) {
       body: renderTableDataEventSeverity,
     },
     "time": {
-      header: gettext("Period"),
+      header: gettext("Date and Time"),
       body: renderTableDataEventTime,
     },
     "description": {

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -419,7 +419,7 @@ describe('EventsView', function() {
     var view = new EventsView(getOperator(), testOptions);
     respond(eventsJson(dummyEventInfo, getDummyHAPI2ZabbixServerInfo()));
     expect($('tr').eq(0).text()).to.be(
-      "HandlingStatusSeverityPeriod Monitoring ServerHostBriefShow Full Text");
+      "HandlingStatusSeverityDate and Time Monitoring ServerHostBriefShow Full Text");
     expect($('tr').eq(1).text()).to.be(
       " ProblemInformation" + getEventTimeString(dummyEventInfo[0]) +
       "ServerHostTest description.");
@@ -433,7 +433,7 @@ describe('EventsView', function() {
     respond(eventsJson(dummyEventInfo, getDummyHAPI2ZabbixServerInfo()),
 	    configJson);
     expect($('tr').eq(0).text()).to.be(
-      "DurationSeverityStatusBriefShow Full TextHostPeriod Monitoring Server");
+      "DurationSeverityStatusBriefShow Full TextHostDate and Time Monitoring Server");
     expect($('tr').eq(1).text()).to.be(
       "02:46:40Information ProblemTest description.Host" +
       getEventTimeString(dummyEventInfo[0]) +


### PR DESCRIPTION
I think, 'Period' is incorrect.
The following is after changing.
![date](https://cloud.githubusercontent.com/assets/7106792/13979312/f9220d84-f11a-11e5-929f-20f52dddca5d.png)
