### PR TITLE
[server][Action] Reexecute action mechanism.

### DIFF
--- a/server/src/ActionManager.cc
+++ b/server/src/ActionManager.cc
@@ -549,6 +549,54 @@ void ActionManager::checkEvents(const EventInfoList &eventList)
 	}
 }
 
+void ActionManager::reExecuteUnfinishedAction(void)
+{
+	ThreadLocalDBCache cache;
+	DBTablesAction &dbAction = cache.getAction();
+	DBTablesMonitoring &dbMonitoring = cache.getMonitoring();
+
+	ActionLogList actionLogList;
+	const vector<int> targetStatuses{ACTLOG_STAT_QUEUING,
+	                                 ACTLOG_STAT_STARTED,
+	                                 ACTLOG_STAT_RESIDENT_QUEUING,
+	                                 ACTLOG_STAT_LAUNCHING_RESIDENT};
+
+	if (!dbAction.getTargetStatusesLogs(actionLogList, targetStatuses)) {
+		MLPL_INFO("Hatohol does not have unfinished action.\n");
+		return;
+	}
+
+	for (const auto &actionLog: actionLogList) {
+		EventInfoList eventList;
+		EventsQueryOption eventOption(USER_ID_SYSTEM);
+
+		eventOption.setTargetServerId(actionLog.serverId);
+		EventIdType eventId = actionLog.eventId;
+		list<EventIdType> eventIds{eventId};
+		eventOption.setEventIds(eventIds);
+		dbMonitoring.getEventInfoList(eventList, eventOption);
+		if (eventList.size() == 0)
+		        continue;
+		EventInfo eventInfo = *eventList.begin();
+
+		ActionDefList actionList;
+		ActionsQueryOption actionOption(USER_ID_SYSTEM);
+		ActionIdList actionIdList{actionLog.actionId};
+		actionOption.setActionIdList(actionIdList);
+		dbAction.getActionList(actionList, actionOption);
+
+		if (actionList.size() == 0)
+		        continue;
+		dbAction.updateLogStatusToAborted(actionLog.id);
+		runAction(*actionList.begin(), eventInfo, dbAction);
+		string message =
+		   StringUtils::sprintf("Action log ID(%" FMT_GEN_ID "): "
+		                        "Update log status to aborted(7).\n",
+		                        actionLog.id);
+		MLPL_WARN("%s", message.c_str());
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Protected methods
 // ---------------------------------------------------------------------------

--- a/server/src/ActionManager.h
+++ b/server/src/ActionManager.h
@@ -59,6 +59,7 @@ public:
 	ActionManager(void);
 	virtual ~ActionManager();
 	void checkEvents(const EventInfoList &eventList);
+	void reExecuteUnfinishedAction(void);
 
 protected:
 	/**

--- a/server/src/DBTablesAction.cc
+++ b/server/src/DBTablesAction.cc
@@ -823,6 +823,19 @@ void DBTablesAction::updateLogStatusToStart(const ActionLogIdType &logId)
 	getDBAgent().runTransaction(arg);
 }
 
+void DBTablesAction::updateLogStatusToAborted(const ActionLogIdType &logId)
+{
+	DBAgent::UpdateArg arg(tableProfileActionLogs);
+
+	const char *actionLogIdColumnName =
+	  COLUMN_DEF_ACTION_LOGS[IDX_ACTION_LOGS_ACTION_LOG_ID].columnName;
+	arg.condition = StringUtils::sprintf("%s=%" FMT_ACTION_LOG_ID,
+                                             actionLogIdColumnName, logId);
+	arg.add(IDX_ACTION_LOGS_STATUS, ACTLOG_STAT_ABORTED);
+
+	getDBAgent().update(arg);
+}
+
 bool DBTablesAction::getLog(ActionLog &actionLog, const ActionLogIdType &logId)
 {
 	const ColumnDef *def = COLUMN_DEF_ACTION_LOGS;
@@ -844,6 +857,25 @@ bool DBTablesAction::getLog(
 	  "%s=%" FMT_SERVER_ID " AND %s=%s",
 	  idColNameSvId, serverId, idColNameEvtId, rhs(eventId));
 	return getLog(actionLog, condition);
+}
+
+bool DBTablesAction::getTargetStatusesLogs(
+  ActionLogList &actionLogList, const vector<int> &targetStatuses)
+{
+	SeparatorInjector commaInjector(",");
+	string statuses;
+	for (const auto &targetStatus: targetStatuses) {
+		commaInjector(statuses);
+		statuses += to_string(targetStatus);
+	}
+	const ColumnDef *def = COLUMN_DEF_ACTION_LOGS;
+	const char *idColNameStat = def[IDX_ACTION_LOGS_STATUS].columnName;
+	const char *idColNameEvtId = def[IDX_ACTION_LOGS_EVENT_ID].columnName;
+	string condition = StringUtils::sprintf(
+	                     "%s in (%s) AND %s!=''",
+	                     idColNameStat, statuses.c_str(), idColNameEvtId);
+
+	return getLogs(actionLogList, condition);
 }
 
 bool DBTablesAction::isIncidentSenderEnabled(void)
@@ -944,6 +976,81 @@ bool DBTablesAction::getLog(ActionLog &actionLog, const string &condition)
 	if (itemGroupStream.getItem()->isNull())
 		actionLog.nullFlags |= ACTLOG_FLAG_EXIT_CODE;
 	itemGroupStream >> actionLog.exitCode;
+
+	return true;
+}
+
+// TODO: Extract commonly used lines in getLog() above and reduce the similar lines. 
+bool DBTablesAction::getLogs(ActionLogList &actionLogList,
+                             const string &condition)
+{
+	DBAgent::SelectExArg arg(tableProfileActionLogs);
+	arg.condition = condition;
+	arg.add(IDX_ACTION_LOGS_ACTION_LOG_ID);
+	arg.add(IDX_ACTION_LOGS_ACTION_ID);
+	arg.add(IDX_ACTION_LOGS_STATUS);
+	arg.add(IDX_ACTION_LOGS_STARTER_ID);
+	arg.add(IDX_ACTION_LOGS_QUEUING_TIME);
+	arg.add(IDX_ACTION_LOGS_START_TIME);
+	arg.add(IDX_ACTION_LOGS_END_TIME);
+	arg.add(IDX_ACTION_LOGS_EXEC_FAILURE_CODE);
+	arg.add(IDX_ACTION_LOGS_EXIT_CODE);
+	arg.add(IDX_ACTION_LOGS_SERVER_ID);
+	arg.add(IDX_ACTION_LOGS_EVENT_ID);
+
+	getDBAgent().runTransaction(arg);
+
+	const auto &grpList = arg.dataTable->getItemGroupList();
+	size_t numGrpList = grpList.size();
+
+	// Not found
+	if (numGrpList == 0)
+		return false;
+
+	for (const auto &itemGrp: grpList) {
+		ItemGroupStream itemGroupStream(itemGrp);
+		actionLogList.push_back(ActionLog());
+		ActionLog &actionLog = actionLogList.back();
+		actionLog.nullFlags = 0;
+
+		itemGroupStream >> actionLog.id;
+		itemGroupStream >> actionLog.actionId;
+		itemGroupStream >> actionLog.status;
+		itemGroupStream >> actionLog.starterId;
+
+		// queing time
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_QUEUING_TIME;
+		itemGroupStream >> actionLog.queuingTime;
+
+		// start time
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_START_TIME;
+		itemGroupStream >> actionLog.startTime;
+
+		// end time
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_END_TIME;
+		itemGroupStream >> actionLog.endTime;
+
+		// failure code
+		itemGroupStream >> actionLog.failureCode;
+
+		// exit code
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_EXIT_CODE;
+		itemGroupStream >> actionLog.exitCode;
+
+		// server id
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_EXIT_CODE;
+		itemGroupStream >> actionLog.serverId;
+
+		// event id
+		if (itemGroupStream.getItem()->isNull())
+			actionLog.nullFlags |= ACTLOG_FLAG_EXIT_CODE;
+		itemGroupStream >> actionLog.eventId;
+	}
 
 	return true;
 }

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -173,8 +173,14 @@ struct ActionLog {
 	int      endTime;
 	int      failureCode;
 	int      exitCode;
+	ServerIdType serverId;
+	EventIdType  eventId;
 	uint32_t nullFlags;
 };
+
+typedef std::list<ActionLog>          ActionLogList;
+typedef ActionLogList::iterator       ActionLogListIterator;
+typedef ActionLogList::const_iterator ActionLogListConstIterator;
 
 struct ChildSigInfo {
 	pid_t pid;
@@ -217,6 +223,7 @@ enum ActionLogStatus {
 	// Resident acitons for an actio ID are executed in series
 	// This status is used for waiting actions.
 	ACTLOG_STAT_RESIDENT_QUEUING,
+	ACTLOG_STAT_ABORTED,
 };
 
 enum ActionLogExecFailureCode {
@@ -343,6 +350,13 @@ public:
 	void updateLogStatusToStart(const ActionLogIdType &logId);
 
 	/**
+	 * Update the status in action log to ACTLOG_STAT_FAILED.
+	 *
+	 * @param logId A logID to be updated.
+	 */
+	void updateLogStatusToAborted(const ActionLogIdType &logId);
+
+	/**
 	 * Get the action log.
 	 * @param actionLog
 	 * The returned values are filled in this instance.
@@ -364,6 +378,9 @@ public:
 	 */
 	bool getLog(ActionLog &actionLog, const ServerIdType &serverId,
 	            const EventIdType &eventId);
+
+	bool getTargetStatusesLogs(ActionLogList &actionLogList,
+	                           const std::vector<int> &targetStatuses);
 
 	/**
 	 * Check whether IncidentSender type action exists or not
@@ -391,6 +408,7 @@ protected:
 	 * @return true if the log is found. Otherwise false.
 	 */
 	bool getLog(ActionLog &actionLog, const std::string &condition);
+	bool getLogs(ActionLogList &actionLogList, const std::string &condition);
 
 	HatoholError checkPrivilegeForAdd(
 	  const OperationPrivilege &privilege, const ActionDef &actionDef);

--- a/server/src/DBTablesMonitoring.cc
+++ b/server/src/DBTablesMonitoring.cc
@@ -1011,6 +1011,7 @@ struct EventsQueryOption::Impl {
 	set<string> incidentStatuses;
 	vector<string> groupByColumns;
 	list<string> hostnameList;
+	list<EventIdType> eventIds;
 
 	Impl()
 	: limitOfUnifiedId(NO_LIMIT),
@@ -1022,7 +1023,8 @@ struct EventsQueryOption::Impl {
 	  triggerId(ALL_TRIGGERS),
 	  beginTime({0, 0}),
 	  endTime({0, 0}),
-	  hostnameList({})
+	  hostnameList({}),
+	  eventIds({})
 	{
 	}
 };
@@ -1135,6 +1137,11 @@ string EventsQueryOption::getCondition(void) const
 	if (!m_impl->hostnameList.empty()) {
 		addCondition(condition,
 			     makeHostnameListCondition(m_impl->hostnameList));
+	}
+
+	if (!m_impl->eventIds.empty()) {
+		addCondition(condition,
+		             makeEventIdListCondition(m_impl->eventIds));
 	}
 
 	string typeCondition;
@@ -1368,6 +1375,11 @@ const std::set<EventType> &EventsQueryOption::getEventTypes(void) const
 	return m_impl->eventTypes;
 }
 
+void EventsQueryOption::setEventIds(const list<EventIdType> &eventIds)
+{
+	m_impl->eventIds = eventIds;
+}
+
 void EventsQueryOption::setTriggerSeverities(
   const set<TriggerSeverityType> &severities)
 {
@@ -1413,6 +1425,22 @@ string EventsQueryOption::makeHostnameListCondition(
 		condition += StringUtils::sprintf("%s", rhs(hostname.c_str()));
 	}
 
+	condition += ")";
+	return condition;
+}
+
+string EventsQueryOption::makeEventIdListCondition(
+  const list<EventIdType> &eventIds) const
+{
+	string condition;
+	const ColumnDef &colId = COLUMN_DEF_EVENTS[IDX_EVENTS_ID];
+	SeparatorInjector commaInjector(",");
+	DBTermCStringProvider rhs(*getDBTermCodec());
+	condition = StringUtils::sprintf("%s in (", colId.columnName);
+	for (const auto &eventId : eventIds) {
+		commaInjector(condition);
+		condition += StringUtils::sprintf("%s", rhs(eventId.c_str()));
+	}
 	condition += ")";
 	return condition;
 }

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -74,6 +74,7 @@ public:
 
 	void setEventTypes(const std::set<EventType> &types);
 	const std::set<EventType> &getEventTypes(void) const;
+	void setEventIds(const std::list<EventIdType> &eventIds);
 	void setTriggerSeverities(const std::set<TriggerSeverityType> &severities);
 	const std::set<TriggerSeverityType> &getTriggerSeverities(void) const;
 	void setTriggerStatuses(const std::set<TriggerStatusType> &statuses);
@@ -84,6 +85,9 @@ public:
 
 	std::string makeHostnameListCondition(
 	  const std::list<std::string> &hostnameList) const;
+
+	std::string makeEventIdListCondition(
+	  const std::list<EventIdType> &eventIds) const;
 
 private:
 	struct Impl;

--- a/server/src/main.cc
+++ b/server/src/main.cc
@@ -46,6 +46,7 @@ using namespace mlpl;
 #include "ConfigManager.h"
 #include "ThreadLocalDBCache.h"
 #include "ChildProcessManager.h"
+#include "ActionManager.h"
 
 static string pidFilePath;
 static int pipefd[2];
@@ -244,6 +245,11 @@ int mainRoutine(int argc, char *argv[])
 
 	// setup configuration database
 	ThreadLocalDBCache cache;
+
+	// Re execute unfinished action
+	ActionManager actionManager;
+	actionManager.reExecuteUnfinishedAction();
+
 	// start REST server
 	// 'rest' is on a stack. The destructor of it will be automatically
 	// called at the end of this function.


### PR DESCRIPTION
This patch adds a feature that executes unfinished actions
when Hatohol server restarts.

Currently, when the Hatohol server craashes or quits forcely,
running and queued actions aren't taken care on the restart of
Hatohol server.