### PR TITLE
[WebUI] Fix an invalid value for the color.

### DIFF
--- a/client/static/css/hatohol.css
+++ b/client/static/css/hatohol.css
@@ -548,7 +548,7 @@ html {
   font-size: 12px;
   font-weight: bold;
   background: #e8800b;
-  color: #fffff;
+  color: #ffffff;
 }
 
 #summaryBar > button.on .badge,


### PR DESCRIPTION
Fix the worng format for the color in the CSS.
However, Google chrome (and probably other browsers) shows it in white,
which is much natural on the current design. So we hadn't noticed it.