### PR TITLE
[WebUI][servers] Remoev close button on server update/add dialog.

### DIFF
--- a/client/static/js/hatohol_server_edit_dialog_parameterized.js
+++ b/client/static/js/hatohol_server_edit_dialog_parameterized.js
@@ -49,9 +49,9 @@ var HatoholServerEditDialogParameterized = function(params) {
   //
   function addButtonClickedCb() {
     if (self.server)
-      hatoholInfoMsgBox(gettext("Now updating the server ..."));
+      hatoholInfoMsgBox(gettext("Now updating the server ..."), {buttons: []});
     else
-      hatoholInfoMsgBox(gettext("Now adding a server..."));
+      hatoholInfoMsgBox(gettext("Now adding a server..."), {buttons: []});
     postAddServer();
   }
 


### PR DESCRIPTION
This patch removes the close button on server update/add dialog.
Typically it doesn't take so long. In addition, asynchronous update
sometimes makes users confused.