### PR TITLE
[item][zabbix] Correspond to zabbix 3.0

### DIFF
--- a/client/static/js.plugins/hap2-zabbix.js
+++ b/client/static/js.plugins/hap2-zabbix.js
@@ -21,7 +21,7 @@
     if (!url)
       return undefined;
 
-    url += "history.php?action=showgraph&itemid=" + itemId;
+    url += "history.php?action=showgraph&itemid=" + itemId + "&itemids%5B%5D=" + itemId;
     return url;
   };
 

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -104,10 +104,6 @@ var EventsView = function(userProfile, options) {
       header: gettext("Status"),
       body: renderTableDataEventType,
     },
-    "status": {
-      header: gettext("Current trigger status"),
-      body: renderTableDataTriggerStatus,
-    },
     "severity": {
       header: gettext("Severity"),
       body: renderTableDataEventSeverity,

--- a/client/test/browser/test_hap2_zabbix.js
+++ b/client/test/browser/test_hap2_zabbix.js
@@ -29,7 +29,7 @@ describe('hap2_zabbix', function() {
 
   it('getItemGraphURL', function() {
     var plugin = getPlugin();
-    var expected = "http://www.example.com/zabbix/history.php?action=showgraph&itemid=911";
+    var expected = "http://www.example.com/zabbix/history.php?action=showgraph&itemid=911&amp;itemids%5B%5D=911";
     expect(plugin.getItemGraphURL(server, 911)).to.be(expected);
   });
 });

--- a/client/test/browser/test_hap2_zabbix.js
+++ b/client/test/browser/test_hap2_zabbix.js
@@ -29,7 +29,7 @@ describe('hap2_zabbix', function() {
 
   it('getItemGraphURL', function() {
     var plugin = getPlugin();
-    var expected = "http://www.example.com/zabbix/history.php?action=showgraph&itemid=911&amp;itemids%5B%5D=911";
+    var expected = "http://www.example.com/zabbix/history.php?action=showgraph&itemid=911&itemids%5B%5D=911";
     expect(plugin.getItemGraphURL(server, 911)).to.be(expected);
   });
 });

--- a/client/test/browser/test_latest_view.js
+++ b/client/test/browser/test_latest_view.js
@@ -121,7 +121,7 @@ describe('LatestView', function() {
 
   it('Float item', function() {
     var view = new LatestView(getOperator());
-    var zabbixURL = "http://192.168.1.100/zabbix/history.php?action=showgraph&amp;itemid=1";
+    var zabbixURL = "http://192.168.1.100/zabbix/history.php?action=showgraph&amp;itemid=1&amp;itemids%5B%5D=1";
     var historyURL= "ajax_history?serverId=1&amp;hostId=10101&amp;itemId=1";
     var expected =
       '<td>Zabbix</td>' +
@@ -141,7 +141,7 @@ describe('LatestView', function() {
 
   it('String item', function() {
     var view = new LatestView(getOperator());
-    var zabbixURL = "http://192.168.1.100/zabbix/history.php?action=showgraph&amp;itemid=2";
+    var zabbixURL = "http://192.168.1.100/zabbix/history.php?action=showgraph&amp;itemid=2&amp;itemids%5B%5D=2";
     var expected =
       '<td>Zabbix</td>' +
       '<td>Host1</td>' +

--- a/client/test/browser/test_utils.js
+++ b/client/test/browser/test_utils.js
@@ -140,7 +140,7 @@ describe('getItemGraphLocation', function() {
     };
     var itemId = 1129;
     var expected =
-      "http://127.0.0.1/zabbix/history.php?action=showgraph&amp;itemid=1129";
+      "http://127.0.0.1/zabbix/history.php?action=showgraph&amp;itemid=1129&amp;itemids%5B%5D=1129";
     expect(getItemGraphLocation(server, itemId)).to.be(expected);
   });
 


### PR DESCRIPTION
2.x uses a query as ”itemid=” but 3.0 uses "itemids[]=".
This PR resolve it to use the both in one URL.