### PR TITLE
[server] Turn plugin's running state on when updating server information

### DIFF
--- a/server/src/UnifiedDataStore.cc
+++ b/server/src/UnifiedDataStore.cc
@@ -880,7 +880,7 @@ HatoholError UnifiedDataStore::updateTargetServer(
 	err = m_impl->stopDataStore(svInfo.id, &isRunning);
 	if (err != HTERR_OK)
 		return err;
-	return m_impl->startDataStore(svInfo, isRunning);
+	return m_impl->startDataStore(svInfo, true);
 }
 
 HatoholError UnifiedDataStore::deleteTargetServer(


### PR DESCRIPTION
When a plugin gets an errors, the running state becomes false.
The state cannot be recovered. This patch fixes the issue by
updating the server information.