### PR TITLE
[WebUI] Add missing parameter for parseErrorCallback()

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -1606,7 +1606,7 @@ var EventsView = function(userProfile, options) {
         $tr.next().find('td:eq(0)').html(html);
         updateCommentCount($tr, reply.incidentHistory);
       },
-      parseErrorCallback: function() {
+      parseErrorCallback: function(reply, parser) {
         var message = parser.getMessage();
         if (!message) {
           message =


### PR DESCRIPTION
parseErrorCallback() needs two parameters. However, it had given
nothing. When an error happensi, the call back won't work properly.