### PR TITLE
[hap2] Convert ndoutils port number correctly

### DIFF
--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -113,7 +113,7 @@ class Common:
 
         colon_idx = server.find(":")
         if colon_idx >= 0:
-            port = server[colon_idx+1:]
+            port = int(server[colon_idx+1:])
             server = server[0:colon_idx]
 
         return server, port, database


### PR DESCRIPTION
Some users want to change DB listening port from 3306 and it should
convert parsed port variable's type into `int` from `str`.

Otherwise, the following exception is raised:

```log
Plugin Error: <type 'exceptions.TypeError'>, an integer is required
```