### PR TITLE
[WebUI][Servers] Make deleting/reloading confirmation dialog sync.

### DIFF
--- a/client/static/js/servers_view.js
+++ b/client/static/js/servers_view.js
@@ -142,7 +142,7 @@ var ServersView = function(userProfile) {
         self.startConnection("server", updateCore);
       },
     });
-    hatoholInfoMsgBox("Deleting...");
+    hatoholInfoMsgBox("Deleting...", {buttons: []});
   }
 
   function updateTriggerServers() {
@@ -162,7 +162,7 @@ var ServersView = function(userProfile) {
         self.startConnection("server", updateCore);
       },
     });
-    hatoholInfoMsgBox("Reloading...");
+    hatoholInfoMsgBox("Reloading...", {buttons: []});
   }
 
   function drawTableBody(rd) {


### PR DESCRIPTION
The current deleting/reloading confirmation dialog can be closed.
This patch disables closing due to the following two reasons.

- The time for the actions is not so long.
- Updating the information on the servers page asynchronously
  sometimes makes users confused.