### PR TITLE
[HatoholMonitoringView] Fix a wrong query name

### DIFF
--- a/client/static/js/hatohol_monitoring_view.js
+++ b/client/static/js/hatohol_monitoring_view.js
@@ -503,7 +503,7 @@ HatoholMonitoringView.prototype.setupHostFilters = function(servers, query, with
     if (query.hostname === "") {
       $("#select-hostname").val("");
     } else {
-      $("#select-hostname").val(query.hostName);
+      $("#select-hostname").val(query.hostname);
     }
   }
 


### PR DESCRIPTION
This typo causes the problem that hostname query does not restore
correctly after filtering.
host'N'name should be hostname.
Otherwise, $("#select-hostname").val(query.hostName) sets empty string
into the specified selectbox.