### PR TITLE
[WebUI] Revert 'Monitoring' label correctly on manual update.

### DIFF
--- a/client/static/js/dashboard_view.js
+++ b/client/static/js/dashboard_view.js
@@ -240,7 +240,7 @@ var DashboardView = function(userProfile) {
     $("#tblHost tbody").append(drawHostBody(rawData, parsedData));
 
     self.displayUpdateTime();
-    self.setAutoReload(load, self.reloadIntervalSeconds);
+    self.enableAutoRefresh(load, self.reloadIntervalSeconds);
   }
 
   function drawLogSearchBody(logSearchSystems) {

--- a/client/static/js/latest_view.js
+++ b/client/static/js/latest_view.js
@@ -206,7 +206,7 @@ var LatestView = function(userProfile) {
                       self.lastQuery ? self.lastQuery : self.baseQuery,
                       true);
     setLoading(false);
-    self.setAutoReload(load, self.reloadIntervalSeconds);
+    self.enableAutoRefresh(load, self.reloadIntervalSeconds);
   }
 
   function getItemsQueryInURI() {

--- a/client/static/js/overview_items.js
+++ b/client/static/js/overview_items.js
@@ -176,7 +176,7 @@ var OverviewItems = function(userProfile) {
                       self.lastQuery ? self.lastQuery : self.baseQuery,
                       true);
     setLoading(false);
-    self.setAutoReload(load, self.reloadIntervalSeconds);
+    self.enableAutoRefresh(load, self.reloadIntervalSeconds);
   }
 
   function getItemsQueryInURI() {

--- a/client/static/js/overview_triggers.js
+++ b/client/static/js/overview_triggers.js
@@ -226,7 +226,7 @@ var OverviewTriggers = function(userProfile) {
     setupFilterValues();
     setupTableSeverityColor();
     setLoading(false);
-    self.setAutoReload(load, self.reloadIntervalSeconds);
+    self.enableAutoRefresh(load, self.reloadIntervalSeconds);
   }
 
   function getTriggersQueryInURI() {

--- a/client/static/js/triggers_view.js
+++ b/client/static/js/triggers_view.js
@@ -445,7 +445,7 @@ var TriggersView = function(userProfile, options) {
     setupFilterValues();
     setupTableColor();
     setLoading(false);
-    self.setAutoReload(load, self.reloadIntervalSeconds);
+    self.enableAutoRefresh(load, self.reloadIntervalSeconds);
   }
 
   function getTriggersQueryInURI() {


### PR DESCRIPTION
After the monitoring is stopped by pressing the 'Monitoring' button
in the navi bar, it isn't reverted on pressing the manual update
button just under it.

This patch fixed the problem.