### PR TITLE
[WebUI][Events] Fix a problem that overwrites base filter settings.

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -440,8 +440,8 @@ var EventsView = function(userProfile, options) {
     if (baseFilter.severities && URISeverities) {
       baseFilter.severities = getListProduct(baseFilter.severities.split(","),
                                              URISeverities.split(",")).join(",");
-      if (baseFilter.severities.length == 0) {
-        baseFilter.severities = "-1"
+      if (baseFilter.severities.length === 0) {
+        baseFilter.severities = "-1";
       }
     } else if (URISeverities) {
       baseFilter.severities = URISeverities;
@@ -450,8 +450,8 @@ var EventsView = function(userProfile, options) {
     if (baseFilter.incidentStatuses && URIIncidentStatuses) {
       baseFilter.incidentStatuses = getListProduct(baseFilter.incidentStatuses.split(","),
                                              URIIncidentStatuses.split(",")).join(",");
-      if (baseFilter.incidentStatuses.length == 0) {
-        baseFilter.incidentStatuses = "NOTHING"
+      if (baseFilter.incidentStatuses.length === 0) {
+        baseFilter.incidentStatuses = "NOTHING";
       }
     } else if (URIIncidentStatuses) {
         baseFilter.incidentStatuses =  URIIncidentStatuses;
@@ -482,7 +482,7 @@ var EventsView = function(userProfile, options) {
   }
 
   function getListProduct(listA, listB) {
-    return listA.filter(function(i){return listB[listB.indexOf(i)];})
+    return listA.filter(function(i){return listB[listB.indexOf(i)];});
   }
 
   function load(options) {

--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -38,7 +38,6 @@ var EventsView = function(userProfile, options) {
     sortType:         "time",
     sortOrder:        hatohol.DATA_QUERY_OPTION_SORT_DESCENDING,
   };
-  $.extend(self.baseQuery, getEventsQueryInURI());
   self.lastFilterId = null;
   self.lastQuickFilter = {};
   self.isFilteringOptionsUsed = false;
@@ -414,7 +413,7 @@ var EventsView = function(userProfile, options) {
   }
 
   function getQuery(options) {
-    var query = {}, baseFilter;
+    var query = {}, baseFilter, URIQuery, URISeverities, URIIncidentStatuses;
 
     options = options || {};
 
@@ -432,8 +431,33 @@ var EventsView = function(userProfile, options) {
       self.lastQuickFilter = getQuickFilter();
     }
     baseFilter = self.userConfig.getFilter(self.lastFilterId);
+    URIQuery = getEventsQueryInURI();
+    URISeverities = URIQuery.severities;
+    delete URIQuery["severities"];
+    URIIncidentStatuses = URIQuery.incidentStatuses;
+    delete URIQuery["incidentStatuses"];
 
-    $.extend(query, self.baseQuery, baseFilter, self.lastQuickFilter, {
+    if (baseFilter.severities && URISeverities) {
+      baseFilter.severities = getListProduct(baseFilter.severities.split(","),
+                                             URISeverities.split(",")).join(",");
+      if (baseFilter.severities.length == 0) {
+        baseFilter.severities = "-1"
+      }
+    } else if (URISeverities) {
+      baseFilter.severities = URISeverities;
+    }
+
+    if (baseFilter.incidentStatuses && URIIncidentStatuses) {
+      baseFilter.incidentStatuses = getListProduct(baseFilter.incidentStatuses.split(","),
+                                             URIIncidentStatuses.split(",")).join(",");
+      if (baseFilter.incidentStatuses.length == 0) {
+        baseFilter.incidentStatuses = "NOTHING"
+      }
+    } else if (URIIncidentStatuses) {
+        baseFilter.incidentStatuses =  URIIncidentStatuses;
+    }
+
+    $.extend(query, self.baseQuery, baseFilter, URIQuery, self.lastQuickFilter, {
       offset:           self.baseQuery.limit * self.currentPage,
       limit:            self.baseQuery.limit,
       limitOfUnifiedId: self.limitOfUnifiedId,
@@ -455,6 +479,10 @@ var EventsView = function(userProfile, options) {
     $.extend(query, baseFilter);
 
     return 'summary/important-event?' + $.param(query);
+  }
+
+  function getListProduct(listA, listB) {
+    return listA.filter(function(i){return listB[listB.indexOf(i)];})
   }
 
   function load(options) {


### PR DESCRIPTION
Previously, severities and incident statuses to be shown, setting
by the base filter, are overritten by the URI's query parameters,
which is typically set by the quick filter.