### PR TITLE
16.04 releng/tsatoh hap2 doc

### DIFF
--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -106,7 +106,7 @@ You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
 "Zabbix API URL" instead of `<servername or ip>` simply.
 
 Also you have to input `amqp://<user>:<password>@hostname/<vhost>` into BrokerURL.
-These parameter should be replaced string that you input command for `$ sudo rabbitmqctl add_(user|vhost)`. If you execute commands same as in this document, you should input `qmqp://hatohol:hatohol@localhost/hatohol`.
+These parameter should be replaced string that you input command for `$ sudo rabbitmqctl add_(user|vhost)`. If you execute commands same as in this document, you should input `amqp://hatohol:hatohol@localhost/hatohol`.
 
 ### HAP2 Nagios Livestatus
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -98,8 +98,15 @@ via pip with the following command:
 
 ### HAP2 Zabbix
 
+You need to install hatohol-hap2-zabbix with following command on CentOS 7:
+
+    # yum install -y hatohol-hap2-zabbix
+
 You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
 "Zabbix API URL" instead of `<servername or ip>` simply.
+
+Also you have to input `amqp://<user>:<password>@hostname/<vhost>` into BrokerURL.
+These parameter should be replaced string that you input command for `$ sudo rabbitmqctl add_(user|vhost)`. If you execute commands same as in this document, you should input `qmqp://hatohol:hatohol@localhost/hatohol`.
 
 ### HAP2 Nagios Livestatus
 

--- a/doc/server/hap2/HowToUse.md
+++ b/doc/server/hap2/HowToUse.md
@@ -98,15 +98,8 @@ via pip with the following command:
 
 ### HAP2 Zabbix
 
-You need to install hatohol-hap2-zabbix with following command on CentOS 7:
-
-    # yum install -y hatohol-hap2-zabbix
-
 You should input `http://<servername or ip>/zabbix/api_jsonrpc.php` into
 "Zabbix API URL" instead of `<servername or ip>` simply.
-
-Also you have to input `amqp://<user>:<password>@hostname/<vhost>` into BrokerURL.
-These parameter should be replaced string that you input command for `$ sudo rabbitmqctl add_(user|vhost)`. If you execute commands same as in this document, you should input `qmqp://hatohol:hatohol@localhost/hatohol`.
 
 ### HAP2 Nagios Livestatus
 


### PR DESCRIPTION
Add a necessary command for install a package and a description for BrokerURL 
For using "Zabbix (HAPI2)" as monitoring server type, I had to install
hatohol-hap2-zabbix. And I thought some description was necessary for
BrokerURL, so I add it and an example.