### PR TITLE
監視サーバ―追加の際、監視サーバータイプに「Zabbix (HAPI2)」を選択した場合に実施する手順への追加と、ブローカーURLへの記述内容についての簡単な解説を追記しました。

### DIFF
--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -98,8 +98,15 @@ via pip with the following command:
 
 ### HAP2 Zabbix
 
+You need to install hatohol-hap2-zabbix with following command on CentOS 7:
+
+    # yum install -y hatohol-hap2-zabbix
+
 You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
 "Zabbix API URL" instead of `<servername or ip>` simply.
+
+Also you have to input `amqp://<user>:<password>@hostname/<vhost>` into BrokerURL.
+These parameter should be replaced string that you input command for `$ sudo rabbitmqctl add_(user|vhost)`.
 
 ### HAP2 Nagios Livestatus
 


### PR DESCRIPTION
監視サーバ―追加の際、監視サーバータイプに「Zabbix (HAPI2)」を選択した場合に実施する手順への追加と、ブローカーURLへの記述内容についての簡単な解説を追記しました。