### PR TITLE
[RestResourceMonitoring] Add a query option: empty=true

### DIFF
--- a/server/src/RestResourceMonitoring.h
+++ b/server/src/RestResourceMonitoring.h
@@ -38,6 +38,7 @@ struct RestResourceMonitoring : public RestResourceMemberHandler
 	void handlerGetHostgroup(void);
 	void handlerGetItem(void);
 	void replyGetItem(void);
+	void replyOnlyServers(void);
 	void handlerGetHistory(void);
 	void handlerGetTriggerBriefs(void);
 	void itemFetchedCallback(Closure0 *closure);


### PR DESCRIPTION
This option is assumed to return only servers with the given
conditions. Currently more than one data has to be gotten to
obtain it.