### PR TITLE
[server] Log an error message on publish() failure.

### DIFF
--- a/server/common/HatoholArmPluginInterfaceHAPI2.cc
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.cc
@@ -557,7 +557,11 @@ void HatoholArmPluginInterfaceHAPI2::send(const std::string &message)
 	AMQPJSONMessage amqpMessage;
 	amqpMessage.body = message;
 	publisher.setMessage(amqpMessage);
-	publisher.publish();
+	if (publisher.publish()) {
+		MLPL_DBG("sended message: %s\n", message.c_str());
+	} else {
+		MLPL_ERR("Failed to send a message: %s\n", message.c_str());
+	}
 }
 
 void HatoholArmPluginInterfaceHAPI2::send(


### PR DESCRIPTION
The current code doesn't check the return value of publish().
If it fails, this patch logs that.