### PR TITLE
[server][RetResourceSummary] Exclude HOLD state.

### DIFF
--- a/server/src/RestResourceSummary.cc
+++ b/server/src/RestResourceSummary.cc
@@ -118,7 +118,6 @@ static bool setAssignedIncidentStatusCondition(
 
 	// Remove system-defined statues that shouldn't be treated as "Assigned".
 	customIncidentStatusMap.erase(IncidentSenderHatohol::STATUS_NONE);
-	customIncidentStatusMap.erase(IncidentSenderHatohol::STATUS_HOLD);
 
 	for (auto &pair: customIncidentStatusMap) {
 		const string &status = pair.first;


### PR DESCRIPTION
Unhandled import incidents should include NONE.
Currently behavior including HOLD makes users confused.