### PR TITLE
[Do not merge][systemd][hap2] Generate unit files for hap2 plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,11 +35,11 @@ Makefile.in
 /data/systemd/generate_service_file.sh
 /data/systemd/hatohol.service
 /data/systemd/generate_hap2_service_file.sh
-/data/systemd/hap2_zabbix_api.service
-/data/systemd/hap2_ceilometer.service
-/data/systemd/hap2_fluentd.service
-/data/systemd/hap2_nagios_ndoutils.service
-/data/systemd/hap2_nagios_livestatus.service
+/data/systemd/hap2-zabbix-api.service
+/data/systemd/hap2-ceilometer.service
+/data/systemd/hap2-fluentd.service
+/data/systemd/hap2-nagios-ndoutils.service
+/data/systemd/hap2-nagios-livestatus.service
 /depcomp
 /hatohol.spec
 /install-sh

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ Makefile.in
 /data/init.d/debian/hatohol.debian
 /data/systemd/generate_service_file.sh
 /data/systemd/hatohol.service
+/data/systemd/generate_hap2_service_file.sh
+/data/systemd/hap2_zabbix_api.service
+/data/systemd/hap2_ceilometer.service
+/data/systemd/hap2_fluentd.service
+/data/systemd/hap2_nagios_ndoutils.service
+/data/systemd/hap2_nagios_livestatus.service
 /depcomp
 /hatohol.spec
 /install-sh

--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,7 @@ data/init.d/centos/hatohol.centos
 data/init.d/centos/Makefile
 data/systemd/Makefile
 data/systemd/generate_service_file.sh
+data/systemd/generate_hap2_service_file.sh
 data/test/Makefile
 server/Makefile
 server/mlpl/Makefile

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,8 +1,29 @@
 initscript_DATA = \
 	hatohol.service \
-	hatohol.conf
+	hatohol.conf \
+	hap2_zabbix_api.service \
+	hap2_nagios_ndoutils.service \
+	hap2_nagios_livestatus.service \
+	hap2_ceilometer.service \
+	hap2_fluentd.service
 
 hatohol.service:
 	sh generate_service_file.sh > hatohol.service
+hap2_zabbix_api.service:
+	DESC="HAP2 for Zabbix API" HAP2_PLUGIN="zabbix_api" CONF_NAME_SUFFIX="zabbix-api" \
+	sh generate_hap2_service_file.sh > hap2_zabbix_api.service
+hap2_nagios_ndoutils.service:
+	DESC="HAP2 for Nagios Ndoutils" HAP2_PLUGIN="nagios_ndoutils" CONF_NAME_SUFFIX="nagios-ndoutils" \
+	sh generate_hap2_service_file.sh > hap2_nagios_ndoutils.service
+hap2_nagios_livestatus.service:
+	DESC="HAP2 for Nagios Livestatus" HAP2_PLUGIN="nagios_livestatus" CONF_NAME_SUFFIX="nagios-livestatus" \
+	sh generate_hap2_service_file.sh > hap2_nagios_livestatus.service
+hap2_ceilometer.service:
+	DESC="HAP2 for Ceilometer" HAP2_PLUGIN="ceilometer" CONF_NAME_SUFFIX="ceilometer" \
+	sh generate_hap2_service_file.sh > hap2_ceilometer.service
+hap2_fluentd.service:
+	DESC="HAP2 for Fluentd" HAP2_PLUGIN="fluentd" CONF_NAME_SUFFIX="fluentd" \
+	sh generate_hap2_service_file.sh > hap2_fluentd.service
+
 initscriptdir = $(pkgdatadir)
 EXTRA_DIST = hatohol.conf

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,29 +1,29 @@
 initscript_DATA = \
 	hatohol.service \
 	hatohol.conf \
-	hap2_zabbix_api.service \
-	hap2_nagios_ndoutils.service \
-	hap2_nagios_livestatus.service \
-	hap2_ceilometer.service \
-	hap2_fluentd.service
+	hap2-zabbix-api.service \
+	hap2-nagios-ndoutils.service \
+	hap2-nagios-livestatus.service \
+	hap2-ceilometer.service \
+	hap2-fluentd.service
 
 hatohol.service:
 	sh generate_service_file.sh > hatohol.service
-hap2_zabbix_api.service:
+hap2-zabbix-api.service:
 	DESC="HAP2 for Zabbix API" HAP2_PLUGIN="zabbix_api" CONF_NAME_SUFFIX="zabbix-api" \
-	sh generate_hap2_service_file.sh > hap2_zabbix_api.service
-hap2_nagios_ndoutils.service:
+	sh generate_hap2_service_file.sh > hap2-zabbix-api.service
+hap2-nagios-ndoutils.service:
 	DESC="HAP2 for Nagios Ndoutils" HAP2_PLUGIN="nagios_ndoutils" CONF_NAME_SUFFIX="nagios-ndoutils" \
-	sh generate_hap2_service_file.sh > hap2_nagios_ndoutils.service
-hap2_nagios_livestatus.service:
+	sh generate_hap2_service_file.sh > hap2-nagios-ndoutils.service
+hap2-nagios-livestatus.service:
 	DESC="HAP2 for Nagios Livestatus" HAP2_PLUGIN="nagios_livestatus" CONF_NAME_SUFFIX="nagios-livestatus" \
-	sh generate_hap2_service_file.sh > hap2_nagios_livestatus.service
-hap2_ceilometer.service:
+	sh generate_hap2_service_file.sh > hap2-nagios-livestatus.service
+hap2-ceilometer.service:
 	DESC="HAP2 for Ceilometer" HAP2_PLUGIN="ceilometer" CONF_NAME_SUFFIX="ceilometer" \
-	sh generate_hap2_service_file.sh > hap2_ceilometer.service
-hap2_fluentd.service:
+	sh generate_hap2_service_file.sh > hap2-ceilometer.service
+hap2-fluentd.service:
 	DESC="HAP2 for Fluentd" HAP2_PLUGIN="fluentd" CONF_NAME_SUFFIX="fluentd" \
-	sh generate_hap2_service_file.sh > hap2_fluentd.service
+	sh generate_hap2_service_file.sh > hap2-fluentd.service
 
 initscriptdir = $(pkgdatadir)
 EXTRA_DIST = hatohol.conf

--- a/data/systemd/generate_hap2_service_file.sh.in
+++ b/data/systemd/generate_hap2_service_file.sh.in
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+exec_prefix=@exec_prefix@
+prefix=@prefix@
+sysconfdir=@expanded_sysconfdir@
+
+cat << EOF
+[Unit]
+Description=${DESC}
+Wants=network-online.target
+After=syslog.target network-online.target
+
+[Service]
+Type=simple
+KillMode=process
+Environment=LOG_CONF=${sysconfdir}/hatohol/hap2-logging.conf
+Environment=HAPI_AMQP_BROKER=rabbitmq
+EnvironmentFile=${sysconfdir}/sysconfig/hap2-${CONF_NAME_SUFFIX}
+ExecStart=${prefix}/libexec/hatohol/hap2/hatohol/hap2_${HAP2_PLUGIN}.py --log-conf=\${LOG_CONF} --amqp-broker=\${HAPI_AMQP_BROKER} --amqp-vhost=\${HAPI_AMQP_VHOST} --amqp-queue=\${HAPI_AMQP_QUEUE} --amqp-user=\${HAPI_AMQP_USER}
+
+[Install]
+WantedBy=multi-user.target
+EOF

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -318,7 +318,7 @@ rm -rf %{buildroot}
 
 %files hap2-zabbix
 %{_datadir}/hatohol/sql/90-server-type-hap2-zabbix.sql
-%{_datadir}/hatohol/hap2-zabbix_api.service
+%{_datadir}/hatohol/hap2-zabbix-api.service
 %{python_sitelib}/hatohol/zabbixapi.py
 %{python_sitelib}/hatohol/zabbixapi.pyc
 %{python_sitelib}/hatohol/zabbixapi.pyo

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -318,6 +318,7 @@ rm -rf %{buildroot}
 
 %files hap2-zabbix
 %{_datadir}/hatohol/sql/90-server-type-hap2-zabbix.sql
+%{_datadir}/hatohol/hap2_zabbix_api.service
 %{python_sitelib}/hatohol/zabbixapi.py
 %{python_sitelib}/hatohol/zabbixapi.pyc
 %{python_sitelib}/hatohol/zabbixapi.pyo
@@ -328,6 +329,7 @@ rm -rf %{buildroot}
 
 %files hap2-nagios-ndoutils
 %{_datadir}/hatohol/sql/90-server-type-hap2-nagios-ndoutils.sql
+%{_datadir}/hatohol/hap2_nagios_ndoutils.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-nagios-ndoutils.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_ndoutils.pyc
@@ -335,6 +337,7 @@ rm -rf %{buildroot}
 
 %files hap2-nagios-livestatus
 %{_datadir}/hatohol/sql/90-server-type-hap2-nagios-livestatus.sql
+%{_datadir}/hatohol/hap2_nagios_livestatus.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-nagios-livestatus.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_livestatus.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_livestatus.pyc
@@ -342,6 +345,7 @@ rm -rf %{buildroot}
 
 %files hap2-fluentd
 %{_datadir}/hatohol/sql/90-server-type-hap2-fluentd.sql
+%{_datadir}/hatohol/hap2_fluentd.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-fluentd.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_fluentd.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_fluentd.pyc
@@ -349,6 +353,7 @@ rm -rf %{buildroot}
 
 %files hap2-ceilometer
 %{_datadir}/hatohol/sql/90-server-type-hap2-ceilometer.sql
+%{_datadir}/hatohol/hap2_ceilometer.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-ceilometer.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_ceilometer.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_ceilometer.pyc

--- a/hatohol.spec.in
+++ b/hatohol.spec.in
@@ -318,7 +318,7 @@ rm -rf %{buildroot}
 
 %files hap2-zabbix
 %{_datadir}/hatohol/sql/90-server-type-hap2-zabbix.sql
-%{_datadir}/hatohol/hap2_zabbix_api.service
+%{_datadir}/hatohol/hap2-zabbix_api.service
 %{python_sitelib}/hatohol/zabbixapi.py
 %{python_sitelib}/hatohol/zabbixapi.pyc
 %{python_sitelib}/hatohol/zabbixapi.pyo
@@ -329,7 +329,7 @@ rm -rf %{buildroot}
 
 %files hap2-nagios-ndoutils
 %{_datadir}/hatohol/sql/90-server-type-hap2-nagios-ndoutils.sql
-%{_datadir}/hatohol/hap2_nagios_ndoutils.service
+%{_datadir}/hatohol/hap2-nagios-ndoutils.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-nagios-ndoutils.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_ndoutils.pyc
@@ -337,7 +337,7 @@ rm -rf %{buildroot}
 
 %files hap2-nagios-livestatus
 %{_datadir}/hatohol/sql/90-server-type-hap2-nagios-livestatus.sql
-%{_datadir}/hatohol/hap2_nagios_livestatus.service
+%{_datadir}/hatohol/hap2-nagios-livestatus.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-nagios-livestatus.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_livestatus.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_nagios_livestatus.pyc
@@ -345,7 +345,7 @@ rm -rf %{buildroot}
 
 %files hap2-fluentd
 %{_datadir}/hatohol/sql/90-server-type-hap2-fluentd.sql
-%{_datadir}/hatohol/hap2_fluentd.service
+%{_datadir}/hatohol/hap2-fluentd.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-fluentd.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_fluentd.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_fluentd.pyc
@@ -353,7 +353,7 @@ rm -rf %{buildroot}
 
 %files hap2-ceilometer
 %{_datadir}/hatohol/sql/90-server-type-hap2-ceilometer.sql
-%{_datadir}/hatohol/hap2_ceilometer.service
+%{_datadir}/hatohol/hap2-ceilometer.service
 %{_libexecdir}/hatohol/hap2/start-stop-hap2-ceilometer.sh
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_ceilometer.py
 %{_libexecdir}/hatohol/hap2/hatohol/hap2_ceilometer.pyc


### PR DESCRIPTION
Because `prefix` and `syscondir` is a possibility to differ in each of building environment.
So, we should generate units files in building time.

Related to #2270.