### PR TITLE
[hap2_nagios_ndoutils] Avoid a plugin from getting old data.

### DIFF
--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -244,6 +244,9 @@ class Common:
                            last_info=self.__trigger_last_info,
                            fetch_id=fetch_id)
 
+    def set_event_last_info(self, last_info):
+        assert True, "This method should be implemented."
+
     def collect_events_and_put(self, fetch_id=None, last_info=None,
                                count=None, direction="ASC"):
         t0 = "nagios_statehistory"

--- a/server/hap2/hatohol/hap2_nagios_ndoutils.py
+++ b/server/hap2/hatohol/hap2_nagios_ndoutils.py
@@ -123,6 +123,16 @@ class Common:
         nag_datetime = datetime.datetime.strptime(over_second, '%Y%m%d%H%M%S')
         return nag_datetime.strftime("%Y-%m-%d %H:%M:%S")
 
+    def __get_latest_statehistory_id(self):
+        sql = "SELECT statehistory_id FROM nagios_statehistory " \
+              "ORDER BY statehistory_id DESC LIMIT 1;"
+
+        statehistory_id = None
+        if self.__cursor.execute(sql):
+            statehistory_id = str(self.__cursor.fetchall()[0][0])
+
+        return statehistory_id
+
     def collect_hosts_and_put(self):
         sql = "SELECT host_object_id,display_name FROM nagios_hosts"
         self.__cursor.execute(sql)
@@ -258,6 +268,13 @@ class Common:
             raw_last_info = last_info
         else:
             raw_last_info = self.get_cached_event_last_info()
+            if not raw_last_info:
+                latest_id = self.__get_latest_statehistory_id()
+                if latest_id:
+                    self.set_event_last_info(latest_id)
+                else:
+                    self.set_event_last_info("0")
+                return
 
         if raw_last_info is not None \
             and raw_last_info != self.INITIAL_LAST_INFO:
@@ -342,7 +359,7 @@ class Common:
             event_id = int(last_info)
         except:
             pass
-        if event_id <= 0:
+        if event_id < 0:
             event_id = None
         return event_id
 

--- a/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
+++ b/server/hap2/hatohol/test/TestHap2NagiosNdoutils.py
@@ -27,7 +27,7 @@ from hap2_nagios_ndoutils import Common
 import hap2_nagios_ndoutils
 import transporter
 
-class CommonForTest(Common):
+class CommonForTest(Common, haplib):
     def __init__(self, options={}):
         Common.__init__(self)
         self.__options = options


### PR DESCRIPTION
The previous way get older data than the plugin is registered.
The volume of the data is possible to be gigantic. It may take
a long time to handle all of them, which is typicaly not urgent.