### PR TITLE
Work for splitting #2370 fix hostqueryopt

### DIFF
--- a/server/src/HostResourceQueryOption.cc
+++ b/server/src/HostResourceQueryOption.cc
@@ -62,6 +62,10 @@ HostResourceQueryOption::Synapse::Synapse(
 // ---------------------------------------------------------------------------
 struct HostResourceQueryOption::Impl {
 	const Synapse  &synapse;
+
+	// *** NOTICE ***
+	// When a member is added, &operator=() should also be modified if needed.
+	//
 	ServerIdType    targetServerId;
 	LocalHostIdType targetHostId;
 	HostgroupIdType targetHostgroupId;
@@ -94,6 +98,12 @@ struct HostResourceQueryOption::Impl {
 		targetHostId          = rhs.targetHostId;
 		targetHostgroupId     = rhs.targetHostgroupId;
 		excludeDefunctServers = rhs.excludeDefunctServers;
+		selectedServerIdSet   = rhs.selectedServerIdSet;
+		excludedServerIdSet   = rhs.excludedServerIdSet;
+		selectedServerHostgroupSetMap = rhs.selectedServerHostgroupSetMap;
+		excludedServerHostgroupSetMap = rhs.excludedServerHostgroupSetMap;
+		selectedServerHostSetMap      = rhs.selectedServerHostSetMap;
+		excludedServerHostSetMap      = rhs.excludedServerHostSetMap;
 		return *this;
 	}
 };

--- a/server/test/Helpers.cc
+++ b/server/test/Helpers.cc
@@ -102,6 +102,12 @@ void _assertItemTable(const ItemTablePtr &expect, const ItemTablePtr &actual)
 }
 
 // TODO: We should prepare '== operator' and cppcut_assert_equal() ?
+void _assertEqual(const std::set<int> &expect, const std::set<int> &actual)
+{
+	assertEqualSet(expect, actual);
+}
+
+// TODO: Use assertEqualSet<string>()
 void _assertEqual(const set<string> &expect, const set<string> &actual)
 {
 	auto errMsg = [&] {
@@ -192,6 +198,22 @@ void _assertEqual(const TriggerInfo &expect, const TriggerInfo &actual)
 	cppcut_assert_equal(expect.hostName,     actual.hostName);
 	cppcut_assert_equal(expect.brief,        actual.brief);
 	cppcut_assert_equal(TRIGGER_VALID,       actual.validity);
+}
+
+// This can also be used as
+//     _assertEqual(const ServerHostSetMap &expect,
+//                  const ServerHostSetMap &actual)
+// because the actual (primitive level) definition is the indentical.
+void _assertEqual(const ServerHostGrpSetMap &expect,
+                  const ServerHostGrpSetMap &actual)
+{
+	cppcut_assert_equal(expect.size(), actual.size());
+	for (const auto &elem: expect) {
+		const auto &key = elem.first;
+		assertHas(actual, key);
+		const auto &actual_elem = actual.find(key)->second;
+		assertEqual(elem.second, actual_elem);
+	}
 }
 
 template <typename T>

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -86,6 +86,46 @@ extern void _assertItemTable(
   const ItemTablePtr &expect, const ItemTablePtr &actual);
 #define assertItemTable(E,A) cut_trace(_assertItemTable(E,A))
 
+template<typename CT, typename KT>
+void _assertHas(const CT &container, const KT &key)
+{
+	std::stringstream ss;
+	const bool found = (container.find(key) != container.end());
+	if (!found)
+		ss << "Not found: " << key;
+	cppcut_assert_equal(
+	  true, found, cut_message("%s", ss.str().c_str()));
+}
+#define assertHas(C,K) cut_trace((_assertHas(C,K)))
+
+template <typename T>
+void assertEqualSet(const std::set<T> &expect, const std::set<T> &actual)
+{
+	auto errMsg = [&] {
+		struct {
+			std::string title;
+			const std::set<T> &members;
+		} args[] = {
+			{"<expect>", expect}, {"<actual>", actual}
+		};
+
+		std::string s;
+		for (const auto &a: args) {
+			s += a.title + "\n";
+			for (const auto &val: a.members)
+				s += val + "\n";
+		}
+		return s;
+	};
+
+	cppcut_assert_equal(expect.size(), actual.size(),
+	                    cut_message("%s\n", errMsg().c_str()));
+	for (const auto &val : expect)
+		assertHas(actual, val);
+}
+
+extern void _assertEqual(const std::set<int> &expect,
+                         const std::set<int> &actual);
 extern void _assertEqual(const std::set<std::string> &expect,
                          const std::set<std::string> &actual);
 extern void _assertEqual(
@@ -93,6 +133,11 @@ extern void _assertEqual(
 extern void _assertEqual(const ArmInfo &expect, const ArmInfo &actual);
 extern void _assertEqual(const ItemInfo &expect, const ItemInfo &actual);
 extern void _assertEqual(const TriggerInfo &expect, const TriggerInfo &actual);
+extern void _assertEqual(const ServerIdSet &expect, const ServerIdSet &actual);
+extern void _assertEqual(const ServerHostGrpSetMap &expect,
+                         const ServerHostGrpSetMap &actual);
+extern void _assertEqual(const ServerHostSetMap &expect,
+                         const ServerHostSetMap &actual);
 #define assertEqual(E,A) cut_trace(_assertEqual(E,A))
 
 extern void _assertEqualJSONString(

--- a/server/test/testHostResourceQueryOption.cc
+++ b/server/test/testHostResourceQueryOption.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Project Hatohol
+ * Copyright (C) 2014,2016 Project Hatohol
  *
  * This file is part of Hatohol.
  *
@@ -653,6 +653,54 @@ void test_copyConstructor(void)
 			            opt0.getDataQueryContext().getUsedCount());
 	}
 	cppcut_assert_equal(1, opt0.getDataQueryContext().getUsedCount());
+}
+
+void test_copyConstructorForImplContent(void)
+{
+	// check the members
+	const ServerIdType    targetServerId = 3;
+	const LocalHostIdType targetHostId = "TestHostId";
+	const HostgroupIdType targetHostgroupId = "TestHostGRP";
+	const bool            excludeDefunctServers = true;
+	const ServerIdSet     selectedServerIdSet({5, 8, 10});
+	const ServerIdSet     excludedServerIdSet({7, 9});
+	const ServerHostGrpSetMap selectedServerHostgroupSetMap({
+	  {4, {"G1", "G2"}}, {6, {"G10"}}
+	});
+	const ServerHostGrpSetMap excludedServerHostgroupSetMap({
+	  {5, {"EG1"}}, {10, {"EG2", "EG3"}}
+	});
+	const ServerHostSetMap selectedServerHostSetMap({
+	  {11, {"Host1", "HostX"}}, {100, {"ABC"}}
+	});
+	const ServerHostSetMap excludedServerHostSetMap({
+	  {20, {"Fish"}},
+	});
+
+	HostResourceQueryOption opt0(TEST_SYNAPSE);
+	opt0.setTargetServerId(targetServerId);
+	opt0.setTargetHostId(targetHostId);
+	opt0.setTargetHostgroupId(targetHostgroupId);
+	opt0.setExcludeDefunctServers(excludeDefunctServers);
+	opt0.setSelectedServerIds(selectedServerIdSet);
+	opt0.setExcludedServerIds(excludedServerIdSet);
+	opt0.setSelectedHostgroupIds(selectedServerHostgroupSetMap);
+	opt0.setExcludedHostgroupIds(excludedServerHostgroupSetMap);
+	opt0.setSelectedHostIds(selectedServerHostSetMap);
+	opt0.setExcludedHostIds(excludedServerHostSetMap);
+
+	HostResourceQueryOption opt1(opt0);
+	cppcut_assert_equal(targetServerId, opt1.getTargetServerId());
+	cppcut_assert_equal(targetHostId, opt1.getTargetHostId());
+	cppcut_assert_equal(targetHostgroupId, opt1.getTargetHostgroupId());
+	assertEqual(selectedServerIdSet, opt1.getSelectedServerIds());
+	assertEqual(excludedServerIdSet, opt1.getExcludedServerIds());
+	assertEqual(selectedServerHostgroupSetMap,
+	            opt1.getSelectedHostgroupIds());
+	assertEqual(excludedServerHostgroupSetMap,
+	            opt1.getExcludedHostgroupIds());
+	assertEqual(selectedServerHostSetMap, opt1.getSelectedHostIds());
+	assertEqual(excludedServerHostSetMap, opt1.getExcludedHostIds());
 }
 
 void test_makeConditionServer(void)


### PR DESCRIPTION
This PR fixes a problem in which the some members in
HostResourceQueryOption aren't copied in the copy
constructor.