### PR TITLE
[server][log] Setting files for logrotate.

### DIFF
--- a/server/log/Makefile.am
+++ b/server/log/Makefile.am
@@ -1,6 +1,7 @@
 logconf_DATA = \
-	hatohol-syslog.conf
-
+	hatohol-syslog.conf \
+	hatohol-server \
+	hatohol-arm-plugin2
 logconfdir = $(pkgdatadir)
 
 EXTRA_DIST = \

--- a/server/log/hatohol-arm-plugin2
+++ b/server/log/hatohol-arm-plugin2
@@ -1,0 +1,8 @@
+/var/log/hatohol/hatohol-arm-plugin2.log {
+rotate 5
+missingok
+monthly
+notifempty
+compress
+create 0664 hatohol hatohol
+}

--- a/server/log/hatohol-server
+++ b/server/log/hatohol-server
@@ -1,0 +1,10 @@
+/var/log/hatohol/hatohol-server.log{
+rotate 5
+missingok
+monthly
+notifempty
+compress
+postrotate
+/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+endscript
+}


### PR DESCRIPTION
Now logs for hatohol server and arm plugins are being
stored in the private file. This patch provides setting files
for logrotate in order to prevent the large log from being crated.