### PR TITLE
Replace StringUtils::toString to std::to_string

### DIFF
--- a/server/mlpl/src/StringUtils.cc
+++ b/server/mlpl/src/StringUtils.cc
@@ -197,16 +197,6 @@ bool StringUtils::isNumber(const string &str, bool *isFloat)
 	return isNumber(str.c_str(), isFloat);
 }
 
-string StringUtils::toString(int number)
-{
-	return sprintf("%d", number);
-}
-
-string StringUtils::toString(uint64_t number)
-{
-	return sprintf("%" PRIu64, number);
-}
-
 string StringUtils::toLower(string str)
 {
 	transform(str.begin(), str.end(), str.begin(), ::tolower);

--- a/server/mlpl/src/StringUtils.h
+++ b/server/mlpl/src/StringUtils.h
@@ -57,8 +57,6 @@ namespace StringUtils {
 	std::string vsprintf(const char *fmt, va_list ap);
 	bool isNumber(const char *str, bool *isFloat = NULL);
 	bool isNumber(const std::string &str, bool *isFloat = NULL);
-	std::string toString(int number);
-	std::string toString(uint64_t number);
 	std::string toLower(std::string str);
 	std::string stripBothEndsSpaces(const std::string &str);
 

--- a/server/mlpl/test/testStringUtils.cc
+++ b/server/mlpl/test/testStringUtils.cc
@@ -257,12 +257,6 @@ void test_isNumberString(void)
 	cppcut_assert_equal(false, StringUtils::isNumber(str2));
 }
 
-void test_toStringFromInt(void)
-{
-	cppcut_assert_equal(string("57"), StringUtils::toString(57));
-	cppcut_assert_equal(string("-205"), StringUtils::toString(-205));
-}
-
 void test_toLower(void)
 {
 	const char *src      = "AbCdEf#2";

--- a/server/src/ArmRedmine.cc
+++ b/server/src/ArmRedmine.cc
@@ -157,7 +157,7 @@ struct ArmRedmine::Impl
 		}
 		if (m_page > 1) {
 			query += "&page=";
-			query += StringUtils::toString(m_page);
+			query += to_string(m_page);
 		}
 		return query;
 	}

--- a/server/src/FaceRest.cc
+++ b/server/src/FaceRest.cc
@@ -1068,7 +1068,7 @@ void FaceRest::ResourceHandler::addServersMap(
 	               monitoringServers.size(), armPluginInfoVect.size());
 	for (; it != monitoringServers.end(); ++it, ++pluginIt) {
 		const MonitoringServerInfo &serverInfo = *it;
-		agent.startObject(StringUtils::toString(serverInfo.id));
+		agent.startObject(to_string(serverInfo.id));
 		agent.add("name", serverInfo.hostName);
 		agent.add("nickname", serverInfo.nickname);
 		agent.add("type", serverInfo.type);
@@ -1088,7 +1088,7 @@ void FaceRest::ResourceHandler::addServersMap(
 		THROW_HATOHOL_EXCEPTION_IF_NOT_OK(
 		  addHostgroupsMap(agent, serverInfo, hostgroups));
 		agent.endObject(); // "gropus"
-		agent.endObject(); // toString(serverInfo.id)
+		agent.endObject(); // to_string(serverInfo.id)
 	}
 	agent.endObject();
 }
@@ -1103,7 +1103,7 @@ void FaceRest::ResourceHandler::addIncidentTrackersMap(JSONBuilder &agent)
 	HatoholError err;
 	agent.startObject("incidentTrackers");
 	for (auto &tracker : trackers) {
-		agent.startObject(StringUtils::toString(tracker.id));
+		agent.startObject(to_string(tracker.id));
 		agent.add("type", tracker.type);
 		agent.add("nickname", tracker.nickname);
 		agent.add("baseURL", tracker.baseURL);

--- a/server/src/GateJSONEventMessage.cc
+++ b/server/src/GateJSONEventMessage.cc
@@ -434,7 +434,7 @@ int64_t GateJSONEventMessage::getID()
 string GateJSONEventMessage::getIDString()
 {
 	const uint64_t id = static_cast<uint64_t>(m_impl->getID());
-	string idString = StringUtils::toString(id);
+	string idString = to_string(id);
 	string fixedIdString;
 	const int digitNum = EVENT_ID_DIGIT_NUM;
 	const int numPads = digitNum - idString.size();

--- a/server/src/HatoholArmPluginGateHAPI2.cc
+++ b/server/src/HatoholArmPluginGateHAPI2.cc
@@ -1061,7 +1061,7 @@ struct HatoholArmPluginGateHAPI2::Impl
 
 		envs.push_back(StringUtils::sprintf(
 		  "HAPI_MONITORING_SERVER_ID=%s",
-		  StringUtils::toString(m_pluginInfo.serverId).c_str()));
+		  to_string(m_pluginInfo.serverId).c_str()));
 
 		envs.push_back(StringUtils::sprintf(
 		  "HAPI_AMQP_URL=%s",
@@ -1091,7 +1091,7 @@ struct HatoholArmPluginGateHAPI2::Impl
 		const int port = soup_uri_get_port(uri);
 		envs.push_back(StringUtils::sprintf(
 		  "HAPI_AMQP_PORT=%s",
-		  port ? StringUtils::toString(port).c_str() : ""));
+		  port ? to_string(port).c_str() : ""));
 
 		const char *user = soup_uri_get_user(uri);
 		envs.push_back(StringUtils::sprintf(

--- a/server/src/IncidentSenderHatohol.cc
+++ b/server/src/IncidentSenderHatohol.cc
@@ -87,7 +87,7 @@ struct IncidentSenderHatohol::Impl
 		incidentInfo.serverId = eventInfo.serverId;
 		incidentInfo.eventId = eventInfo.id;
 		incidentInfo.triggerId = eventInfo.triggerId;
-		incidentInfo.identifier = StringUtils::toString(eventInfo.unifiedId);
+		incidentInfo.identifier = to_string(eventInfo.unifiedId);
 		incidentInfo.location = "";
 		incidentInfo.status = STATUS_NONE;
 		incidentInfo.priority = "";

--- a/server/src/RedmineAPI.cc
+++ b/server/src/RedmineAPI.cc
@@ -90,7 +90,7 @@ bool parseIssue(JSONParser &agent, IncidentInfo &incidentInfo)
 		MLPL_ERR("Failed to parse Incident ID.\n");
 		return false;
 	}
-	incidentInfo.identifier = StringUtils::toString((uint64_t)issueId);
+	incidentInfo.identifier = to_string((uint64_t)issueId);
 
 	agent.startObject("status");
 	agent.read("name", incidentInfo.status);
@@ -142,7 +142,7 @@ bool parseDateTime(JSONParser &agent, const string &objectName,
 		time.tv_sec = 0;
 	time.tv_nsec = 0;
 
-	return true;	
+	return true;
 }
 
 void logErrors(JSONParser &agent)

--- a/server/src/RestResourceMonitoring.cc
+++ b/server/src/RestResourceMonitoring.cc
@@ -737,7 +737,7 @@ void RestResourceMonitoring::historyFetchedCallback(
 		// They are obvious because they are provided by the client.
 		/*
 		// use string to treat 64bit value properly on certain browsers
-		string itemId = StringUtils::toString(historyInfo.itemId);
+		string itemId = to_string(historyInfo.itemId);
 		agent.add("serverId",  serverId);
 		agent.add("itemId",    itemId);
 		*/

--- a/server/src/RestResourceServer.cc
+++ b/server/src/RestResourceServer.cc
@@ -714,7 +714,7 @@ void RestResourceServer::handlerServerConnStat(void)
 	for (size_t idx = 0; idx < serverConnStatVec.size(); idx++) {
 		const ServerConnStatus &svConnStat = serverConnStatVec[idx];
 		const ArmInfo &armInfo = svConnStat.armInfo;
-		agent.startObject(StringUtils::toString(svConnStat.serverId));
+		agent.startObject(to_string(svConnStat.serverId));
 		agent.add("running",         armInfo.running);
 		agent.add("status",          armInfo.stat);
 		agent.add("statUpdateTime",  armInfo.statUpdateTime);

--- a/server/src/RestResourceUser.cc
+++ b/server/src/RestResourceUser.cc
@@ -144,9 +144,9 @@ static void addUserRolesMap(
 	UserRoleInfoList userRoleList;
 	UserRoleQueryOption option(job->m_dataQueryContextPtr);
 	string nonePrivilege
-	  = StringUtils::toString(OperationPrivilege::NONE_PRIVILEGE);
+	  = to_string(OperationPrivilege::NONE_PRIVILEGE);
 	string allPrivileges
-	  = StringUtils::toString(OperationPrivilege::ALL_PRIVILEGES);
+	  = to_string(OperationPrivilege::ALL_PRIVILEGES);
 	dataStore->getUserRoleList(userRoleList, option);
 
 	agent.startObject("userRoles");
@@ -159,7 +159,7 @@ static void addUserRolesMap(
 	agent.endObject();
 	for (; it != userRoleList.end(); ++it) {
 		UserRoleInfo &userRoleInfo = *it;
-		agent.startObject(StringUtils::toString(userRoleInfo.flags));
+		agent.startObject(to_string(userRoleInfo.flags));
 		agent.add("name", userRoleInfo.name);
 		agent.endObject();
 	}
@@ -331,9 +331,9 @@ void RestResourceUser::handlerGetAccessInfo(void)
 		string serverIdString;
 		HostGrpAccessInfoMap *hostgroupsMap = it->second;
 		if (serverId == ALL_SERVERS)
-			serverIdString = StringUtils::toString(-1);
+			serverIdString = to_string(-1);
 		else
-			serverIdString = StringUtils::toString(serverId);
+			serverIdString = to_string(serverId);
 		agent.startObject(serverIdString);
 		agent.startObject("allowedHostgroups");
 		HostGrpAccessInfoMapIterator it2 = hostgroupsMap->begin();

--- a/server/test/DBTablesTest.cc
+++ b/server/test/DBTablesTest.cc
@@ -1738,7 +1738,7 @@ EventIdType findLastEventId(const ServerIdType &serverId)
 	}
 	if (!found)
 		return EVENT_NOT_FOUND;
-	return StringUtils::toString(maxId);
+	return to_string(maxId);
 }
 
 SmartTime findTimeOfLastEvent(

--- a/server/test/FaceRestTestUtils.cc
+++ b/server/test/FaceRestTestUtils.cc
@@ -39,7 +39,7 @@ void startFaceRest(void)
 {
 	struct : public FaceRestParam {
 		Mutex mutex;
-		virtual void setupDoneNotifyFunc(void) 
+		virtual void setupDoneNotifyFunc(void)
 		{
 			mutex.unlock();
 		}
@@ -392,7 +392,7 @@ void assertServersIdNameHashInParser(JSONParser *parser)
 	assertStartObject(parser, "servers");
 	for (size_t i = 0; i < NumTestServerInfo; i++) {
 		const MonitoringServerInfo &svInfo = testServerInfo[i];
-		assertStartObject(parser, StringUtils::toString(svInfo.id));
+		assertStartObject(parser, to_string(svInfo.id));
 		assertValueInParser(parser, "name", svInfo.hostName);
 
 		const ArmPluginInfo *pluginInfo =

--- a/server/test/testDBTablesConfig.cc
+++ b/server/test/testDBTablesConfig.cc
@@ -988,7 +988,7 @@ void data_isHatoholArmPlugin(void)
 	gcut_add_datum("MONITORING_SYSTEM_HAPI2",
 	               "data", G_TYPE_INT, (int)MONITORING_SYSTEM_HAPI2,
 	               "expect", G_TYPE_BOOLEAN, TRUE, NULL);
-	gcut_add_datum("MONITORING_SYSTEM_FAKE", 
+	gcut_add_datum("MONITORING_SYSTEM_FAKE",
 	               "data", G_TYPE_INT, (int)MONITORING_SYSTEM_FAKE,
 	               "expect", G_TYPE_BOOLEAN, FALSE, NULL);
 }
@@ -1467,7 +1467,7 @@ void test_upsertSeverityRankInfoUpdate(void)
 	dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
 	dbConfig.upsertSeverityRankInfo(severityRankInfo, privilege);
 	const string statement = "SELECT * FROM severity_ranks WHERE id = "+
-		StringUtils::toString(static_cast<int>(actualId));
+		to_string(static_cast<int>(actualId));
 	const string expect =
 	  StringUtils::sprintf("%" FMT_SEVERITY_RANK_ID "|%d|%s|%s|%d",
 			       actualId, severityRankInfo.status,
@@ -1752,7 +1752,7 @@ void test_upsertCustomIncidentStatusUpdate(void)
 	dbConfig.upsertCustomIncidentStatus(customIncidentStatus, privilege);
 	const string statement =
 		"SELECT * FROM custom_incident_statuses WHERE id = " +
-		StringUtils::toString(static_cast<int>(actualId));
+		to_string(static_cast<int>(actualId));
 	const string expect =
 	  StringUtils::sprintf("%" FMT_CUSTOM_INCIDENT_STATUS_ID "|%s|%s",
 			       actualId,
@@ -1777,7 +1777,7 @@ void test_updateCustomIncidentStatus(void)
 	dbConfig.updateCustomIncidentStatus(customIncidentStatus, privilege);
 	const string statement =
 		"SELECT * FROM custom_incident_statuses WHERE id = " +
-		StringUtils::toString(static_cast<int>(actualId));
+		to_string(static_cast<int>(actualId));
 	const string expect =
 	  StringUtils::sprintf("%" FMT_CUSTOM_INCIDENT_STATUS_ID "|%s|%s",
 			       actualId,

--- a/server/test/testDBTablesHost.cc
+++ b/server/test/testDBTablesHost.cc
@@ -1296,7 +1296,7 @@ void test_syncHostgroups(void)
 		const Hostgroup &svHostgroup = testHostgroup[i];
 		if (svHostgroup.serverId != targetServerId)
 			continue;
-		if (svHostgroup.idInServer != StringUtils::toString(targetHostgroupId))
+		if (svHostgroup.idInServer != to_string(targetHostgroupId))
 			continue;
 		hostgroupMap[svHostgroup.idInServer] = &svHostgroup;
 	}

--- a/server/test/testDBTablesLastInfo.cc
+++ b/server/test/testDBTablesLastInfo.cc
@@ -76,7 +76,7 @@ void test_upsertLastInfo(void)
 	OperationPrivilege privilege(USER_ID_SYSTEM);
 	LastInfoIdType lastInfoId = dbLastInfo.upsertLastInfo(lastInfo, privilege);
 	const string statement = "SELECT * FROM last_info WHERE last_info_id = "+
-		StringUtils::toString(static_cast<int>(NumTestLastInfoDef + 1));
+		to_string(static_cast<int>(NumTestLastInfoDef + 1));
 	const string expect =
 	  StringUtils::sprintf("%" FMT_LAST_INFO_ID "|%d|%s|%d",
 			       lastInfoId, lastInfo.dataType,
@@ -177,7 +177,7 @@ void test_deleteLastInfoList(void)
 	// check existence
 	const string statement =
 	  "SELECT * FROM last_info WHERE last_info_id = " +
-	  StringUtils::toString(actualId);
+	  to_string(actualId);
 	const string expect =
 	  StringUtils::sprintf("%" FMT_LAST_INFO_ID "|%d|%s|%d",
 	                       actualId,
@@ -192,7 +192,7 @@ void test_deleteLastInfoList(void)
 
 	const string afterDeleteStatement =
 	  "SELECT * FROM last_info WHERE last_info_id = " +
-	  StringUtils::toString(actualId);
+	  to_string(actualId);
 	const string afterDeleteExpect = "";
 	assertDBContent(&dbLastInfo.getDBAgent(),
 	                afterDeleteStatement, afterDeleteExpect);

--- a/server/test/testDBTablesMonitoring.cc
+++ b/server/test/testDBTablesMonitoring.cc
@@ -1287,9 +1287,9 @@ void test_addEventInfoUnifiedId(void)
 			expected += "\n";
 		if (!actual.empty())
 			actual += "\n";
-		expected += StringUtils::toString(i);
+		expected += to_string(i);
 		expected += string("|") + makeEventOutput(*it);
-		actual += StringUtils::toString(it->unifiedId);
+		actual += to_string(it->unifiedId);
 		actual += string("|") + makeEventOutput(*it);
 	}
 	cppcut_assert_equal(expected, actual);

--- a/server/test/testFaceRestCustomIncidentStatus.cc
+++ b/server/test/testFaceRestCustomIncidentStatus.cc
@@ -142,7 +142,7 @@ static void createTestCustomIncidentStatus(
 static void createPostData(const CustomIncidentStatus &customIncidentStatus,
 			   StringMap &params)
 {
-	params["id"]     = StringUtils::toString(customIncidentStatus.id);
+	params["id"]     = to_string(customIncidentStatus.id);
 	params["code"]  = customIncidentStatus.code;
 	params["label"]  = customIncidentStatus.label;
 }

--- a/server/test/testFaceRestIncident.cc
+++ b/server/test/testFaceRestIncident.cc
@@ -50,11 +50,11 @@ static void incidentInfo2StringMap(
 	dest["status"] = src.status;
 	dest["priority"] = src.priority;
 	dest["assignee"] = src.assignee;
-	dest["doneRatio"] = StringUtils::toString(src.doneRatio);
+	dest["doneRatio"] = to_string(src.doneRatio);
 
 	/* Hatohol doesn't allow changing following properties:
-	dest["trackerId"] = StringUtils::toString(src.trackerId);
-	dest["serverId"] = StringUtils::toString(serc.serverId);
+	dest["trackerId"] = to_string(src.trackerId);
+	dest["serverId"] = to_string(serc.serverId);
 	dest["eventId"] = src.eventId;
 	dest["triggerId"] = src.triggerId;
 	dest["identifier"] = src.identifier;
@@ -406,7 +406,7 @@ void test_getUnknownSubResource(void)
 	getServerResponse(arg);
 	cppcut_assert_equal(404, arg.httpStatusCode);
 }
-	
+
 void test_updateIncidentComment(void)
 {
 	loadTestDBIncidents();

--- a/server/test/testFaceRestIncidentTracker.cc
+++ b/server/test/testFaceRestIncidentTracker.cc
@@ -131,8 +131,8 @@ static void createTestIncidentTracker(IncidentTrackerInfo &incidentTracker)
 static void createPostData(const IncidentTrackerInfo &incidentTracker,
 			   StringMap &params)
 {
-	params["id"]        = StringUtils::toString(incidentTracker.id);
-	params["type"]      = StringUtils::toString((int)incidentTracker.type);
+	params["id"]        = to_string(incidentTracker.id);
+	params["type"]      = to_string((int)incidentTracker.type);
 	params["nickname"]  = incidentTracker.nickname;
 	params["baseURL"]   = incidentTracker.baseURL;
 	params["projectId"] = incidentTracker.projectId;

--- a/server/test/testFaceRestMonitoring.cc
+++ b/server/test/testFaceRestMonitoring.cc
@@ -106,7 +106,7 @@ static void assertHostsIdNameHashInParser(const TriggerInfo *triggers,
 	assertStartObject(parser, "servers");
 	for (size_t i = 0; i < numberOfTriggers; i++) {
 		const TriggerInfo &triggerInfo = triggers[i];
-		assertStartObject(parser, StringUtils::toString(triggerInfo.serverId));
+		assertStartObject(parser, to_string(triggerInfo.serverId));
 		assertStartObject(parser, "hosts");
 		assertStartObject(parser, triggerInfo.hostIdInServer);
 		assertValueInParser(parser, "name", triggerInfo.hostName);
@@ -123,7 +123,7 @@ static void assertHostsIdNameHashInParser(
 	assertStartObject(parser, "servers");
 	for (size_t i = 0; i < expectedRecords.size(); i++) {
 		const EventInfo &eventInfo = *expectedRecords[i];
-		assertStartObject(parser, StringUtils::toString(eventInfo.serverId));
+		assertStartObject(parser, to_string(eventInfo.serverId));
 		assertStartObject(parser, "hosts");
 		assertStartObject(parser, eventInfo.hostIdInServer);
 		assertValueInParser(parser, "name", eventInfo.hostName);
@@ -753,7 +753,7 @@ void test_getHistoryWithMinimumParameter(void)
 
 	RequestArg arg("/history");
 	StringMap params;
-	params["serverId"] = StringUtils::toString(testItemInfo[0].serverId);
+	params["serverId"] = to_string(testItemInfo[0].serverId);
 	params["itemId"] = testItemInfo[0].id;
 	arg.parameters = params;
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);
@@ -770,7 +770,7 @@ void test_getHistoryWithInvalidItemId(void)
 
 	RequestArg arg("/history");
 	StringMap params;
-	params["serverId"] = StringUtils::toString(testItemInfo[0].serverId);
+	params["serverId"] = to_string(testItemInfo[0].serverId);
 	params["itemId"] = testItemInfo[0].id;
 	arg.parameters = params;
 	arg.userId = findUserWith(OPPRVLG_GET_ALL_SERVER);

--- a/server/test/testFaceRestServer.cc
+++ b/server/test/testFaceRestServer.cc
@@ -144,7 +144,7 @@ static void _assertServerConnStat(JSONParser *parser)
 	assertStartObject(parser, "serverConnStat");
 	while (!expectIdSet.empty()) {
 		serverIdItr = expectIdSet.begin();
-		const string serverIdStr = StringUtils::toString(*serverIdItr);
+		const string serverIdStr = to_string(*serverIdItr);
 		assertStartObject(parser, serverIdStr);
 		assertValueInParser(parser, "running", false);
 		assertValueInParser(parser, "status", ARM_WORK_STAT_INIT);
@@ -189,18 +189,18 @@ static void serverInfo2StringMap(
   const MonitoringServerInfo &svInfo, const ArmPluginInfo &armInfo,
   StringMap &dest)
 {
-	dest["type"] = StringUtils::toString(svInfo.type);
+	dest["type"] = to_string(svInfo.type);
 	dest["hostName"] = svInfo.hostName;
 	dest["ipAddress"] = svInfo.ipAddress;
 	dest["nickname"] = svInfo.nickname;
-	dest["port"] = StringUtils::toString(svInfo.port);
+	dest["port"] = to_string(svInfo.port);
 	dest["userName"] = svInfo.userName;
 	dest["password"] = svInfo.password;
 	dest["dbName"] = svInfo.dbName;
 	dest["pollingInterval"]
-	  = StringUtils::toString(svInfo.pollingIntervalSec);
+	  = to_string(svInfo.pollingIntervalSec);
 	dest["retryInterval"]
-	  = StringUtils::toString(svInfo.retryIntervalSec);
+	  = to_string(svInfo.retryIntervalSec);
 	dest["baseURL"] = svInfo.baseURL;
 	dest["extendedInfo"] = svInfo.extendedInfo;
 
@@ -273,7 +273,7 @@ void test_addServerHapiJSON(void)
 	armPluginInfo.tlsCACertificatePath = "/etc/hatohol/ca-cert.pem";
 
 	StringMap params;
-	params["type"] = StringUtils::toString(expected.type);
+	params["type"] = to_string(expected.type);
 	params["nickname"] = expected.nickname;
 	params["brokerUrl"] = armPluginInfo.brokerUrl;
 	params["tlsCertificatePath"] = armPluginInfo.tlsCertificatePath;

--- a/server/test/testFaceRestSeverityRank.cc
+++ b/server/test/testFaceRestSeverityRank.cc
@@ -143,8 +143,8 @@ static void createTestSeverityRank(SeverityRankInfo &severityRank)
 static void createPostData(const SeverityRankInfo &severityRank,
 			   StringMap &params)
 {
-	params["id"]     = StringUtils::toString(severityRank.id);
-	params["status"] = StringUtils::toString(static_cast<int>(severityRank.status));
+	params["id"]     = to_string(severityRank.id);
+	params["status"] = to_string(static_cast<int>(severityRank.status));
 	params["color"]  = severityRank.color;
 	params["label"]  = severityRank.label;
 	if (severityRank.asImportant) {

--- a/server/test/testFaceRestUser.cc
+++ b/server/test/testFaceRestUser.cc
@@ -516,7 +516,7 @@ static void assertUserRolesMapInParser(JSONParser *parser)
 
 	for (size_t i = 0; i < NumTestUserRoleInfo; i++) {
 		const UserRoleInfo &userRoleInfo = testUserRoleInfo[i];
-		flagsStr = StringUtils::toString(userRoleInfo.flags);
+		flagsStr = to_string(userRoleInfo.flags);
 		assertStartObject(parser, flagsStr);
 		assertValueInParser(parser, "name", userRoleInfo.name);
 		parser->endObject();
@@ -585,7 +585,7 @@ static void _assertAllowedServers(const string &path, const UserIdType &userId,
 		if (serverId == ALL_SERVERS)
 			idStr = "-1";
 		else
-			idStr = StringUtils::toString(serverId);
+			idStr = to_string(serverId);
 		assertStartObject(parser, idStr);
 		HostGrpAccessInfoMap *hostGrpAccessInfoMap = it->second;
 		assertServerAccessInfo(parser, *hostGrpAccessInfoMap);

--- a/server/test/testIncidentSenderRedmine.cc
+++ b/server/test/testIncidentSenderRedmine.cc
@@ -236,7 +236,7 @@ static void makeExpectedIncidentInfo(IncidentInfo &incident,
 	incident.eventId = event.id;
 	incident.triggerId = event.triggerId;
 	incident.trackerId = tracker.id;
-	incident.identifier = StringUtils::toString((int)postedIssue.id);
+	incident.identifier = to_string((int)postedIssue.id);
 	incident.location = tracker.baseURL + "/issues/" + incident.identifier;
 	incident.status = postedIssue.getStatusName();
 	incident.assignee = "";
@@ -286,7 +286,7 @@ void _assertSend(const HatoholErrorCode &expected,
 		int64_t trackerId = 0;
 		agent.read("id", trackerId);
 		cppcut_assert_equal(tracker.trackerId,
-				    StringUtils::toString((int)trackerId));
+				    to_string((int)trackerId));
 		agent.endObject();
 	}
 

--- a/server/tools/hatohol-def-src-file-generator.cc
+++ b/server/tools/hatohol-def-src-file-generator.cc
@@ -90,17 +90,17 @@ static const char *LGPL_V3_HEADER_PLAIN =
 
 static string toString(const int value)
 {
-	return StringUtils::sprintf("%d", value);
+	return to_string(value);
 }
 
 static string toString(const uint64_t value)
 {
-	return StringUtils::sprintf("%" PRIu64, value);
+	return to_string(value);
 }
 
 static string toString(const string &value)
 {
-	return StringUtils::sprintf("'%s'", value.c_str());
+	return "'" + value + "'";
 }
 
 static string makeLine(LanguageType langType,


### PR DESCRIPTION
StringUtils::toStringはc++11でstd::to_stringとして標準化されているので置き換えました。