### PR TITLE
Don't show "Overview : Items" page

### DIFF
--- a/client/hatohol/base_settings.py
+++ b/client/hatohol/base_settings.py
@@ -206,30 +206,30 @@ ENABLED_PAGES = (
     #
     # monitoring views
     #
-    #"ajax_dashboard",
-    #"ajax_overview_triggers",
+    "ajax_dashboard",
+    "ajax_overview_triggers",
     #"ajax_overview_items",
-    #"ajax_latest",
-    #"ajax_triggers",
-    #"ajax_events",
+    "ajax_latest",
+    "ajax_triggers",
+    "ajax_events",
 
     #
     # settings views
     #
-    #"ajax_servers",
-    #"ajax_actions",
-    #"ajax_graphs",
-    #"ajax_incident_settings",
-    #"ajax_log_search_systems",
-    #"ajax_users",
-    #"ajax_severity_ranks"
-    #"ajax_custom_incident_labels"
+    "ajax_servers",
+    "ajax_actions",
+    "ajax_graphs",
+    "ajax_incident_settings",
+    "ajax_log_search_systems",
+    "ajax_users",
+    "ajax_severity_ranks",
+    "ajax_custom_incident_labels",
 
     #
     # Help menu
     #
-    #"http://www.hatohol.org/docs"
-    #"#version"
+    "http://www.hatohol.org/docs",
+    "#version",
 )
 
 def get_config_lines_from_file():


### PR DESCRIPTION
Because it's take too long time to fetch all items if many
monitoring servers & hosts are registered. We need a breakthrough
idea to revive it.

In this commit I uncomment a configuration "ENABLED_PAGES" in
client/hatohol/base_settings.py except "ajax_overview_items" to
disable the page, but it's may not proper way to do it. So way may
change the way in the future release.