### PR TITLE
[Hap][test] Fix the broken test. (#2222)

### DIFF
--- a/server/hap2/hatohol/test/TestStandardHap.py
+++ b/server/hap2/hatohol/test/TestStandardHap.py
@@ -93,8 +93,8 @@ class TestStandardHap(unittest.TestCase):
             return self.__received_ms_info
 
     def test_normal_run(self):
-        hap = self.StandardHapTestee()
         sys.argv = [sys.argv[0], "--transporter", "EzTransporter"]
+        hap = self.StandardHapTestee()
         hap()
         hap.enable_handling_sigchld(False)
         expect_ms = haplib.MonitoringServerInfo(json.loads(EzTransporter.TEST_MONITORING_SERVER_RESULT))


### PR DESCRIPTION
The test has replaced sys.argv to hide some unittest arguments
and use a transporter for test (EzTransporter).

A recent chagange for ConfigFileParser added the partial parse
of the argument in the constructor of StandardHap. It is done
before the replacement of sys.argv. It may cause an unexpected
parse result.

This patch replaces sys.argv before it's parsed.