### PR TITLE
 [hap2][nagios-livestatus] Convert ndoutils port number correctly

### DIFF
--- a/server/hap2/hatohol/hap2_nagios_livestatus.py
+++ b/server/hap2/hatohol/hap2_nagios_livestatus.py
@@ -84,7 +84,7 @@ class Common:
             path = url
             return path, None
         else:
-            port = url[colon_idx+1:]
+            port = int(url[colon_idx+1:])
             server = url[0:colon_idx]
             return server, port
 


### PR DESCRIPTION
`mk_livestatus` uses `socket` module internally.

It uses `socket#connect` like this: https://github.com/arthru/python-mk-livestatus/blob/master/mk_livestatus/livestatus.py#L58-L61

`socket#connect` seems to require `("ip address", integer value of port_number)` tuple: https://docs.python.org/2.7/howto/sockets.html#creating-a-socket.

We should fix it by similar approach like #2292.