### PR TITLE
[hap2] Fix a typo

### DIFF
--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -612,7 +612,7 @@ class HapiProcessor:
             if pm.message_dict["result"] == "FAILURE":
                 msg = "Got 'FAILURE' repsponse. req: " + str(request_id)
                 logger.error(msg)
-                return Exception(msg)
+                raise Exception(msg)
             return pm.message_dict["result"]
 
         except ValueError as exception:


### PR DESCRIPTION
```log
return ->
raise
```

`return` and `raise` are confusable appearance... :cold_sweat: 