### PR TITLE
[WebUI] Prevent internal links from opening on a new window

### DIFF
--- a/client/static/js/graphs_view.js
+++ b/client/static/js/graphs_view.js
@@ -87,7 +87,7 @@ var GraphsView = function(userProfile) {
       table += "<input class='selectcheckbox' graphID='" + graphID +
 	"' type='checkbox'></td>";
       table += "<td>" + graphID + "</td>";
-      table += "<td><a href=\"" + graphURL +  "\">" + title + "</a></td>";
+      table += "<td>" + anchorTagForDomesticLink(graphURL, title) + "</td>";
       table += "<td><a href=\"ajax_history?mode=edit&id=" + graphID + "\" " +
         "class='btn btn-default'>" + gettext("EDIT") + "</a></td>";
       table += "</tr>";

--- a/client/static/js/graphs_view.js
+++ b/client/static/js/graphs_view.js
@@ -88,8 +88,10 @@ var GraphsView = function(userProfile) {
 	"' type='checkbox'></td>";
       table += "<td>" + graphID + "</td>";
       table += "<td>" + anchorTagForDomesticLink(graphURL, title) + "</td>";
-      table += "<td><a href=\"ajax_history?mode=edit&id=" + graphID + "\" " +
-        "class='btn btn-default'>" + gettext("EDIT") + "</a></td>";
+
+      var editURL = "ajax_history?mode=edit&id=" + graphID;
+      table += "<td>" + anchorTagForDomesticLink(editURL, gettext("EDIT"),
+                                                 "btn btn-default") + "</td>";
       table += "</tr>";
     });
     return table;

--- a/client/static/js/hatohol_navi.js
+++ b/client/static/js/hatohol_navi.js
@@ -109,11 +109,13 @@ var HatoholNavi = function(userProfile, currentPage) {
       children: [
         {
           title: gettext("Online Documents"),
-          href: "http://www.hatohol.org/docs"
+          href: "http://www.hatohol.org/docs",
+          target: "_blank"
         },
         {
           title: hatohol.brandName + " " + gettext("version: ") + HATOHOL_VERSION,
-          href: "#version"
+          href: "#version",
+          showOnly: true
         },
       ]
     },
@@ -169,10 +171,16 @@ var HatoholNavi = function(userProfile, currentPage) {
     } else if (menuItem.href == self.currentPage) {
       title = '<a>' + menuItem.title + '</a>';
       klass = "active";
+    } else if (menuItem.target) {
+      title = '<a href="' + menuItem.href  + '" target="' +
+              menuItem.target + '">' + menuItem.title + '</a>';
+      klass = undefined;
+    } else if (menuItem.showOnly) {
+      title = '<a href="' + menuItem.href  + '" onclick="return false">' +
+              menuItem.title + '</a>';
+      klass = undefined;
     } else {
-      title = '<a href=' + menuItem.href +
-              ' onClick="hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)"' +
-              '>' + menuItem.title + '</a>';
+      title = anchorTagForDomesticLink(menuItem.href, menuItem.title);
       klass = undefined;
     }
 

--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -151,10 +151,7 @@ var LatestView = function(userProfile) {
   function getGraphLink(item) {
     if (!item || !item["lastValue"] || isNaN(item["lastValue"]))
       return "";
-    var link = "<a href='" + getGraphURL(item) + "'>";
-    link += gettext("Graph");
-    link += "</a>";
-    return link;
+    return anchorTagForDomesticLink(getGraphURL(item), gettext("Graph"));
   }
 
   function drawTableBody(replyData) {

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -420,12 +420,11 @@ var TriggersView = function(userProfile, options) {
       html += "<td class='" + severityClass + "'>" +
         escapeHTML(hostName) + "</td>";
       html += "<td class='" + severityClass + "'>" +
-        "<a href='ajax_events?serverId=" + escapeHTML(serverId) +
-        "&triggerId=" + escapeHTML(trigger["id"]) + "'" +
-        " onClick='hatoholTracer.pass(HatoholTracePoint.PRE_HREF_CHANGE)'" +
-        ">" +
-        escapeHTML(triggerName) +
-        "</a></td>";
+        anchorTagForDomesticLink(
+          'ajax_events?serverId=' + escapeHTML(serverId) +
+          '&triggerId=' + escapeHTML(trigger["id"]),
+          escapeHTML(triggerName));
+        + "</td>";
       html += "</tr>";
     }
 

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -422,6 +422,16 @@ function domesticLink(uri) {
   document.location.href = uri;
 }
 
+function anchorTagForDomesticLink(uri, label, klass)
+{
+  tag = '<a href="' + uri + '"' +
+        ' onclick="domesticLink(\'' + uri + '\'); return false;"';
+  if (klass)
+    tag += ' class="' + klass + '"';
+  tag += '>' + label + '</a>';
+  return tag;
+}
+
 (function(global) {
   function Namespace(str) {
     var spaces = str.split('.');

--- a/client/test/browser/test_graphs_view.js
+++ b/client/test/browser/test_graphs_view.js
@@ -116,7 +116,8 @@ describe("GraphsView", function() {
       '<input class="selectcheckbox" graphid="2" type="checkbox">' +
       '</td>' +
       '<td>2</td>' +
-      '<td><a href="ajax_history?id=2">Graph1</a></td>'
+      '<td>' + anchorTagForDomesticLink('ajax_history?id=2', 'Graph1') +
+      '</td>';
 
     respond(defaultGraphs);
     expect(view).to.be.a(GraphsView);

--- a/client/test/browser/test_hatohol_navi.js
+++ b/client/test/browser/test_hatohol_navi.js
@@ -11,6 +11,10 @@ describe('HatoholNavi', function() {
     "flags": 0
   });
 
+  function domesticAnchorList(uri, label) {
+    return '<li>' + anchorTagForDomesticLink(uri, label) + '</li>';
+  };
+
   beforeEach(function() {
     var nav = $("<ul/>").addClass("nav");
     $("body").append(nav);
@@ -37,39 +41,33 @@ describe('HatoholNavi', function() {
     var userProfile = new HatoholUserProfile(guestUser);
     var nav = new HatoholNavi(userProfile);
     var expected = '';
-    expected += '<li><a href="ajax_dashboard">' +
-      gettext('Dashboard') + '</a></li>';
-    expected += '<li><a href="ajax_overview_triggers">' +
-      gettext('Overview : Triggers') + '</a></li>';
-    expected += '<li><a href="ajax_overview_items">' +
-      gettext('Overview : Items') + '</a></li>';
-    expected += '<li><a href="ajax_latest">' +
-      gettext("Latest data") + '</a></li>';
-    expected += '<li><a href="ajax_triggers">' +
-      gettext('Triggers') + '</a></li>';
-    expected += '<li><a href="ajax_events">' +
-      gettext('Events') + '</a></li>';
+    expected += domesticAnchorList("ajax_dashboard", gettext('Dashboard'));
+    expected += domesticAnchorList("ajax_overview_triggers",
+                                   gettext('Overview : Triggers'));
+    expected += domesticAnchorList("ajax_overview_items",
+                                   gettext('Overview : Items'));
+    expected += domesticAnchorList("ajax_latest", gettext("Latest data"));
+    expected += domesticAnchorList("ajax_triggers", gettext('Triggers'));
+    expected += domesticAnchorList("ajax_events", gettext('Events'));
     expected += '<li class="dropdown">';
     expected += '<a href="#" class="dropdown-toggle" data-toggle="dropdown">' +
       'Settings<span class="caret"></span></a>';
     expected += '<ul class="dropdown-menu">';
-    expected += '<li><a href="ajax_servers">' +
-      gettext('Monitoring Servers') + '</a></li>';
-    expected += '<li><a href="ajax_actions">' +
-      gettext('Actions') + '</a></li>';
-    expected += '<li><a href="ajax_graphs">' +
-      gettext('Graphs') + '</a></li>';
-    expected += '<li><a href="ajax_log_search_systems">' +
-      gettext('Log search systems') + '</a></li>';
+    expected += domesticAnchorList("ajax_servers",
+                                   gettext('Monitoring Servers'));
+    expected += domesticAnchorList("ajax_actions", gettext('Actions'));
+    expected += domesticAnchorList("ajax_graphs", gettext('Graphs'));
+    expected += domesticAnchorList("ajax_log_search_systems",
+                                   gettext('Log search systems'));
     expected += '</ul></li>';
     expected += '<li class="dropdown">';
     expected += '<a href="#" class="dropdown-toggle" data-toggle="dropdown">' +
       'Help<span class="caret"></span></a>';
     expected += '<ul class="dropdown-menu">';
-    expected += '<li><a href="http://www.hatohol.org/docs">' +
-      gettext('Online Documents') + '</a></li>';
-    expected += '<li><a href="#version">' +
-      gettext('Hatohol version: ') + HATOHOL_VERSION + '</a></li>';
+    expected += '<li><a href="http://www.hatohol.org/docs" target="_blank">' +
+                gettext('Online Documents') + '</a></li>';
+    expected += '<li><a href="#version" onclick="return false">' +
+                gettext('Hatohol version: ') + HATOHOL_VERSION + '</a></li>';
     expected += '</ul></li>';
 
     expect($("ul.nav")[0].innerHTML).to.be(expected);
@@ -79,39 +77,34 @@ describe('HatoholNavi', function() {
     var nav = new HatoholNavi(guestUser, "ajax_latest");
     var expected = '';
 
-    expected += '<li><a href="ajax_dashboard">' +
-      gettext('Dashboard') + '</a></li>';
-    expected += '<li><a href="ajax_overview_triggers">' +
-      gettext('Overview : Triggers') + '</a></li>';
-    expected += '<li><a href="ajax_overview_items">' +
-      gettext('Overview : Items') + '</a></li>';
+    expected += domesticAnchorList("ajax_dashboard", gettext('Dashboard'));
+    expected += domesticAnchorList("ajax_overview_triggers",
+                                   gettext('Overview : Triggers'));
+    expected += domesticAnchorList("ajax_overview_items",
+                                   gettext('Overview : Items'));
     expected += '<li class="active"><a>' +
       gettext('Latest data') + '</a></li>';
-    expected += '<li><a href="ajax_triggers">' +
-      gettext('Triggers') + '</a></li>';
-    expected += '<li><a href="ajax_events">' +
-      gettext('Events') + '</a></li>';
+    expected += domesticAnchorList("ajax_triggers", gettext('Triggers'));
+    expected += domesticAnchorList("ajax_events", gettext('Events'));
     expected += '<li class="dropdown">';
     expected += '<a href="#" class="dropdown-toggle" data-toggle="dropdown">' +
       'Settings<span class="caret"></span></a>';
     expected += '<ul class="dropdown-menu">';
-    expected += '<li><a href="ajax_servers">' +
-      gettext('Monitoring Servers') + '</a></li>';
-    expected += '<li><a href="ajax_actions">' +
-      gettext('Actions') + '</a></li>';
-    expected += '<li><a href="ajax_graphs">' +
-      gettext('Graphs') + '</a></li>';
-    expected += '<li><a href="ajax_log_search_systems">' +
-      gettext('Log search systems') + '</a></li>';
+    expected += domesticAnchorList("ajax_servers",
+                                   gettext('Monitoring Servers'));
+    expected += domesticAnchorList("ajax_actions", gettext('Actions'));
+    expected += domesticAnchorList("ajax_graphs", gettext('Graphs'));
+    expected += domesticAnchorList("ajax_log_search_systems",
+                                   gettext('Log search systems'));
     expected += '</ul></li>';
     expected += '<li class="dropdown">';
     expected += '<a href="#" class="dropdown-toggle" data-toggle="dropdown">' +
       'Help<span class="caret"></span></a>';
     expected += '<ul class="dropdown-menu">';
-    expected += '<li><a href="http://www.hatohol.org/docs">' +
-      gettext('Online Documents') + '</a></li>';
-    expected += '<li><a href="#version">' +
-      gettext('Hatohol version: ') + HATOHOL_VERSION + '</a></li>';
+    expected += '<li><a href="http://www.hatohol.org/docs" target="_blank">' +
+                gettext('Online Documents') + '</a></li>';
+    expected += '<li><a href="#version" onclick="return false">' +
+                gettext('Hatohol version: ') + HATOHOL_VERSION + '</a></li>';
     expected += '</ul></li>';
 
     expect($("ul.nav")[0].innerHTML).to.be(expected);

--- a/client/test/browser/test_latest_view.js
+++ b/client/test/browser/test_latest_view.js
@@ -132,7 +132,7 @@ describe('LatestView', function() {
       formatDate(1415232279) +
       '</td>' +
       '<td>54.28 %</td>' +
-      '<td><a href="' + historyURL + '">Graph</a></td>';
+      '<td>' + anchorTagForDomesticLink(historyURL, 'Graph') + '</td>';
     respond('{}', itemsJson(defaultItems, defaultServers));
     expect($('#table')).to.have.length(1);
     expect($('tr')).to.have.length(defaultItems.length + 1);

--- a/client/test/browser/test_triggers_view.js
+++ b/client/test/browser/test_triggers_view.js
@@ -254,7 +254,9 @@ describe('TriggersView', function() {
       formatDate(1422584694) +
       '</td>' +
       '<td class="">Zabbix_SELF</td>' +
-      '<td class=""><a href="' + eventURL + '">Failed in connecting to Zabbix.</a></td>';
+      '<td class="">' +
+      anchorTagForDomesticLink(eventURL, 'Failed in connecting to Zabbix.') +
+      '</td>';
     respond(triggersJson(defaultTriggers, defaultServers));
     expect($('#table')).to.have.length(1);
     expect($('tr')).to.have.length(defaultTriggers.length + 1);
@@ -270,7 +272,10 @@ describe('TriggersView', function() {
       '<td class="status0" data-sort-value="0">OK</td>' +
       '<td class="" data-sort-value="0">-</td>' +
       '<td class="">Host2</td>' +
-      '<td class=""><a href="' + eventURL + '">Host name of zabbix_agentd was changed on TestHost0</a></td>';
+      '<td class="">' +
+      anchorTagForDomesticLink(
+        eventURL, 'Host name of zabbix_agentd was changed on TestHost0') +
+      '</td>';
     respond(triggersJson(defaultTriggers, defaultServers), "{}", "{}");
     expect($('#table')).to.have.length(1);
     expect($('tr')).to.have.length(defaultTriggers.length + 1);

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -632,4 +632,21 @@ describe('flags', function() {
   });
 });
 
+describe('anchorTagForDomesticLink', function() {
+  it('generates an HTML', function() {
+    var expected = '<a href="foo/x.html" ' +
+                   'onclick="domesticLink(\'foo/x.html\'); return false;">' +
+                   'link to X</a>';
+    expect(anchorTagForDomesticLink('foo/x.html', 'link to X')).to.be(expected);
+  });
+
+  it('handles class parameter', function() {
+    var expected = '<a href="foo/x.html" ' +
+                   'onclick="domesticLink(\'foo/x.html\'); return false;" ' +
+                   'class="btn foo X">label</a>';
+    var actual = anchorTagForDomesticLink('foo/x.html', 'label', 'btn foo X');
+    expect(actual).to.be(expected);
+  });
+});
+
 });


### PR DESCRIPTION
Some links in WebUI such as menu items should not open an another a window
or a tab in order to prevent an expected situation.

This PR realizes it by forcing its own page transition method domesticLink().

NOTE: This is the fixed version of #2229