### PR TITLE
[WebUI:All page] Close defender with hatohol-tracer

### DIFF
--- a/client/static/js/before_close.js
+++ b/client/static/js/before_close.js
@@ -1,0 +1,15 @@
+(function() {
+  "use strict";
+  var isTransitAllowed = false;
+
+  $(window).on("beforeunload",function(){
+    if (isTransitAllowed)
+      return;
+    return gettext("Hatohol is running to monitor system(s).\n" +
+    "You are trying to transition or close this page.");
+  });
+
+  hatoholTracer.addListener(HatoholTracePoint.PRE_HREF_CHANGE, function() {
+    isTransitAllowed = true;
+  });
+})();

--- a/client/viewer/base_ajax.html
+++ b/client/viewer/base_ajax.html
@@ -134,6 +134,7 @@
     <script src="{{ STATIC_URL }}js/hatohol_pager.js"></script>
     <script src="{{ STATIC_URL }}js/hatohol_version.js"></script>
     <script src="{{ STATIC_URL }}js/utils.js"></script>
+    <script src="{{ STATIC_URL }}js/before_close.js"></script>
     {% for file in plugin_js_files %}
     <script src="{{ STATIC_URL }}js.plugins/{{ file }}"></script>
     {% endfor %}


### PR DESCRIPTION
#2052 【[WebUI] ブラウザクローズの誤操作防止】
HatoholTracePoint.PRE_HREF_CHANGE 参照型
不要コード・不要ファイルが混ざったため、再PRです。