### PR TITLE
[history_view] Invoke load in loadConfig

### DIFF
--- a/client/static/js/history_view.js
+++ b/client/static/js/history_view.js
@@ -267,7 +267,7 @@ var HistoryView = function(userProfile, options) {
         delete self.config.user_id;
         $("#edit-graph-title").val(self.config.title);
         setupGraphItems(self.parseGraphItems());
-        // Do not invoke load() function here.
+        load()
       },
       null,
       { pathPrefix: '', timeout: 30000 });


### PR DESCRIPTION
When we open saved graph, history_view.js does not load saved one currently.