### PR TITLE
[client][event_view] Hide duration column

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -119,10 +119,10 @@ var EventsView = function(userProfile, options) {
       header: gettext("Brief"),
       body: renderTableDataEventDescription,
     },
-    "duration": {
-      header: gettext("Duration"),
-      body: renderTableDataEventDuration,
-    },
+//    "duration": {
+//      header: gettext("Duration"),
+//      body: renderTableDataEventDuration,
+//    },
     "incidentStatus": {
       header: gettext("Handling"),
       body: renderTableDataIncidentStatus,

--- a/client/test/browser/test_events_view.js
+++ b/client/test/browser/test_events_view.js
@@ -433,7 +433,7 @@ describe('EventsView', function() {
     respond(eventsJson(dummyEventInfo, getDummyHAPI2ZabbixServerInfo()),
 	    configJson);
     expect($('tr').eq(0).text()).to.be(
-      "DurationSeverityStatusBriefShow Full TextHostDate and Time Monitoring Server");
+      "SeverityStatusBriefShow Full TextHostDate and Time Monitoring Server");
     expect($('tr').eq(1).text()).to.be(
       "02:46:40Information ProblemTest description.Host" +
       getEventTimeString(dummyEventInfo[0]) +


### PR DESCRIPTION
It is temporary commit.
After release 16.04, we add new API to Hatohol server and re-display this column.

Related: #115