### PR TITLE
[WebUI] Use prop() instead of attr() for wide JQuery compatibility.

### DIFF
--- a/client/static/js/hatohol_events_view_config.js
+++ b/client/static/js/hatohol_events_view_config.js
@@ -609,7 +609,7 @@ HatoholEventsViewConfig.prototype.setCurrentFilterConfig = function(filter) {
     $("#enable-" + filterName + "-filter-selector").prop("checked", config.enable);
     $("input:radio" +
       "[name=" + filterName + "-filter-select-options]" +
-      "[value=" + exclude + "]").attr('checked', true);
+      "[value=" + exclude + "]").prop('checked', true);
 
     // set candidate items (left side)
     for (i = 0; i < choices.length; i++) {


### PR DESCRIPTION
JQuery attr() with 'checked' only works on JQuery version before
1.5 and 1.6.1 to 1.8. While, prop() is a good alternative, which
works on wide versions.