### PR TITLE
[hap2][nagios_ndoutils] Fix global name is not defined error

### DIFF
--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -289,7 +289,7 @@ class Common:
 
             hapi_event_type = self.EVENT_TYPE_MAP.get(state)
             if hapi_event_type is None:
-                log.warning("Unknown status: " + str(status))
+                logger.warning("Unknown state: " + str(state))
                 hapi_event_type = "UNKNOWN"
 
             hapi_status, hapi_severity = \


### PR DESCRIPTION
hap2_nagios_ndoutils.py complains the following flood of errors:

```log
ERROR:hatohol.hap:hap2_nagios_ndoutils.py:Poller:hap.py:96:26318:Unexpected error: <type 'exceptions.NameError'>, global name 'log' is not defined
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/hatohol/haplib.py", line 1123, in __poll_in_try_block
    self.poll()
  File "/usr/local/lib/python2.7/dist-packages/hatohol/haplib.py", line 1066, in poll
    action()
  File "/usr/local/libexec/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py", line 374, in poll_events
    self.collect_events_and_put()
  File "/usr/local/libexec/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py", line 292, in collect_events_and_put
    logger.warning("Unknown status: " + str(status))
NameError: global name 'log' is not defined
...
ERROR:hatohol.hap:hap2_nagios_ndoutils.py:Poller:hap.py:96:29412:Unexpected error: <type 'exceptions.NameError'>, global name 'status' is not defined
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/hatohol/haplib.py", line 1123, in __poll_in_try_block
    self.poll()
  File "/usr/local/lib/python2.7/dist-packages/hatohol/haplib.py", line 1066, in poll
    action()
  File "/usr/local/libexec/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py", line 374, in poll_events
    self.collect_events_and_put()
  File "/usr/local/libexec/hatohol/hap2/hatohol/hap2_nagios_ndoutils.py", line 292, in collect_events_and_put
    logger.warning("Unknown status: " + str(status))
NameError: global name 'status' is not defined
```