### PR TITLE
[FaceRestIncident][test] Suppress a unused variable warning

### DIFF
--- a/server/test/testFaceRestIncident.cc
+++ b/server/test/testFaceRestIncident.cc
@@ -42,8 +42,6 @@ void cut_setup(void)
 void cut_teardown(void)
 {
 	stopFaceRest();
-
-	UnifiedDataStore *dataStore = UnifiedDataStore::getInstance();
 }
 
 static void incidentInfo2StringMap(


### PR DESCRIPTION
This variable has been left since this commit: https://github.com/project-hatohol/hatohol/commit/48c950c0ea8d9fbb5162d91208cb00576d3d4901#diff-85b92f69fd18823fb7079177939e0583
Previously, cut_teardown needs to tidy up CopyOnDemand releated
settings.
But current implementation does not use CopyOnDemand related code.
It had been removed completely at #2143.