### PR TITLE
Prevent new window from opening

### DIFF
--- a/client/static/js/graphs_view.js
+++ b/client/static/js/graphs_view.js
@@ -87,7 +87,7 @@ var GraphsView = function(userProfile) {
       table += "<input class='selectcheckbox' graphID='" + graphID +
 	"' type='checkbox'></td>";
       table += "<td>" + graphID + "</td>";
-      table += "<td><a href=\"" + graphURL +  "\">" + title + "</a></td>";
+      table += "<td>" + anchorTagForDomesticLink(graphURL, title) + "</td>";
       table += "<td><a href=\"ajax_history?mode=edit&id=" + graphID + "\" " +
         "class='btn btn-default'>" + gettext("EDIT") + "</a></td>";
       table += "</tr>";

--- a/client/static/js/graphs_view.js
+++ b/client/static/js/graphs_view.js
@@ -88,8 +88,10 @@ var GraphsView = function(userProfile) {
 	"' type='checkbox'></td>";
       table += "<td>" + graphID + "</td>";
       table += "<td>" + anchorTagForDomesticLink(graphURL, title) + "</td>";
-      table += "<td><a href=\"ajax_history?mode=edit&id=" + graphID + "\" " +
-        "class='btn btn-default'>" + gettext("EDIT") + "</a></td>";
+
+      var editURL = "ajax_history?mode=edit&id=" + graphID;
+      table += "<td>" + anchorTagForDomesticLink(editURL, gettext("EDIT"),
+                                                 "btn btn-default") + "</td>";
       table += "</tr>";
     });
     return table;

--- a/client/static/js/hatohol_navi.js
+++ b/client/static/js/hatohol_navi.js
@@ -170,9 +170,7 @@ var HatoholNavi = function(userProfile, currentPage) {
       title = '<a>' + menuItem.title + '</a>';
       klass = "active";
     } else {
-      title = '<a href=' + menuItem.href +
-              ' onClick="hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)"' +
-              '>' + menuItem.title + '</a>';
+      title = anchorTagForDomesticLink(menuItem.href, menuItem.title);
       klass = undefined;
     }
 

--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -151,10 +151,7 @@ var LatestView = function(userProfile) {
   function getGraphLink(item) {
     if (!item || !item["lastValue"] || isNaN(item["lastValue"]))
       return "";
-    var link = "<a href='" + getGraphURL(item) + "'>";
-    link += gettext("Graph");
-    link += "</a>";
-    return link;
+    return anchorTagForDomesticLink(getGraphURL(item), gettext("Graph"));
   }
 
   function drawTableBody(replyData) {

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -420,12 +420,11 @@ var TriggersView = function(userProfile, options) {
       html += "<td class='" + severityClass + "'>" +
         escapeHTML(hostName) + "</td>";
       html += "<td class='" + severityClass + "'>" +
-        "<a href='ajax_events?serverId=" + escapeHTML(serverId) +
-        "&triggerId=" + escapeHTML(trigger["id"]) + "'" +
-        " onClick='hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)'" +
-        ">" +
-        escapeHTML(triggerName) +
-        "</a></td>";
+        anchorTagForDomesticLink(
+          'ajax_events?serverId=' + escapeHTML(serverId) +
+          '&triggerId=' + escapeHTML(trigger["id"]),
+          escapeHTML(triggerName));
+        + "</td>";
       html += "</tr>";
     }
 

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -422,6 +422,14 @@ function domesticLink(uri) {
   document.location.href = uri;
 }
 
+function anchorTagForDomesticLink(uri, label)
+{
+  tag = '<a href="' + uri + '"' +
+        ' onClick="domesticLink(\'' + uri + '\'); return false;"' +
+        '>' + label + '</a>';
+  return tag;
+}
+
 (function(global) {
   function Namespace(str) {
     var spaces = str.split('.');

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -422,11 +422,13 @@ function domesticLink(uri) {
   document.location.href = uri;
 }
 
-function anchorTagForDomesticLink(uri, label)
+function anchorTagForDomesticLink(uri, label, klass)
 {
   tag = '<a href="' + uri + '"' +
-        ' onClick="domesticLink(\'' + uri + '\'); return false;"' +
-        '>' + label + '</a>';
+        ' onClick="domesticLink(\'' + uri + '\'); return false;"';
+  if (klass)
+    tag += ' class="' + klass + '"';
+  tag += '>' + label + '</a>';
   return tag;
 }
 

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -632,4 +632,13 @@ describe('flags', function() {
   });
 });
 
+describe('anchorTagForDomesticLink', function() {
+  it('generates an HTML', function() {
+    var expected = '<a href="foo/x.html" ' +
+                   'onClick="domesticLink(\'foo/x.html\'); return false;">' +
+                   'link to X</a>';
+    expect(anchorTagForDomesticLink('foo/x.html', 'link to X')).to.be(expected);
+  });
+});
+
 });

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -639,6 +639,14 @@ describe('anchorTagForDomesticLink', function() {
                    'link to X</a>';
     expect(anchorTagForDomesticLink('foo/x.html', 'link to X')).to.be(expected);
   });
+
+  it('handles class parameter', function() {
+    var expected = '<a href="foo/x.html" ' +
+                   'onClick="domesticLink(\'foo/x.html\'); return false;" ' +
+                   'class="btn foo X">label</a>';
+    var actual = anchorTagForDomesticLink('foo/x.html', 'label', 'btn foo X');
+    expect(actual).to.be(expected);
+  });
 });
 
 });


### PR DESCRIPTION
Some links in WebUI such as menu items should not open an another a window
or a tab in order to prevent an expected situation.
This PR realizes it by forcing its own page transition method domesticLink().