### PR TITLE
Put empty contents

### DIFF
--- a/server/hap2/hatohol/hap2_ceilometer.py
+++ b/server/hap2/hatohol/hap2_ceilometer.py
@@ -185,8 +185,14 @@ class Common:
 
         self.__alarm_cache_has_all = (host_ids is None)
         update_type = "ALL"
+
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
         self.divide_and_put_data(self.put_triggers, triggers,
-                           update_type=update_type, fetch_id=fetch_id)
+                                 put_empty_contents, update_type=update_type,
+                                 fetch_id=fetch_id)
 
     def collect_events_and_put(self, fetch_id=None, last_info=None,
                                count=None, direction="ASC"):
@@ -203,7 +209,8 @@ class Common:
             host_ids = [obj["hostId"] for obj in self.__collect_hosts()]
         for host_id in host_ids:
             items.extend(self.__collect_items_and_put(host_id))
-        self.divide_and_put_data(self.put_items, items, fetch_id)
+
+        self.divide_and_put_data(self.put_items, items, True, fetch_id)
 
     def collect_history_and_put(self, fetch_id, host_id, item_id,
                                 begin_time, end_time):
@@ -227,7 +234,8 @@ class Common:
                 "value": str(history["counter_volume"]),
             })
         sorted_samples = sorted(samples, key=lambda s: s["time"])
-        self.divide_and_put_data(self.put_history, sorted_samples, item_id, fetch_id)
+        self.divide_and_put_data(self.put_history, sorted_samples, True,
+                                 item_id, fetch_id)
 
     def __collect_items_and_put(self, host_id):
         url = "%s/v2/resources/%s" % (self.__ceilometer_ep, host_id)
@@ -327,8 +335,14 @@ class Common:
                 "extendedInfo": ""
             })
         sorted_events = sorted(events, key=lambda evt: evt["time"])
-        self.divide_and_put_data(self.put_events, sorted_events, fetch_id=fetch_id,
-                           last_info_generator=self.__last_info_generator)
+
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
+        self.divide_and_put_data(self.put_events, sorted_events,
+                                 put_empty_contents, fetch_id=fetch_id,
+                                 last_info_generator=self.__last_info_generator)
 
     def __last_info_generator(self, events):
         for evt in events:

--- a/server/hap2/hatohol/hap2_nagios_livestatus.py
+++ b/server/hap2/hatohol/hap2_nagios_livestatus.py
@@ -160,7 +160,13 @@ class Common:
         self.__trigger_last_info = \
             hapcommon.get_biggest_num_of_dict_array(triggers,
                                                     "lastChangeTime")
+
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
         self.divide_and_put_data(self.put_triggers, triggers,
+                           put_empty_contents,
                            update_type=update_type,
                            last_info=self.__trigger_last_info,
                            fetch_id=fetch_id)
@@ -233,7 +239,13 @@ class Common:
             # livestatus return a sorted list.
             # result[0] is latest statehist.
             self.__latest_statehist = json.dumps(result[0])
-        self.divide_and_put_data(self.put_events, events, fetch_id=fetch_id,
+
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
+        self.divide_and_put_data(self.put_events, events, put_empty_contents,
+                           fetch_id=fetch_id,
                            last_info_generator=self.return_latest_statehist)
 
     def return_latest_statehist(self, events):

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -224,7 +224,12 @@ class Common:
         self.__trigger_last_info = \
             hapcommon.get_biggest_num_of_dict_array(triggers,
                                                     "lastChangeTime")
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
         self.divide_and_put_data(self.put_triggers, triggers,
+                           put_empty_contents,
                            update_type=update_type,
                            last_info=self.__trigger_last_info,
                            fetch_id=fetch_id)
@@ -309,7 +314,13 @@ class Common:
                 "brief": msg,
                 "extendedInfo": ""
             })
-        self.divide_and_put_data(self.put_events, events, fetch_id=fetch_id)
+
+        put_empty_contents = True
+        if fetch_id is None:
+            put_empty_contents = False
+
+        self.divide_and_put_data(self.put_events, events, put_empty_contents,
+                                 fetch_id=fetch_id)
 
 
     def __validate_object_ids(self, host_ids):

--- a/server/hap2/hatohol/hap2_zabbix_api.py
+++ b/server/hap2/hatohol/hap2_zabbix_api.py
@@ -65,11 +65,12 @@ class ZabbixAPIConductor(object):
 
     def collect_and_put_items(self, host_ids=None, fetch_id=None):
         self.divide_and_put_data(self.put_items, self.__api.get_items(host_ids),
-                            fetch_id)
+                                 True, fetch_id)
 
     def collect_and_put_history(self, item_id, begin_time, end_time, fetch_id):
         history = self.__api.get_history(item_id, begin_time, end_time)
-        self.divide_and_put_data(self.put_history, history, item_id, fetch_id)
+        self.divide_and_put_data(self.put_history, history, True,
+                                 item_id, fetch_id)
 
     def update_hosts_and_host_group_membership(self):
         hosts, hg_membership = self.__api.get_hosts()
@@ -84,9 +85,11 @@ class ZabbixAPIConductor(object):
         if self.__trigger_last_info is None:
             self.__trigger_last_info = self.get_last_info("trigger")
 
+        put_empty_contents=False
         if fetch_id is not None:
             update_type = "ALL"
             triggers = self.__api.get_triggers(host_ids=host_ids)
+            put_empty_contents=True
         else:
             update_type = "UPDATED"
             triggers = self.__api.get_triggers(self.__trigger_last_info, host_ids)
@@ -99,6 +102,7 @@ class ZabbixAPIConductor(object):
                                                     "lastChangeTime")
 
         self.divide_and_put_data(self.put_triggers, triggers,
+                           put_empty_contents,
                            update_type=update_type,
                            last_info=self.__trigger_last_info,
                            fetch_id=fetch_id)
@@ -143,7 +147,8 @@ class ZabbixAPIConductor(object):
         if len(events) == 0:
             return
 
-        self.divide_and_put_data(self.put_events, events, fetch_id=fetch_id)
+        self.divide_and_put_data(self.put_events, events,
+                                 True, fetch_id=fetch_id)
 
 
 class Hap2ZabbixAPIPoller(haplib.BasePoller, ZabbixAPIConductor):

--- a/server/hap2/hatohol/haplib.py
+++ b/server/hap2/hatohol/haplib.py
@@ -557,7 +557,12 @@ class HapiProcessor:
         self.__sender.request("putHistory", params, request_id)
         self.__wait_response(request_id)
 
-    def divide_and_put_data(self, put_func, contents, *args, **kwargs):
+    def divide_and_put_data(self, put_func, contents, put_empty_contents=False,
+                            *args, **kwargs):
+        if put_empty_contents and len(contents) == 0:
+            put_func([], dict(), *args, **kwargs)
+            return
+
         chunk_size = DEFAULT_MAX_CHUNK_SIZE
         copy_contents = copy.copy(contents)
 

--- a/server/hap2/hatohol/rabbitmqconnector.py
+++ b/server/hap2/hatohol/rabbitmqconnector.py
@@ -126,10 +126,12 @@ class RabbitMQConnector(Transporter):
         if receiver is None:
             logger.warning("Receiver is not registered.")
             return
+        logger.debug(body)
         receiver(self._channel, body)
 
     def __publish(self, msg):
         try:
+            logger.debug(msg)
             self.__publish_raw(msg)
         except:
             # TODO: consider the way to save the message and try to

--- a/server/hap2/hatohol/test/TestHap2Ceilometer.py
+++ b/server/hap2/hatohol/test/TestHap2Ceilometer.py
@@ -89,14 +89,15 @@ class CommonForTest(Common):
     def put_hosts(self, hosts):
         self.store["hosts"] = hosts
 
-    def put_triggers(self, triggers, update_type,
+    def put_triggers(self, triggers, put_empty_contents, update_type,
                      last_info=None, fetch_id=None):
         self.store["triggers"] = triggers
         self.store["update_type"] = update_type
         self.store["last_info"] = last_info
         self.store["fetch_id"] = fetch_id
 
-    def put_events(self, events, fetch_id=None, last_info_generator=None):
+    def put_events(self, events, put_empty_contents,
+                   fetch_id=None, last_info_generator=None):
         self.store["events"] = events
         self.store["fetch_id"] = fetch_id
         self.store["last_info_generator"] = last_info_generator
@@ -206,11 +207,11 @@ class CommonForTest(Common):
     def get_cached_event_last_info(self):
         return "abcdef"
 
-    def put_items(self, items, fetch_id):
+    def put_items(self, items, put_empty_contents, fetch_id):
         self.store["items"] = items
         self.store["fetch_id"] = fetch_id
 
-    def put_history(self, samples, item_id, fetch_id):
+    def put_history(self, samples, put_history, item_id, fetch_id):
         self.store["samples"] = samples
         self.store["item_id"] = item_id
         self.store["fetch_id"] = fetch_id

--- a/server/hap2/hatohol/test/TestHap2NagiosLivestatus.py
+++ b/server/hap2/hatohol/test/TestHap2NagiosLivestatus.py
@@ -63,7 +63,7 @@ class CommonForTest(Common):
     def put_host_group_membership(self, membership):
         self.stores["host_group_membership"] = membership
 
-    def put_triggers(self, triggers, update_type,
+    def put_triggers(self, triggers, put_empty_contents, update_type,
                      last_info=None, fetch_id=None):
         self.stores["triggers"] = triggers
         self.stores["update_type"] = update_type
@@ -73,7 +73,8 @@ class CommonForTest(Common):
     def get_cached_event_last_info(self):
         return None
 
-    def put_events(self, events, fetch_id=None, last_info_generator=None):
+    def put_events(self, events, put_empty_contents,
+                   fetch_id=None, last_info_generator=None):
         self.stores["events"] = events
         self.stores["fetch_id"] = fetch_id
         self.stores["last_info_generator"] = last_info_generator

--- a/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
+++ b/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
@@ -60,7 +60,7 @@ class CommonForTest(Common):
     def put_host_group_membership(self, membership):
         self.stores["host_group_membership"] = membership
 
-    def put_triggers(self, triggers, update_type,
+    def put_triggers(self, triggers, put_empty_contents, update_type,
                      last_info=None, fetch_id=None):
         self.stores["triggers"] = triggers
         self.stores["update_type"] = update_type
@@ -70,7 +70,8 @@ class CommonForTest(Common):
     def get_cached_event_last_info(self):
         return None
 
-    def put_events(self, events, fetch_id=None, last_info_generator=None):
+    def put_events(self, events, put_empty_contents,
+                   fetch_id=None, last_info_generator=None):
         self.stores["events"] = events
         self.stores["fetch_id"] = fetch_id
         self.stores["last_info_generator"] = last_info_generator


### PR DESCRIPTION
When hap2 get request(ex. item, history) and monitoring target does not have data, HAP2 does not return nothing.
So, request become timeout. After apply this PR, request does not become by HAP2 return empty list(items, histories).