### PR TITLE
[ServersView] Remove unused columns

### DIFF
--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -191,25 +191,22 @@ var ServersView = function(userProfile) {
              "data-container='body' " +
            ">" + escapeHTML(gettext("Checking")) + "</td>";
       s += "<td>" + makeMonitoringSystemTypeLabel(o) + "</td>";
+
       if (serverURL) {
         s += "<td class='server-url-link'><a href='" + serverURL +
-          "' target='_blank'>" + escapeHTML(o["hostName"])  + "</a></td>";
-        s += "<td class='server-ip-link'><a href='" + serverURL +
-          "' target='_blank'>" + escapeHTML(ip) + "</a></td>";
-      } else if (o["type"] == hatohol.MONITORING_SYSTEM_HAPI_CEILOMETER){
-        s += "<td>" + escapeHTML(o["hostName"])  + "</td>";
-        s += "<td>N/A</td>";
+          "' target='_blank'>" + escapeHTML(o["nickname"])  + "</a></td>";
       } else {
-        s += "<td>" + escapeHTML(o["hostName"])  + "</td>";
-        s += "<td>" + escapeHTML(ip) + "</td>";
+        s += "<td>" + escapeHTML(o["nickname"])  + "</td>";
       }
-      s += "<td>" + escapeHTML(o["nickname"])  + "</td>";
+      s += "<td>" + escapeHTML(o["baseURL"])  + "</td>";
+
       if (mapsURL) {
         s += "<td><a href='" + mapsURL + "' target='_blank'>" +
           gettext('Show Maps') + "</a></td>";
       } else {
         s += "<td></td>";
       }
+
       s += "<td id='server-info-" + escapeHTML(serverId) + "'" +
            "  data-title='" + gettext("Server ID") + ": " + escapeHTML(serverId) + "'" +
            "  data-html=true" +

--- a/client/test/browser/test_server_view.js
+++ b/client/test/browser/test_server_view.js
@@ -160,10 +160,8 @@ describe('ServerView', function() {
     var view = new ServersView(userProfile);
     respond();
 
-    var hostnameColumn = $('td.server-url-link');
-    var ipAddressColumn = $('td.server-ip-link');
-    expect(hostnameColumn).to.have.length(expectedVisibleLinkNums);
-    expect(ipAddressColumn).to.have.length(expectedVisibleLinkNums);
+    var nicknameColumn = $('td.server-url-link');
+    expect(nicknameColumn).to.have.length(expectedVisibleLinkNums);
   }
 
   function checkGetStatusLabel(stat, expectMsg, expectMsgClass) {

--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -65,9 +65,8 @@
         <th class="delete-selector" style='display:none;'> </th>
         <th>{% trans "Connection status" %}</th>
         <th>{% trans "Type" %}</th>
-        <th>{% trans "Hostname" %}</th>
-        <th>{% trans "IP Address" %}</th>
         <th>{% trans "Nickname" %}</th>
+        <th>{% trans "URL" %}</th>
         <th>{% trans "Maps" %}</th>
         <th class="server-info-column" style="display:none;"></th>
         <th class="edit-server-column" style="display:none;"></th>


### PR DESCRIPTION
Recently built-in monitoring types are removed from Hatohol server.
As a result no monitoring type provides "Hostname" and
"IP Address" properties. So we should remove these columns.

Fix #2205