### PR TITLE
[WebUI][history] Get item candidates after the host is fixed.

### DIFF
--- a/client/static/js/hatohol_item_selector.js
+++ b/client/static/js/hatohol_item_selector.js
@@ -36,8 +36,7 @@ var HatoholItemSelector = function(options) {
     self.view.setupHostQuerySelectorCallback(
       function() {
         var query = self.view.getHostFilterQuery();
-        query.limit = 1; // we need only "servers" object
-        self.view.startConnection("items?" + $.param(query), function(reply) {
+        self.view.startConnection("item?empty=true&" + $.param(query), function(reply) {
           self.servers = reply.servers;
           self.setupCandidates();
         });
@@ -45,8 +44,8 @@ var HatoholItemSelector = function(options) {
       '#select-server', '#select-host-group', '#select-host');
     $("#select-item").attr("disabled", "disabled");
     $("#add-item-button").attr("disabled", "disabled");
-    $("#select-server").change(loadItemCandidates);
-    $("#select-host-group").change(loadItemCandidates);
+    $("#select-server").change(resetItemField);
+    $("#select-host-group").change(resetItemField);
     $("#select-host").change(loadItemCandidates);
     $("#select-item").change(function() {
       if ($(this).val() == "---------")
@@ -128,12 +127,16 @@ var HatoholItemSelector = function(options) {
       $(selector).popover("hide");
     });
   }
+
+  function resetItemField() {
+    self.view.setFilterCandidates($("#select-item"));
+  }
 };
 
 HatoholItemSelector.prototype.show = function() {
   var self = this;
   if (!self.servers) {
-    self.view.startConnection("item?limit=1", function(reply) {
+    self.view.startConnection("item?empty=true", function(reply) {
       self.servers = reply.servers;
       self.setupCandidates();
     });


### PR DESCRIPTION
It will take a long time if the zabbix server monitors a lot of
hosts with many items. So this patch get item candidates after the
host is determined.