### PR TITLE
[hap2] Unify "HAPI2" notation

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -394,7 +394,7 @@ class Common:
     def __parse_alarm_host(self, threshold_rule):
         # TODO [long term]
         # we should handle the case many hosts are involved in the alarm.
-        # HAPI2.0 handles only one host for every trigger.
+        # HAPI2 handles only one host for every trigger.
         # To do solve this problem, we have to extend the HAPI specifiation.
         query_array = threshold_rule.get("query")
         if query_array is None:

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -165,7 +165,7 @@ class Common:
         if host_ids is not None and not self.__validate_object_ids(host_ids):
             logger.error("Invalid: host_ids: %s" % host_ids)
             # TODO by 15.09 (*1): send error
-            # There's no definition to send error in HAPI 2.0.
+            # There's no definition to send error in HAPI2.
             # We have to extend the specification to enable this.
             return
 

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -188,7 +188,7 @@ class Hap2ZabbixAPIMain(haplib.BaseMainPlugin, ZabbixAPIConductor):
     def hap_fetch_events(self, params, request_id):
         count = params["count"]
         if count > MAX_NUMBER_OF_EVENTS_OF_HAPI2:
-            error_msg = "%d count exceeds the limit of the HAPI2.0 specification." % count
+            error_msg = "%d count exceeds the limit of the HAPI2 specification." % count
             logger.error(error_msg)
             self.hap_return_error(error_msg, request_id)
             return

--- a/server/hap2/hatohol/hapcommon.py
+++ b/server/hap2/hatohol/hapcommon.py
@@ -27,11 +27,11 @@ from datetime import timedelta
 
 def translate_unix_time_to_hatohol_time(unix_time, ns=0):
     """
-    Translate unix_time into a time string of HAPI 2.0.
+    Translate unix_time into a time string of HAPI2.
 
     @param unix_time An unix time (integer or string).
     @param ns A nanosecnd part of the time (integer or string).
-    @return A timestamp string in HAPI2.0
+    @return A timestamp string in HAPI2
     """
     utc_time = time.gmtime(int(unix_time))
     hatohol_time = time.strftime("%Y%m%d%H%M%S", utc_time)
@@ -74,10 +74,10 @@ def get_current_hatohol_time():
 
 def conv_to_hapi_time(date_time, offset=timedelta()):
     """
-    Convert a datetime object to a string formated for HAPI
+    Convert a datetime object to a string formated for HAPI2
     @param date_time A datatime object
     @param offset    An offset to the time
-    @return A string of the date and time in HAPI2.0
+    @return A string of the date and time in HAPI2
     """
     adjust_time = date_time + offset
     return adjust_time.strftime("%Y%m%d%H%M%S.") \

--- a/server/hap2/hatohol/simple_caller.py
+++ b/server/hap2/hatohol/simple_caller.py
@@ -114,7 +114,7 @@ class SimpleCaller:
 
 
 if __name__ == '__main__':
-    prog_name = "Simple Caller for HAPI 2.0"
+    prog_name = "Simple Caller for HAPI2"
     args, transporter_args = simple_server.basic_setup(SimpleCaller.arg_def,
                                                        prog_name=prog_name)
     caller = SimpleCaller(transporter_args)

--- a/server/hap2/hatohol/simple_server.py
+++ b/server/hap2/hatohol/simple_server.py
@@ -203,7 +203,7 @@ class SimpleServer:
         self.__sender.response(result, call_id)
 
 
-def basic_setup(arg_def_func=None, prog_name="Simple Server for HAPI 2.0"):
+def basic_setup(arg_def_func=None, prog_name="Simple Server for HAPI2"):
     parser = argparse.ArgumentParser()
     transporter_manager = transporter.Manager(DEFAULT_TRANSPORTER)
     transporter_manager.define_arguments(parser)

--- a/server/hap2/hatohol/transporter.py
+++ b/server/hap2/hatohol/transporter.py
@@ -31,7 +31,7 @@ logger = getLogger("hatohol.transporter:%s" % hapcommon.get_top_file_name())
 
 class Transporter:
     """
-    An abstract class for transportation of RPC messages for HAPI-2.0.
+    An abstract class for transportation of RPC messages for HAPI2.
     """
     def __init__(self):
         self.__receiver = None


### PR DESCRIPTION
Let's use `HAPI2` notation.

ref: https://github.com/project-hatohol/HAPI-2.0-Specification/pull/80/files#diff-04c6e90faac2675aa89e2176d2eec7d8R5