### PR TITLE
[server] Add a config file for syslog.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,7 @@ server/mlpl/test/Makefile
 server/mlpl/mlpl.pc
 server/common/Makefile
 server/src/Makefile
+server/log/Makefile
 server/hap2/Makefile
 server/hap2/hap2.conf
 server/hap2/hap2-control-functions.sh

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = mlpl common src hap2 tools test data benchmark
+SUBDIRS = mlpl common src hap2 tools test data benchmark log

--- a/server/log/Makefile.am
+++ b/server/log/Makefile.am
@@ -1,0 +1,4 @@
+logconf_DATA = \
+	hatohol-syslog.conf
+
+logconfdir = $(pkgdatadir)

--- a/server/log/hatohol-syslog.conf
+++ b/server/log/hatohol-syslog.conf
@@ -1,0 +1,2 @@
+:programname, isequal, "hatohol" -/var/log/hatohol/hatohol-server.log
+& ~


### PR DESCRIPTION
This patch provides a syslogd configuration file to
save Hatohol server log into /var/log/hatohol/hatohol-server.log.