### PR TITLE
Hatohol tracer

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -684,7 +684,7 @@ var EventsView = function(userProfile, options) {
 
   function setupCallbacks() {
     $('#summaryAllEvents').click(function() {
-      document.location.href = "ajax_events";
+      domesticLink("ajax_events");
     });
 
     $('#summaryUnhandledImportantEvents').click(function() {
@@ -694,7 +694,7 @@ var EventsView = function(userProfile, options) {
       if (importantSeverities.length > 0)
         query.severities = importantSeverities.join(",");
 
-      document.location.href = "ajax_events?" + $.param(query);
+      domesticLink("ajax_events?" + $.param(query));
     });
 
     $('#summaryImportantEvents').click(function() {
@@ -704,7 +704,7 @@ var EventsView = function(userProfile, options) {
       if (importantSeverities.length > 0)
         query.severities = importantSeverities.join(",");
 
-      document.location.href = "ajax_events?" + $.param(query);
+      domesticLink("ajax_events?" + $.param(query));
     });
 
     $('#select-summary-filter').change(function() {

--- a/client/static/js/hatohol_navi.js
+++ b/client/static/js/hatohol_navi.js
@@ -171,8 +171,8 @@ var HatoholNavi = function(userProfile, currentPage) {
       klass = "active";
     } else {
       title = '<a href=' + menuItem.href +
-              ' onClick="hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)"'
-              + '>' + menuItem.title + '</a>';
+              ' onClick="hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)"' +
+              '>' + menuItem.title + '</a>';
       klass = undefined;
     }
 

--- a/client/static/js/hatohol_navi.js
+++ b/client/static/js/hatohol_navi.js
@@ -170,8 +170,9 @@ var HatoholNavi = function(userProfile, currentPage) {
       title = '<a>' + menuItem.title + '</a>';
       klass = "active";
     } else {
-      title = '<a href=' + menuItem.href + '>' +
-        menuItem.title + '</a>';
+      title = '<a href=' + menuItem.href +
+              ' onClick="hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)"'
+              + '>' + menuItem.title + '</a>';
       klass = undefined;
     }
 

--- a/client/static/js/hatohol_tracer.js
+++ b/client/static/js/hatohol_tracer.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Project Hatohol
+ *
+ * This file is part of Hatohol.
+ *
+ * Hatohol is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3
+ * as published by the Free Software Foundation.
+ *
+ * Hatohol is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Hatohol. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+var HatoholTracePoint = {
+  PRE_HREF_CHANGE: 0
+};
+
+var HatoholTracer = function() {
+  var self = this;
+
+  self.listeners = {};
+  for (var key in HatoholTracePoint) {
+    var tracePointId = HatoholTracePoint[key];
+    self.listeners[tracePointId] = [];
+  }
+
+  this.addListener = function(tracePointId, func) {
+    if (!(tracePointId in self.listeners))
+      throw "Unknown tracePointId: " + tracePointId;
+    self.listeners[tracePointId].push(func);
+  };
+
+  this.pass = function(tracePointId, params) {
+    if (!(tracePointId in self.listeners))
+      throw "Unknown tracePointId: " + tracePointId;
+    var listeners = self.listeners[tracePointId];
+    for (var i = 0; i < listeners.length; i++)
+        listeners[i](params);
+  };
+};
+
+var hatoholTracer = new HatoholTracer();

--- a/client/static/js/hatohol_user_profile.js
+++ b/client/static/js/hatohol_user_profile.js
@@ -52,7 +52,7 @@ var HatoholUserProfile = function(user) {
       new HatoholConnector({
         url: '/logout',
         replyCallback: function(reply, parser) {
-          document.location.href = "ajax_dashboard";
+          domesticLink("ajax_dashboard");
         },
         parseErrorCallback: hatoholErrorMsgBoxForParser
       });

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -420,10 +420,10 @@ var TriggersView = function(userProfile, options) {
       html += "<td class='" + severityClass + "'>" +
         escapeHTML(hostName) + "</td>";
       html += "<td class='" + severityClass + "'>" +
-	"<a href='ajax_events?serverId=" + escapeHTML(serverId) +
-	"&triggerId=" + escapeHTML(trigger["id"]) + "'>" +
-	escapeHTML(triggerName) +
-	"</a></td>";
+        "<a href='ajax_events?serverId=" + escapeHTML(serverId) +
+        "&triggerId=" + escapeHTML(trigger["id"]) + "'>" +
+        escapeHTML(triggerName) +
+        "</a></td>";
       html += "</tr>";
     }
 

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -421,7 +421,9 @@ var TriggersView = function(userProfile, options) {
         escapeHTML(hostName) + "</td>";
       html += "<td class='" + severityClass + "'>" +
         "<a href='ajax_events?serverId=" + escapeHTML(serverId) +
-        "&triggerId=" + escapeHTML(trigger["id"]) + "'>" +
+        "&triggerId=" + escapeHTML(trigger["id"]) + "'" +
+        " onClick='hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)'" +
+        ">" +
         escapeHTML(triggerName) +
         "</a></td>";
       html += "</tr>";

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -415,6 +415,13 @@ function sortObjectArray(obj, key, order) {
   });
 }
 
+// A utility function for the link inside the Hatohol Web
+// with calling a required tracer function.
+function domesticLink(uri) {
+  hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE);
+  document.location.href = uri;
+}
+
 (function(global) {
   function Namespace(str) {
     var spaces = str.split('.');

--- a/client/test/browser/index.html
+++ b/client/test/browser/index.html
@@ -34,6 +34,7 @@
   }
 </script>
 <script src="../../static/js/hatohol_def.js"></script>
+<script src="../../static/js/hatohol_tracer.js"></script>
 <script src="../../static/js/utils.js"></script>
 <script src="../../static/js/hatohol_message_box.js"></script>
 <script src="../../static/js/hatohol_session_manager.js"></script>
@@ -76,6 +77,7 @@
 <script src="../../static/js.plugins/hap2-nagios-ndoutils.js"></script>
 <script src="../../static/js.plugins/hap2-ceilometer.js"></script>
 <script src="../../static/js.plugins/hap2-zabbix.js"></script>
+<script src="test_hatohol_tracer.js"></script>
 <script src="test_hatohol_session_manager.js"></script>
 <script src="test_hatohol_connector.js"></script>
 <script src="test_hatohol_reply_parser.js"></script>

--- a/client/test/browser/test_hatohol_tracer.js
+++ b/client/test/browser/test_hatohol_tracer.js
@@ -1,0 +1,22 @@
+describe('HatoholTracer', function() {
+  // NOTE: In the actual use, a global object hatoholTracer
+  //       is supposed to be used.
+  it('add listener', function(done) {
+    var tracer = new HatoholTracer();
+    tracer.addListener(HatoholTracePoint.PRE_HREF_CHANGE, function(){});
+    done();
+  });
+
+  it('invoke registered lister', function(done) {
+    function cb(params) {
+      expect(params.foo).to.be(1);
+      expect(params.goo).to.be(-2);
+      done();
+    };
+    var tracer = new HatoholTracer();
+    var tracePointId = HatoholTracePoint.PRE_HREF_CHANGE;
+    tracer.addListener(tracePointId, cb);
+    tracer.pass(tracePointId, {foo:1, goo:-2});
+  });
+});
+

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -115,6 +115,7 @@
     <script src="{{ STATIC_URL }}js.external/jstz.min.js"></script>
     <script src="{{ STATIC_URL }}js.external/bootstrap.min.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_def.js"></script>
+    <script src="{{ STATIC_URL }}js/hatohol_tracer.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_message_box.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_session_manager.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_dialog.js"></script>


### PR DESCRIPTION
This patches provide a feature that calls back listers when the prefixed
trace points are invoked.

The motivation of this feature is to solve the problem #2052, in which
the intended page transition should be distinguished and allowed. 