### PR TITLE
Hap2 conf 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,7 @@ server/mlpl/mlpl.pc
 server/common/Makefile
 server/src/Makefile
 server/hap2/Makefile
+server/hap2/hap2.conf
 server/hap2/hap2-control-functions.sh
 server/hap2/hatohol/Makefile
 server/hap2/hatohol/autotools_vars.py

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,7 @@ server/src/Makefile
 server/hap2/Makefile
 server/hap2/hap2-control-functions.sh
 server/hap2/hatohol/Makefile
+server/hap2/hatohol/autotools_vars.py
 server/data/Makefile
 server/tools/Makefile
 server/tools/hatohol-db-initiator

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -305,6 +305,7 @@ rm -rf %{buildroot}
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.pyc
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_starter.pyo
+%config %{_sysconfdir}/hatohol/hap2.conf
 %config %{_sysconfdir}/hatohol/hap2-logging.conf
 
 %files hap2-rabbitmq-connector

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -295,6 +295,9 @@ rm -rf %{buildroot}
 %{python_sitelib}/hatohol/transporter.py
 %{python_sitelib}/hatohol/transporter.pyc
 %{python_sitelib}/hatohol/transporter.pyo
+%{python_sitelib}/hatohol/autotools_vars.py
+%{python_sitelib}/hatohol/autotools_vars.pyc
+%{python_sitelib}/hatohol/autotools_vars.pyo
 %{python_sitelib}/hatohol/transporters/__init__.py
 %{python_sitelib}/hatohol/transporters/__init__.pyc
 %{python_sitelib}/hatohol/transporters/__init__.pyo

--- a/server/hap2/Makefile.am
+++ b/server/hap2/Makefile.am
@@ -12,6 +12,7 @@ hatohol_hap2_DATA = \
 	hap2-control-functions.sh
 
 pkgsysconf_DATA = \
+	hap2.conf \
 	hap2-logging.conf
 pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
@@ -50,6 +51,7 @@ nobase_hatohol_hap2_SCRIPTS = \
 
 EXTRA_DIST = \
 	hap2-control-functions.sh.in \
+	hap2.conf \
 	hap2-logging.conf \
 	$(hatohol_hap2_SCRIPTS) \
 	$(hatohol_hap2_DATA) \

--- a/server/hap2/hap2.conf.in
+++ b/server/hap2/hap2.conf.in
@@ -1,0 +1,25 @@
+# Don't use hyphen in the left hand side.
+#
+# Python conf. file module returns all value as a 'str' type.
+# When you set None or bool, the right hand side shall be empty.
+#
+# You have to write your any option in [hap2] section.
+
+[hap2]
+amqp_broker = localhost
+#amqp_port = 5672
+#amqp_vhost = hatohol
+amqp_queue = q01
+amqp_user = hatohol
+amqp_password = hatohol
+#amqp_ssl_key = @expanded_sysconfdir@/hatohol/key.pem
+#amqp_ssl_cert = @expanded_sysconfdir@/hatohol/client-cert.pem
+#amqp_ssl_ca = @expanded_sysconfdir@/hatohol/ca-cert.pem
+
+# If you remove comment out the next line, disable_poller option is enabled.
+#disable_poller
+log = INFO
+log_conf = @expanded_sysconfdir@/hatohol/hap2-logging.conf
+transporter = RabbitMQHapiConnector
+status_log_interval = 600
+polling_target = hosts host_groups host_group_membership trigers events

--- a/server/hap2/hatohol/autotools_vars.py.in
+++ b/server/hap2/hatohol/autotools_vars.py.in
@@ -1,0 +1,18 @@
+# Copyright (C) 2016 Project Hatohol
+#
+# This file is part of Hatohol.
+#
+# Hatohol is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License, version 3
+# as published by the Free Software Foundation.
+#
+# Hatohol is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Hatohol. If not, see
+# <http://www.gnu.org/licenses/>.
+
+SYSCONFDIR = '@expanded_sysconfdir@'

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -33,6 +33,8 @@ import errno
 import time
 import traceback
 import multiprocessing
+import argparse
+import ConfigParser
 from hatohol import hapcommon
 
 logger = getLogger("hatohol.hap:%s" % hapcommon.get_top_file_name())
@@ -144,3 +146,41 @@ class Signal:
     def __init__(self, restart=False, critical=False):
         self.restart = restart
         self.critical = critical
+
+
+class ConfigFileParser():
+    def __init__(self, conf_path, remaining_args, parser):
+        config_parser = ConfigParser.SafeConfigParser(allow_no_value=True)
+        config_parser.read(conf_path)
+        self.item_dict = dict(config_parser.items("hap2"))
+        self.parser = argparse.ArgumentParser(parents=[parser])
+        self.group = self.parser.add_argument_group("Variables")
+        self.remaining_args = remaining_args
+
+    def add_argument(self, *args, **kwargs):
+        default_value = None
+        if kwargs.has_key("default"):
+            default_value = kwargs.pop("default")
+
+        for arg in args:
+            arg_name = self.__remove_and_replace_hyphen(arg)
+            if self.item_dict.has_key(arg_name):
+                default_value = self.item_dict[arg_name]
+                break
+            else:
+                continue
+
+        if kwargs.has_key("type") and default_value:
+            default_value = kwargs["type"](default_value)
+        if not default_value:
+            default_value = None
+        self.group.add_argument(default=default_value, *args, **kwargs)
+
+    def parse_args(self):
+        return self.parser.parse_args(self.remaining_args)
+
+    def __remove_and_replace_hyphen(self, argument_name):
+        while argument_name[0] == "-":
+            argument_name = argument_name[1:]
+
+        return argument_name.replace("-", "_")

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -98,16 +98,6 @@ def handle_exception(raises=(SystemExit,)):
     return exctype, value
 
 
-class Signal:
-    """
-    This class is supposed to raise as an exception in order to
-    propagate some events and jump over stack frames.
-    """
-
-    def __init__(self, restart=False, critical=False):
-        self.restart = restart
-        self.critical = critical
-
 def _handle_ioerr(e, timeout, expired_time):
     if e.errno != errno.EINTR:
         raise
@@ -140,5 +130,17 @@ def MultiprocessingQueue(queue_class=multiprocessing.Queue):
     q.get = __get
     return q
 
+
 def MultiprocessingJoinableQueue():
     return MultiprocessingQueue(multiprocessing.JoinableQueue)
+
+
+class Signal:
+    """
+    This class is supposed to raise as an exception in order to
+    propagate some events and jump over stack frames.
+    """
+
+    def __init__(self, restart=False, critical=False):
+        self.restart = restart
+        self.critical = critical

--- a/server/hap2/hatohol/hap.py
+++ b/server/hap2/hatohol/hap.py
@@ -64,13 +64,13 @@ def initialize_logger(parser=None):
 
 
 def setup_logger(args):
+    if args.log_conf_file is not None:
+        logging.config.fileConfig(args.log_conf_file)
+
     numeric_level = getattr(logging, args.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % loglevel)
     getLogger("hatohol").setLevel(numeric_level)
-
-    if args.log_conf_file is not None:
-        logging.config.fileConfig(args.log_conf_file)
 
 
 def handle_exception(raises=(SystemExit,)):

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -21,10 +21,13 @@
 import argparse
 from logging import getLogger
 import signal
+import os
 from hatohol import hap
 from hatohol import haplib
 from hatohol import transporter
 from hatohol import hapcommon
+from hatohol import autotools_vars
+import logging
 
 logger = getLogger("hatohol.standardhap:%s" % hapcommon.get_top_file_name())
 
@@ -34,19 +37,28 @@ class StandardHap:
         group = parser.add_argument_group("Config")
 
         help_msg = """
-        Designate a Config file. Default is None.
-        Other command line arguments takes precedence over config file item.
+        A configuration file.
+        Other command line arguments override items in the config. file.
         """
         group.add_argument("--config", default=None, help=help_msg)
         args, remaining_args = parser.parse_known_args()
 
+        config_path = None
         if args.config:
-            parser = hap.ConfigFileParser(args.config, remaining_args, parser)
+            config_path = args.config
+        else:
+            default_conf_path = autotools_vars.SYSCONFDIR + "/hatohol/hap2.conf"
+            if os.path.isfile(default_conf_path):
+                config_path = default_conf_path
+        if config_path:
+            parser = hap.ConfigFileParser(config_path, remaining_args, parser)
         else:
             #The line enable help message.
             parser = argparse.ArgumentParser(parents=[parser])
 
         hap.initialize_logger(parser)
+        if config_path:
+            logger.info("Configuration file: %s" % config_path)
         parser.add_argument("-p", "--disable-poller", action="store_true")
         parser.add_argument("--polling-targets", nargs="*",
                             choices=haplib.BasePoller.ACTIONS,

--- a/server/hap2/hatohol/standardhap.py
+++ b/server/hap2/hatohol/standardhap.py
@@ -30,9 +30,23 @@ logger = getLogger("hatohol.standardhap:%s" % hapcommon.get_top_file_name())
 
 class StandardHap:
     def __init__(self, default_transporter="RabbitMQHapiConnector"):
-        parser = argparse.ArgumentParser()
-        hap.initialize_logger(parser)
+        parser = argparse.ArgumentParser(add_help=False)
+        group = parser.add_argument_group("Config")
 
+        help_msg = """
+        Designate a Config file. Default is None.
+        Other command line arguments takes precedence over config file item.
+        """
+        group.add_argument("--config", default=None, help=help_msg)
+        args, remaining_args = parser.parse_known_args()
+
+        if args.config:
+            parser = hap.ConfigFileParser(args.config, remaining_args, parser)
+        else:
+            #The line enable help message.
+            parser = argparse.ArgumentParser(parents=[parser])
+
+        hap.initialize_logger(parser)
         parser.add_argument("-p", "--disable-poller", action="store_true")
         parser.add_argument("--polling-targets", nargs="*",
                             choices=haplib.BasePoller.ACTIONS,

--- a/server/hap2/setup_common.py
+++ b/server/hap2/setup_common.py
@@ -5,5 +5,5 @@ setup(name='hatohol',
       author='Procect Hatohol',
       author_email='hatohol-users@list.sourceforge.net',
       url='https://github.com/project-hatohol/hatohol',
-      py_modules=['hatohol.hap', 'hatohol.haplib', 'hatohol.hapcommon','hatohol.transporter', 'hatohol.standardhap']
+      py_modules=['hatohol.hap', 'hatohol.haplib', 'hatohol.hapcommon','hatohol.transporter', 'hatohol.standardhap', 'hatohol.autotools_vars']
      )


### PR DESCRIPTION
Previously plugins need many command line arguments such as paramters to connet w/ AMQP brokers. This patch provides a feature in which they are given by the configuration file.


****
This is a fixed version of #2193