### PR TITLE
[client][Servers] Remove Maps columns that is less useful.

### DIFF
--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -169,7 +169,7 @@ var ServersView = function(userProfile) {
     var x;
     var s;
     var o;
-    var ip, serverURL, mapsURL;
+    var ip, serverURL;
 
     s = "";
     for (x = 0; x < rd["servers"].length; ++x) {
@@ -180,7 +180,6 @@ var ServersView = function(userProfile) {
       serverIds.push(serverId);
       var idConnStat = getIdConnStat(serverId);
       serverURL = getServerLocation(o);
-      mapsURL = getMapsLocation(o);
       s += "<tr>";
       s += "<td class='delete-selector' style='display:none;'>";
       s += "<input type='checkbox' class='selectcheckbox' serverId='" + escapeHTML(o["id"]) + "'>";
@@ -201,12 +200,6 @@ var ServersView = function(userProfile) {
       }
       s += "<td>" + escapeHTML(o["baseURL"])  + "</td>";
 
-      if (mapsURL) {
-        s += "<td><a href='" + mapsURL + "' target='_blank'>" +
-          gettext('Show Maps') + "</a></td>";
-      } else {
-        s += "<td></td>";
-      }
 
       s += "<td id='server-info-" + escapeHTML(serverId) + "'" +
            "  data-title='" + gettext("Server ID") + ": " + escapeHTML(serverId) + "'" +

--- a/client/viewer/servers_ajax.html
+++ b/client/viewer/servers_ajax.html
@@ -67,7 +67,6 @@
         <th>{% trans "Type" %}</th>
         <th>{% trans "Nickname" %}</th>
         <th>{% trans "URL" %}</th>
-        <th>{% trans "Maps" %}</th>
         <th class="server-info-column" style="display:none;"></th>
         <th class="edit-server-column" style="display:none;"></th>
       </tr>


### PR DESCRIPTION
This patch removes the Maps column in Monitoring servers page.
Because the page is for setting server's paramters and checking them,
using it as the gate to the map differents from the original
purpose of the page.

In addition, map is only provided by Zabbix. So showing it in the
common column will cause wasted spaces when Zabbix is not used.