### PR TITLE
Use pragma once instead of include guards

### DIFF
--- a/server/common/AMQPConnection.h
+++ b/server/common/AMQPConnection.h
@@ -16,9 +16,7 @@
  * License along with Hatohol. If not, see
  * <http://www.gnu.org/licenses/>.
  */
-#ifndef AMQPConnection_h
-#define AMQPConnection_h
-
+#pragma once
 #include "AMQPConnectionInfo.h"
 #include <glib.h>
 #include <unistd.h>
@@ -84,4 +82,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // AMQPConnection_h

--- a/server/common/AMQPConnectionInfo.h
+++ b/server/common/AMQPConnectionInfo.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AMQPConnectionInfo_h
-#define AMQPConnectionInfo_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include "Params.h"
@@ -66,4 +64,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // AMQPConnectionInfo_h

--- a/server/common/AMQPConsumer.h
+++ b/server/common/AMQPConsumer.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AMQPConsumer_h
-#define AMQPConsumer_h
-
+#pragma once
 #include <functional>
 #include "HatoholThreadBase.h"
 #include "AMQPConnection.h"
@@ -53,4 +51,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // AMQPConsumer_h

--- a/server/common/AMQPMessageHandler.h
+++ b/server/common/AMQPMessageHandler.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AMQPMessageHandler_h
-#define AMQPMessageHandler_h
-
+#pragma once
 #include "Params.h"
 #include "AMQPConnection.h"
 #include "AMQPConsumer.h"
@@ -35,4 +33,3 @@ public:
 			    const AMQPMessage &message) = 0;
 };
 
-#endif // AMQPMessageHandler_h

--- a/server/common/AMQPPublisher.h
+++ b/server/common/AMQPPublisher.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AMQPPublisher_h
-#define AMQPPublisher_h
-
+#pragma once
 #include "Params.h"
 #include "AMQPConnection.h"
 
@@ -41,4 +39,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // AMQPPublisher_h

--- a/server/common/ArmPluginInfo.h
+++ b/server/common/ArmPluginInfo.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmPluginInfo_h
-#define ArmPluginInfo_h
-
+#pragma once
 #include <string>
 #include <vector>
 #include <map>
@@ -73,4 +71,3 @@ typedef std::map<MonitoringSystemType, ArmPluginInfo *> ArmPluginInfoMap;
 typedef ArmPluginInfoMap::iterator          ArmPluginInfoMapIterator;
 typedef ArmPluginInfoMap::const_iterator    ArmPluginInfoMapConstIterator;
 
-#endif // ArmPluginInfo_h

--- a/server/common/ArmStatus.h
+++ b/server/common/ArmStatus.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmStatus_h
-#define ArmStatus_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <SmartTime.h>
@@ -77,4 +75,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // ArmStatus_h

--- a/server/common/DataStoreException.h
+++ b/server/common/DataStoreException.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataStoreException_h
-#define DataStoreException_h
-
+#pragma once
 #include "HatoholException.h"
 
 class DataStoreException : public HatoholException
@@ -38,4 +36,3 @@ do { \
 	throw DataStoreException(msg, __FILE__, __LINE__); \
 } while (0)
 
-#endif // DataStoreException_h

--- a/server/common/EndianConverter.h
+++ b/server/common/EndianConverter.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EndianConverter_h
-#define EndianConverter_h
+#pragma once
 
 #if defined __x86_64__ || defined __i386__
 class EndianConverter {
@@ -73,4 +72,3 @@ public:
 };
 #endif // defined __x86_64__ || defined __i386__
 
-#endif // EndianConverter_h

--- a/server/common/HatoholArmPluginInterfaceHAPI2.h
+++ b/server/common/HatoholArmPluginInterfaceHAPI2.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholArmPluginInterfaceHAPI2_h
-#define HatoholArmPluginInterfaceHAPI2_h
-
+#pragma once
 #include <string>
 #include <random>
 #include "HatoholThreadBase.h"
@@ -203,4 +201,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // HatoholArmPluginInterfaceHAPI2_h

--- a/server/common/HatoholError.h
+++ b/server/common/HatoholError.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholError_h
-#define HatoholError_h
-
+#pragma once
 #include <string>
 #include <map>
 
@@ -173,4 +171,3 @@ private:
 	std::string      m_optMessage;
 };
 
-#endif // HatoholError_h

--- a/server/common/HatoholException.h
+++ b/server/common/HatoholException.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholException_h
-#define HatoholException_h
-
+#pragma once
 #include <Logger.h>
 #include <StringUtils.h>
 #include <exception>
@@ -165,4 +163,3 @@ protected:
 	virtual void onCaught(void);
 };
 
-#endif // HatoholException_h

--- a/server/common/HatoholThreadBase.h
+++ b/server/common/HatoholThreadBase.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholThreadBase_h
-#define HatoholThreadBase_h
-
+#pragma once
 #include <list>
 #include <memory>
 #include <glib.h>
@@ -107,6 +105,4 @@ private:
 	static void threadCleanup(HatoholThreadArg *arg);
 	static gpointer threadStarter(gpointer data);
 };
-
-#endif // HatoholThreadBase_h
 

--- a/server/common/ItemData.h
+++ b/server/common/ItemData.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemData_h
-#define ItemData_h
-
+#pragma once
 #include <string>
 #include <sstream>
 #include <map>
@@ -387,4 +385,3 @@ template<> bool ItemUint64::operator ==(const ItemData &itemData) const;
 template<> ItemData * ItemString::operator /(const ItemData &itemData) const;
 template<> ItemData * ItemString::operator /(const ItemData &itemData) const;
 
-#endif // ItemData_h

--- a/server/common/ItemDataPtr.h
+++ b/server/common/ItemDataPtr.h
@@ -17,13 +17,10 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemDataPtr_h
-#define ItemDataPtr_h
-
+#pragma once
 #include "ItemData.h"
 #include "UsedCountablePtr.h"
 
 typedef UsedCountablePtr<ItemData>       VariableItemDataPtr;
 typedef UsedCountablePtr<const ItemData> ItemDataPtr;
 
-#endif // #define ItemDataPtr_h

--- a/server/common/ItemDataUtils.h
+++ b/server/common/ItemDataUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemDataUtils_h 
-#define ItemDataUtils_h
-
+#pragma once
 #include <string>
 #include "ItemDataPtr.h"
 #include "ItemGroupPtr.h"
@@ -100,7 +98,4 @@ private:
 typedef std::vector<ItemDataIndex *>        ItemDataIndexVector;
 typedef ItemDataIndexVector::iterator       ItemDataIndexVectorIterator;
 typedef ItemDataIndexVector::const_iterator ItemDataIndexVectorConstIterator;
-
-#endif // ItemDataUtils_h
-
 

--- a/server/common/ItemEnum.h
+++ b/server/common/ItemEnum.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemEnum_h
-#define ItemEnum_h
+#pragma once
 
 enum
 {
@@ -472,4 +471,3 @@ enum
 	ITEM_ID_ZBX_TRIGGERS_EXPANDED_DESCRIPTION,
 };
 
-#endif // ItemEnum_h

--- a/server/common/ItemGroup.h
+++ b/server/common/ItemGroup.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemGroup_h
-#define ItemGroup_h
-
+#pragma once
 #include <map>
 #include <list>
 #include <inttypes.h>
@@ -126,4 +124,3 @@ private:
 	  const ItemDataNullFlagType &nullFlag);
 };
 
-#endif  // ItemGroup_h

--- a/server/common/ItemGroupPtr.h
+++ b/server/common/ItemGroupPtr.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemGroupPtr_h
-#define ItemGroupPtr_h
-
+#pragma once
 #include "ItemGroup.h"
 #include "UsedCountablePtr.h"
 
@@ -28,6 +26,4 @@ typedef UsedCountablePtr<const ItemGroup> ItemGroupPtr;
 
 template<>
 UsedCountablePtr<ItemGroup>::UsedCountablePtr(void);
-
-#endif // #define ItemGroupPtr_h
 

--- a/server/common/ItemGroupType.h
+++ b/server/common/ItemGroupType.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemGroupType_h
-#define ItemGroupType_h
-
+#pragma once
 #include <set>
 #include <vector>
 #include "ItemData.h"
@@ -54,6 +52,4 @@ struct ItemGroupTypeSetComp {
 typedef std::set<ItemGroupType *, ItemGroupTypeSetComp> ItemGroupTypeSet;
 typedef ItemGroupTypeSet::iterator       ItemGroupTypeSetIterator;
 typedef ItemGroupTypeSet::const_iterator ItemGroupTypeSetConstIterator;
-
-#endif // ItemGroupType_h
 

--- a/server/common/ItemTable.h
+++ b/server/common/ItemTable.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemTable_h
-#define ItemTable_h
-
+#pragma once
 #include <map>
 #include "UsedCountable.h"
 #include "ItemGroup.h"
@@ -89,4 +87,3 @@ private:
 	std::vector<size_t> m_indexedColumnIndexes;
 };
 
-#endif  // ItemTable_h

--- a/server/common/ItemTablePtr.h
+++ b/server/common/ItemTablePtr.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemTablePtr_h
-#define ItemTablePtr_h
-
+#pragma once
 #include <list>
 #include <map>
 #include "UsedCountablePtr.h"
@@ -38,6 +36,4 @@ template<> ItemTablePtr::UsedCountablePtr(void);
 typedef std::map<ItemGroupPtr, VariableItemTablePtr, ItemGroupPtrComparator>
   ItemGroupTableMap;
 typedef ItemGroupTableMap::iterator ItemGroupTableMapIterator;
-
-#endif // #define ItemTablePtr_h
 

--- a/server/common/JSONBuilder.h
+++ b/server/common/JSONBuilder.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef JSONBuilder_h
-#define JSONBuilder_h
-
+#pragma once
 #include <string>
 #include <json-glib/json-glib.h>
 
@@ -46,4 +44,3 @@ private:
 	JsonBuilder *m_builder;
 };
 
-#endif // JSONBuilder_h

--- a/server/common/JSONParser.h
+++ b/server/common/JSONParser.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef JSONParser_h
-#define JSONParser_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <stack>
@@ -98,4 +96,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // JSONParser_h

--- a/server/common/Monitoring.h
+++ b/server/common/Monitoring.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Monitoring_h
-#define Monitoring_h
-
+#pragma once
 #include <SmartTime.h>
 #include <Params.h>
 #include <vector>
@@ -275,4 +273,3 @@ struct IncidentHistory {
 	static void initialize(IncidentHistory &incidentHistory);
 };
 
-#endif // Monitoring_h

--- a/server/common/MonitoringServerInfo.h
+++ b/server/common/MonitoringServerInfo.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MonitoringServerInfo_h
-#define MonitoringServerInfo_h
-
+#pragma once
 #include <list>
 #include <string>
 #include "Params.h"
@@ -104,4 +102,3 @@ typedef std::list<MonitoringServerInfo>    MonitoringServerInfoList;
 typedef MonitoringServerInfoList::iterator MonitoringServerInfoListIterator;
 typedef MonitoringServerInfoList::const_iterator MonitoringServerInfoListConstIterator;
 
-#endif // MonitoringServerInfo_h

--- a/server/common/NamedPipe.h
+++ b/server/common/NamedPipe.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef NamedPipe_h
-#define NamedPipe_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <glib.h>
@@ -189,4 +187,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // NamedPipe_h

--- a/server/common/Params.h
+++ b/server/common/Params.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Params_h
-#define Params_h
-
+#pragma once
 #include <cstdio>
 #include <stdint.h>
 #include <set>
@@ -258,4 +256,3 @@ enum SyncType {
 static const int      AUTO_INCREMENT_VALUE = 0;
 static const uint64_t AUTO_INCREMENT_VALUE_U64 = 0;
 
-#endif // Params_h

--- a/server/common/UsedCountable.h
+++ b/server/common/UsedCountable.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef UsedCountable_h
-#define UsedCountable_h
-
+#pragma once
 #include <AtomicValue.h>
 
 class UsedCountable {
@@ -38,4 +36,3 @@ private:
 	mutable mlpl::AtomicValue<int> m_usedCount;
 };
 
-#endif // UsedCountable_h

--- a/server/common/UsedCountablePtr.h
+++ b/server/common/UsedCountablePtr.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef UsedCountablePtr_h
-#define UsedCountablePtr_h
-
+#pragma once
 #include <cstdio>
 #include "Utils.h"
 
@@ -89,4 +87,3 @@ private:
 	}
 };
 
-#endif // #define UsedCountablePtr_h

--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Utils_h
-#define Utils_h
-
+#pragma once
 #include <cstdlib>
 #include <vector>
 #include <string>
@@ -298,6 +296,4 @@ do { \
 #define DEMANGLED_TYPE_NAME(X)  Utils::demangle(TYPE_NAME(X)).c_str()
 
 #define ARRAY_SIZE(a)	(sizeof(a)/sizeof(a[0]))
-
-#endif // Utils_h
 

--- a/server/common/ZabbixAPI.h
+++ b/server/common/ZabbixAPI.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZabbixAPI_h
-#define ZabbixAPI_h
-
+#pragma once
 #include <string>
 #include <libsoup/soup.h>
 #include "Monitoring.h"
@@ -368,4 +366,3 @@ private:
 	  const T &dummyValue);
 };
 
-#endif // ZabbixAPI_h

--- a/server/mlpl/src/AtomicValue.h
+++ b/server/mlpl/src/AtomicValue.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AtomicValue_h
-#define AtomicValue_h
+#pragma once
 
 namespace mlpl {
 
@@ -71,6 +70,4 @@ private:
 };
 
 } // namespace mlpl
-
-#endif // AtomicValue_h
 

--- a/server/mlpl/src/EventSemaphore.h
+++ b/server/mlpl/src/EventSemaphore.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef EventSemaphore_h
-#define EventSemaphore_h
+#pragma once
 
 namespace mlpl {
 
@@ -60,6 +59,4 @@ private:
 };
 
 } // namespace mlpl
-
-#endif // EventSemaphore_h
 

--- a/server/mlpl/src/Logger.h
+++ b/server/mlpl/src/Logger.h
@@ -17,12 +17,11 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Logger_h
-#define Logger_h
-
+#pragma once
 #include <pthread.h>
 #include <string>
 #include "ReadWriteLock.h"
+
 namespace mlpl {
 
 enum LogLevel {
@@ -84,6 +83,4 @@ do { \
 #define MLPL_ERR(FMT,  ...) MLPL_P(mlpl::MLPL_LOG_ERR,  FMT, ##__VA_ARGS__)
 #define MLPL_CRIT(FMT, ...) MLPL_P(mlpl::MLPL_LOG_CRIT, FMT, ##__VA_ARGS__)
 #define MLPL_BUG(FMT,  ...) MLPL_P(mlpl::MLPL_LOG_BUG,  FMT, ##__VA_ARGS__)
-
-#endif // Logger_h
 

--- a/server/mlpl/src/Mutex.h
+++ b/server/mlpl/src/Mutex.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Mutex_h
-#define Mutex_h
-
+#pragma once
 #include <pthread.h>
 
 namespace mlpl {
@@ -62,4 +60,3 @@ private:
 
 } // namespace mlpl
 
-#endif // Mutex_h

--- a/server/mlpl/src/ParsableString.h
+++ b/server/mlpl/src/ParsableString.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ParsableString_h
-#define ParsableString_h
-
+#pragma once
 #include <vector>
 #include <list>
 #include <string>
@@ -161,4 +159,3 @@ private:
 
 } // namespace mlpl
 
-#endif // ParsableString_h

--- a/server/mlpl/src/ReadWriteLock.h
+++ b/server/mlpl/src/ReadWriteLock.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ReadWriteLock_h
-#define ReadWriteLock_h
-
+#pragma once
 #include <pthread.h>
 
 namespace mlpl {
@@ -41,4 +39,3 @@ private:
 
 } // namespace mlpl
 
-#endif // ReadWriteLock_h

--- a/server/mlpl/src/Reaper.h
+++ b/server/mlpl/src/Reaper.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Reaper_h
-#define Reaper_h
-
+#pragma once
 namespace mlpl {
 
 template<typename T>
@@ -111,6 +109,4 @@ public:
 };
 
 } // namespace mlpl
-
-#endif // Reaper_h
 

--- a/server/mlpl/src/SeparatorInjector.h
+++ b/server/mlpl/src/SeparatorInjector.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SeparatorInjector_h
-#define SeparatorInjector_h
-
+#pragma once
 #include <string>
 
 namespace mlpl {
@@ -47,4 +45,3 @@ private:
 
 } // namespace mlpl
 
-#endif // SeparatorInjector_h

--- a/server/mlpl/src/SimpleSemaphore.h
+++ b/server/mlpl/src/SimpleSemaphore.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SimpleSemaphore_h
-#define SimpleSemaphore_h
-
+#pragma once
 #include <cstddef>
 
 namespace mlpl {
@@ -88,6 +86,4 @@ private:
 };
 
 } // namespace mlpl
-
-#endif // SimpleSemaphore_h
 

--- a/server/mlpl/src/SmartBuffer.h
+++ b/server/mlpl/src/SmartBuffer.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SmartBuffer_h
-#define SmartBuffer_h
-
+#pragma once
 #include <cstdlib>
 #include <stdint.h>
 #include <string>
@@ -279,4 +277,3 @@ protected:
 
 } // namespace mlpl
 
-#endif // SmartBuffer_h

--- a/server/mlpl/src/SmartQueue.h
+++ b/server/mlpl/src/SmartQueue.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SmartQueue_h
-#define SmartQueue_h
-
+#pragma once
 #include <Mutex.h>
 #include <SimpleSemaphore.h>
 #include <Reaper.h>
@@ -149,4 +147,3 @@ private:
 
 } // namespace mlpl
 
-#endif // SmartQueue_h

--- a/server/mlpl/src/SmartTime.h
+++ b/server/mlpl/src/SmartTime.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SmartTime_h
-#define SmartTime_h
-
+#pragma once
 #include <time.h>
 #include <ostream>
 #include <stdint.h>
@@ -78,4 +76,3 @@ private:
 
 std::ostream &operator<<(std::ostream &os, const mlpl::SmartTime &stime);
 
-#endif // SmartTime_h

--- a/server/mlpl/src/StringUtils.h
+++ b/server/mlpl/src/StringUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef StringUtils_h
-#define StringUtils_h
-
+#pragma once
 #include <vector>
 #include <list>
 #include <string>
@@ -128,4 +126,3 @@ namespace StringUtils {
 
 } // namespace mlpl
 
-#endif // StringUtils_h

--- a/server/mlpl/test/loggerTester.h
+++ b/server/mlpl/test/loggerTester.h
@@ -16,10 +16,8 @@
  * License along with Hatohol. If not, see
  * <http://www.gnu.org/licenses/>.
  */
-		 
-#ifndef loggerTester_h
-#define loggerTester_h
+
+#pragma once
 
 const static char *testString  = "Logger_Test_Message.";
 
-#endif // loggerTester_h

--- a/server/src/ActionExecArgMaker.h
+++ b/server/src/ActionExecArgMaker.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ActionExecArgMaker_h
-#define ActionExecArgMaker_h
-
+#pragma once
 #include <memory>
 #include "Params.h"
 #include "StringUtils.h"
@@ -42,6 +40,4 @@ protected:
 private:
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // ActionExecArgMaker_h
 

--- a/server/src/ActionManager.h
+++ b/server/src/ActionManager.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ActionManager_h
-#define ActionManager_h
-
+#pragma once
 #include <memory>
 #include "Params.h"
 #include "SmartBuffer.h"
@@ -250,6 +248,4 @@ private:
 	struct ActorProfile;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // ActionManager_h
 

--- a/server/src/ActorCollector.h
+++ b/server/src/ActorCollector.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ActorCollector_h
-#define ActorCollector_h
-
+#pragma once
 #include "HatoholThreadBase.h"
 #include "HatoholError.h"
 
@@ -107,6 +105,4 @@ protected:
 private:
 	struct Impl;
 };
-
-#endif // ActorCollector_h
 

--- a/server/src/ArmBase.h
+++ b/server/src/ArmBase.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmBase_h
-#define ArmBase_h
-
+#pragma once
 #include <string>
 #include "HatoholThreadBase.h"
 #include "DBTablesConfig.h"
@@ -115,4 +113,3 @@ typedef std::vector<ArmBase *>        ArmBaseVector;
 typedef ArmBaseVector::iterator       ArmBaseVectorIterator;
 typedef ArmBaseVector::const_iterator ArmBaseVectorConstIterator;
 
-#endif // ArmBase_h

--- a/server/src/ArmFake.h
+++ b/server/src/ArmFake.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmFake_h
-#define ArmFake_h
-
+#pragma once
 #include "ArmBase.h"
 
 class ArmFake : public ArmBase {
@@ -30,6 +28,4 @@ public:
 protected:
 	virtual ArmPollingResult mainThreadOneProc(void) override;
 };
-
-#endif // ArmFake_h
 

--- a/server/src/ArmIncidentTracker.h
+++ b/server/src/ArmIncidentTracker.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmIncidentTracker_h
-#define ArmIncidentTracker_h
-
+#pragma once
 #include "ArmBase.h"
 #include "DBTablesConfig.h"
 
@@ -44,4 +42,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // ArmIncidentTracker_h

--- a/server/src/ArmRedmine.h
+++ b/server/src/ArmRedmine.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmRedmine_h
-#define ArmRedmine_h
-
+#pragma once
 #include "ArmIncidentTracker.h"
 #include "DBTablesConfig.h"
 
@@ -44,4 +42,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // ArmRedmine_h

--- a/server/src/ArmUtils.h
+++ b/server/src/ArmUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ArmUtils_h
-#define ArmUtils_h
-
+#pragma once
 #include <Monitoring.h>
 #include "DBTablesConfig.h"
 
@@ -53,7 +51,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;;
 };
-
-#endif // ArmUtils_h
-
 

--- a/server/src/ChildProcessManager.h
+++ b/server/src/ChildProcessManager.h
@@ -17,11 +17,9 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ChildProcessManager_h
-#define ChildProcessManager_h
-
+#pragma once
 #include <string>
-#include <sys/types.h> 
+#include <sys/types.h>
 #include <sys/wait.h>
 #include "HatoholThreadBase.h"
 #include "HatoholError.h"
@@ -123,7 +121,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // ChildProcessManager_h
-
 

--- a/server/src/Closure.h
+++ b/server/src/Closure.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Closure_h
-#define Closure_h
-
+#pragma once
 #include <list>
 #include <ReadWriteLock.h>
 
@@ -186,4 +184,3 @@ struct Signal1 : public SignalBase
 	}
 };
 
-#endif // Closure_h

--- a/server/src/ConfigManager.h
+++ b/server/src/ConfigManager.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ConfigManager_h
-#define ConfigManager_h
-
+#pragma once
 #include <glib.h>
 #include <stdint.h>
 #include "DBTablesConfig.h"
@@ -133,4 +131,3 @@ private:
 	virtual ~ConfigManager();
 };
 
-#endif // ConfigManager_h

--- a/server/src/DB.h
+++ b/server/src/DB.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DB_h
-#define DB_h
-
+#pragma once
 #include <memory>
 #include <mutex>
 #include <typeinfo>
@@ -59,4 +57,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DB_h

--- a/server/src/DBAgent.h
+++ b/server/src/DBAgent.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBAgent_h
-#define DBAgent_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <glib.h>
@@ -432,4 +430,3 @@ private:
 	struct Impl;
 };
 
-#endif // DBAgent_h

--- a/server/src/DBAgentFactory.h
+++ b/server/src/DBAgentFactory.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBAgentFactory_h
-#define DBAgentFactory_h
-
+#pragma once
 #include <typeinfo>
 #include "DBAgent.h"
 
@@ -32,4 +30,3 @@ protected:
 	static DBAgent *newDBAgentSQLite3(const DBConnectInfo &connectInfo);
 };
 
-#endif // DBAgentFactory_h

--- a/server/src/DBAgentMySQL.h
+++ b/server/src/DBAgentMySQL.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBAgentMySQL_h
-#define DBAgentMySQL_h
-
+#pragma once
 #include <mysql.h>
 #include "DBAgent.h"
 
@@ -111,4 +109,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBAgentMySQL_h

--- a/server/src/DBAgentSQLite3.h
+++ b/server/src/DBAgentSQLite3.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBAgentSQLite3_h
-#define DBAgentSQLite3_h
-
+#pragma once
 #include <sqlite3.h>
 #include "SQLProcessorTypes.h"
 #include "DBAgent.h"
@@ -135,4 +133,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBAgentSQLite3_h

--- a/server/src/DBClientJoinBuilder.h
+++ b/server/src/DBClientJoinBuilder.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBClientJoin_h
-#define DBClientJoin_h
-
+#pragma once
 #include "DBAgent.h"
 #include "DataQueryOption.h"
 
@@ -118,4 +116,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBClientJoin_h

--- a/server/src/DBHatohol.h
+++ b/server/src/DBHatohol.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBHatohol_h
-#define DBHatohol_h
-
+#pragma once
 #include "DB.h"
 
 class DBTablesConfig;
@@ -65,4 +63,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBHatohol_h

--- a/server/src/DBTables.h
+++ b/server/src/DBTables.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTables_h
-#define DBTables_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <Mutex.h>
@@ -149,4 +147,3 @@ struct SeqTransactionProc :
   public MutableSeqTransactionProc<const T, const SEQ_TYPE> {
 };
 
-#endif // DB_h

--- a/server/src/DBTablesAction.h
+++ b/server/src/DBTablesAction.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesAction_h
-#define DBTablesAction_h
-
+#pragma once
 #include <string>
 #include "DBTablesMonitoring.h"
 #include "DBTables.h"
@@ -429,4 +427,3 @@ private:
 
 };
 
-#endif // DBTablesAction_h

--- a/server/src/DBTablesConfig.h
+++ b/server/src/DBTablesConfig.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesConfig_h
-#define DBTablesConfig_h
-
+#pragma once
 #include "DBTables.h"
 #include "DBTablesMonitoring.h"
 #include "MonitoringServerInfo.h"
@@ -412,4 +410,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBTablesConfig_h

--- a/server/src/DBTablesHost.h
+++ b/server/src/DBTablesHost.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesHost_h
-#define DBTablesHost_h
-
+#pragma once
 #include "DBTables.h"
 #include "DataQueryOption.h"
 #include "HostResourceQueryOption.h"
@@ -428,4 +426,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBTablesHost_h

--- a/server/src/DBTablesLastInfo.h
+++ b/server/src/DBTablesLastInfo.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesLastInfo_h
-#define DBTablesLastInfo_h
-
+#pragma once
 #include <string>
 #include "DBTablesMonitoring.h"
 #include "DBTables.h"
@@ -134,4 +132,3 @@ private:
 
 };
 
-#endif // DBTablesLastInfo_h

--- a/server/src/DBTablesMonitoring.h
+++ b/server/src/DBTablesMonitoring.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesMonitoring_h
-#define DBTablesMonitoring_h
-
+#pragma once
 #include <list>
 #include "DBTables.h"
 #include "DataQueryOption.h"
@@ -432,4 +430,3 @@ void operator>>(ItemGroupStream &itemGroupStream, TriggerStatusType &rhs);
 void operator>>(ItemGroupStream &itemGroupStream, TriggerSeverityType &rhs);
 void operator>>(ItemGroupStream &itemGroupStream, EventType &rhs);
 
-#endif // DBTablesMonitoring_h

--- a/server/src/DBTablesUser.h
+++ b/server/src/DBTablesUser.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTablesUser_h
-#define DBTablesUser_h
-
+#pragma once
 #include <list>
 #include <map>
 #include "DBTables.h"
@@ -286,4 +284,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DBTablesUser_h

--- a/server/src/DBTermCStringProvider.h
+++ b/server/src/DBTermCStringProvider.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTermCStringProvider_h
-#define DBTermCStringProvider_h
-
+#pragma once
 #include <string>
 #include <list>
 #include <stdint.h>
@@ -42,6 +40,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // DBTermCStringProvider_h
 

--- a/server/src/DBTermCodec.h
+++ b/server/src/DBTermCodec.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTermCodec_h
-#define DBTermCodec_h
-
+#pragma once
 #include <string>
 #include <stdint.h>
 
@@ -30,4 +28,3 @@ public:
 	virtual std::string enc(const std::string &val) const;
 };
 
-#endif // DBTermCodec_h

--- a/server/src/DataQueryContext.h
+++ b/server/src/DataQueryContext.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataQueryContext_h
-#define DataQueryContext_h
-
+#pragma once
 #include "Params.h"
 #include "UsedCountable.h"
 #include "UsedCountablePtr.h"
@@ -51,4 +49,3 @@ private:
 
 typedef UsedCountablePtr<DataQueryContext> DataQueryContextPtr;
 
-#endif // DataQueryContext_h

--- a/server/src/DataQueryOption.h
+++ b/server/src/DataQueryOption.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataQueryOption_h
-#define DataQueryOption_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <vector>
@@ -224,4 +222,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DataQueryOption_h

--- a/server/src/DataStore.h
+++ b/server/src/DataStore.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataStore_h
-#define DataStore_h
-
+#pragma once
 #include <map>
 #include <vector>
 #include <Monitoring.h>
@@ -60,4 +58,3 @@ typedef std::vector<std::shared_ptr<DataStore>> DataStoreVector;
 typedef DataStoreVector::iterator               DataStoreVectorIterator;
 typedef DataStoreVector::const_iterator         DataStoreVectorConstIterator;
 
-#endif // DataStore_h

--- a/server/src/DataStoreFactory.h
+++ b/server/src/DataStoreFactory.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataStoreFactory_h
-#define DataStoreFactory_h
-
+#pragma once
 #include <memory>
 #include "DataStore.h"
 
@@ -28,6 +26,4 @@ public:
 	static std::shared_ptr<DataStore> create(const MonitoringServerInfo &svInfo,
 	                         const bool &autoStart = false);
 };
-
-#endif // DataStoreFactory_h
 

--- a/server/src/DataStoreFake.h
+++ b/server/src/DataStoreFake.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataStoreFake_h
-#define DataStoreFake_h
-
+#pragma once
 #include "ArmFake.h"
 #include "DataStore.h"
 
@@ -37,4 +35,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DataStoreFake_h

--- a/server/src/DataStoreManager.h
+++ b/server/src/DataStoreManager.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataStoreManager_h
-#define DataStoreManager_h
-
+#pragma once
 #include <list>
 #include <memory>
 #include "DataStore.h"
@@ -107,4 +105,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // DataStoreManager_h

--- a/server/src/FaceBase.h
+++ b/server/src/FaceBase.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FaceBase_h
-#define FaceBase_h
-
+#pragma once
 #include "HatoholThreadBase.h"
 
 class FaceBase : public HatoholThreadBase {
@@ -27,6 +25,4 @@ public:
 	FaceBase(void);
 	virtual ~FaceBase();
 };
-
-#endif // FaceBase_h
 

--- a/server/src/FaceRest.h
+++ b/server/src/FaceRest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FaceRest_h
-#define FaceRest_h
-
+#pragma once
 #include <libsoup/soup.h>
 #include "FaceBase.h"
 #include "JSONBuilder.h"
@@ -99,4 +97,3 @@ private:
 	static const char *pathForLogout;
 };
 
-#endif // FaceRest_h

--- a/server/src/FaceRestPrivate.h
+++ b/server/src/FaceRestPrivate.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FaceRestPrivate_h
-#define FaceRestPrivate_h
-
+#pragma once
 #include "FaceRest.h"
 #include <StringUtils.h>
 #include <UsedCountable.h>
@@ -234,4 +232,3 @@ bool getParamWithErrorReply(
 	return true;
 }
 
-#endif // FaceRestPrivate_h

--- a/server/src/GateJSONEventMessage.h
+++ b/server/src/GateJSONEventMessage.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef GateJSONEventMessage_h
-#define GateJSONEventMessage_h
-
+#pragma once
 #include <json-glib/json-glib.h>
 
 #include <string>
@@ -52,6 +50,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // GateJSONEventMessage_h
 

--- a/server/src/Hatohol.h
+++ b/server/src/Hatohol.h
@@ -17,15 +17,11 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Hatohol_h
-#define Hatohol_h
-
+#pragma once
 #include "Utils.h"
 #include "ConfigManager.h"
 
 void hatoholInit(const CommandLineOptions *cmdLineOpts = NULL,
                  const bool &dontCareChildProcessManager = false);
 void hatoholInitChildProcessManager(void);
-
-#endif // Hatohol_h
 

--- a/server/src/HatoholArmPluginGateHAPI2.h
+++ b/server/src/HatoholArmPluginGateHAPI2.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholArmPluginGateHAPI2_h
-#define HatoholArmPluginGateHAPI2_h
-
+#pragma once
 #include "DataStore.h"
 #include "HatoholArmPluginInterfaceHAPI2.h"
 #include "JSONBuilder.h"
@@ -114,4 +112,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // HatoholArmPluginGateHAPI2_h

--- a/server/src/HatoholArmPluginGateJSON.h
+++ b/server/src/HatoholArmPluginGateJSON.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholArmPluginGateJSON_h
-#define HatoholArmPluginGateJSON_h
-
+#pragma once
 #include "DataStore.h"
 
 class HatoholArmPluginGateJSON : public DataStore {
@@ -36,6 +34,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // HatoholArmPluginGateJSON_h
 

--- a/server/src/HatoholDBUtils.h
+++ b/server/src/HatoholDBUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholDBUtils_h
-#define HatoholDBUtils_h
-
+#pragma once
 #include "DBTablesMonitoring.h"
 #include "HostInfoCache.h"
 
@@ -90,4 +88,3 @@ protected:
 	  HistoryInfo &historyInfo, const ItemGroup *item);
 };
 
-#endif // HatoholDBUtils_h

--- a/server/src/HostInfoCache.h
+++ b/server/src/HostInfoCache.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HostInfoCache_h
-#define HostInfoCache_h
-
+#pragma once
 #include <string>
 #include "DBTablesMonitoring.h"
 
@@ -70,4 +68,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // HostInfoCache_h

--- a/server/src/HostResourceQueryOption.h
+++ b/server/src/HostResourceQueryOption.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HostResourceQueryOption_h
-#define HostResourceQueryOption_h
-
+#pragma once
 #include <string>
 #include "Params.h"
 #include "DBAgent.h"
@@ -249,4 +247,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // HostResourceQueryOption_h

--- a/server/src/IncidentSender.h
+++ b/server/src/IncidentSender.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef IncidentSender_h
-#define IncidentSender_h
-
+#pragma once
 #include "HatoholError.h"
 #include "DBTablesConfig.h"
 #include "DBTablesMonitoring.h"
@@ -193,4 +191,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // IncidentSender_h

--- a/server/src/IncidentSenderHatohol.h
+++ b/server/src/IncidentSenderHatohol.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef IncidentSenderHatohol_h
-#define IncidentSenderHatohol_h
-
+#pragma once
 #include "IncidentSender.h"
 
 class IncidentSenderHatohol : public IncidentSender
@@ -45,4 +43,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // IncidentSenderHatohol_h

--- a/server/src/IncidentSenderManager.h
+++ b/server/src/IncidentSenderManager.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef IncidentSenderManager_h
-#define IncidentSenderManager_h
-
+#pragma once
 #include "Params.h"
 #include "DBTablesMonitoring.h"
 #include "IncidentSender.h"
@@ -93,4 +91,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // IncidentSenderManager_h

--- a/server/src/IncidentSenderRedmine.h
+++ b/server/src/IncidentSenderRedmine.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef IncidentSenderRedmine_h
-#define IncidentSenderRedmine_h
-
+#pragma once
 #include "IncidentSender.h"
 
 class IncidentSenderRedmine : public IncidentSender
@@ -60,4 +58,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // IncidentSenderRedmine_h

--- a/server/src/ItemFetchWorker.h
+++ b/server/src/ItemFetchWorker.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemFetchWorker_h
-#define ItemFetchWorker_h
-
+#pragma once
 #include <deque>
 #include <memory>
 #include "Params.h"
@@ -48,4 +46,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // ItemFetchWorker_h

--- a/server/src/ItemGroupEnum.h
+++ b/server/src/ItemGroupEnum.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemGroupEnum_h
-#define ItemGroupEnum_h
+#pragma once
 
 enum
 {
@@ -49,4 +48,3 @@ enum
 	GROUP_ID_ZBX_DRULES,
 };
 
-#endif // ItemGroupEnum_h

--- a/server/src/ItemGroupStream.h
+++ b/server/src/ItemGroupStream.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemGroupStream_h 
-#define ItemGroupStream_h
-
+#pragma once
 #include <string>
 #include "ItemGroup.h"
 
@@ -131,6 +129,4 @@ private:
 template<> uint64_t ItemGroupStream::read<std::string, uint64_t>(void);
 template<> std::string ItemGroupStream::read<int, std::string>(void);
 template<> std::string ItemGroupStream::read<uint64_t, std::string>(void);
-
-#endif // ItemGroupStream_h
 

--- a/server/src/ItemTableUtils.h
+++ b/server/src/ItemTableUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ItemTableUtils_h 
-#define ItemTableUtils_h
-
+#pragma once
 #include <string>
 #include "ItemTable.h"
 #include "HatoholException.h"
@@ -50,4 +48,3 @@ public:
 	}
 };
 
-#endif // ItemTableUtils_h

--- a/server/src/LabelUtils.h
+++ b/server/src/LabelUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LabelUtils_h
-#define LabelUtils_h
-
+#pragma once
 #include <string>
 #include "DBTablesMonitoring.h"
 
@@ -30,4 +28,3 @@ public:
 	static std::string getTriggerSeverityLabel(TriggerSeverityType severity);
 };
 
-#endif // LabelUtils_h

--- a/server/src/OperationPrivilege.h
+++ b/server/src/OperationPrivilege.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OperationPrivilege_h
-#define OperationPrivilege_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include "Params.h"
@@ -114,4 +112,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // OperationPrivilege_h

--- a/server/src/ResidentCommunicator.h
+++ b/server/src/ResidentCommunicator.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ResidentCommunicator_h
-#define ResidentCommunicator_h
-
+#pragma once
 #include <cstdio>
 #include <string>
 #include "ResidentProtocol.h"
@@ -126,4 +124,3 @@ private:
 	NamedPipe  *m_pipe;
 };
 
-#endif // ResidentCommunicator_h

--- a/server/src/ResidentProtocol.h
+++ b/server/src/ResidentProtocol.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ResidentProtocol_h
-#define ResidentProtocol_h
-
+#pragma once
 #include <cstdlib>
 #include <stdint.h>
 #include <SmartBuffer.h>
@@ -179,4 +177,3 @@ enum {
 	RESIDENT_MOD_NOTIFY_EVENT_ACK_OK,
 };
 
-#endif // ResidentProtocol_h

--- a/server/src/RestResourceAction.h
+++ b/server/src/RestResourceAction.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceAction_h
-#define RestResourceAction_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceAction : public FaceRest::ResourceHandler
@@ -39,4 +37,3 @@ struct RestResourceAction : public FaceRest::ResourceHandler
 	static const char *pathForAction;
 };
 
-#endif // RestResourceAction_h

--- a/server/src/RestResourceCustomIncidentStatus.h
+++ b/server/src/RestResourceCustomIncidentStatus.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceCustomIncidentStatus_h
-#define RestResourceCustomIncidentStatus_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceCustomIncidentStatus : public FaceRest::ResourceHandler
@@ -38,4 +36,3 @@ struct RestResourceCustomIncidentStatus : public FaceRest::ResourceHandler
 	static const char *pathForCustomIncidentStatus;
 };
 
-#endif // RestResourceCustomIncidentStatus_h

--- a/server/src/RestResourceIncident.h
+++ b/server/src/RestResourceIncident.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceIncident_h
-#define RestResourceIncident_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceIncident : public RestResourceMemberHandler
@@ -51,4 +49,3 @@ struct RestResourceIncident : public RestResourceMemberHandler
 	void updateIncidentHistory(IncidentHistory &history);
 };
 
-#endif // RestResourceIncident_h

--- a/server/src/RestResourceIncidentTracker.h
+++ b/server/src/RestResourceIncidentTracker.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceIncidentTracker_h
-#define RestResourceIncidentTracker_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceIncidentTracker : public FaceRest::ResourceHandler
@@ -39,4 +37,3 @@ struct RestResourceIncidentTracker : public FaceRest::ResourceHandler
 	static const char *pathForIncidentTracker;
 };
 
-#endif // RestResourceIncidentTracker_h

--- a/server/src/RestResourceMonitoring.h
+++ b/server/src/RestResourceMonitoring.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceMonitoring_h
-#define RestResourceMonitoring_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceMonitoring : public RestResourceMemberHandler
@@ -61,4 +59,3 @@ struct RestResourceMonitoring : public RestResourceMemberHandler
 	static const char *pathForTriggerBriefs;
 };
 
-#endif // RestResourceMonitoring_h

--- a/server/src/RestResourceServer.h
+++ b/server/src/RestResourceServer.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceServer_h
-#define RestResourceServer_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceServer : public RestResourceMemberHandler
@@ -47,4 +45,3 @@ struct RestResourceServer : public RestResourceMemberHandler
 	void triggerFetchedCallback(Closure0 *closure);
 };
 
-#endif // RestResourceServer_h

--- a/server/src/RestResourceSeverityRank.h
+++ b/server/src/RestResourceSeverityRank.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceSeverityRank_h
-#define RestResourceSeverityRank_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceSeverityRank : public FaceRest::ResourceHandler
@@ -39,4 +37,3 @@ struct RestResourceSeverityRank : public FaceRest::ResourceHandler
 	static const char *pathForSeverityRank;
 };
 
-#endif // RestResourceSeverityRank_h

--- a/server/src/RestResourceSummary.h
+++ b/server/src/RestResourceSummary.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceSummary_h
-#define RestResourceSummary_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceSummary : public RestResourceMemberHandler
@@ -35,4 +33,3 @@ public:
 	void handlerImportantEventSummary(void);
 };
 
-#endif // RestResourceSummary_h

--- a/server/src/RestResourceSystem.h
+++ b/server/src/RestResourceSystem.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceSystem_h
-#define RestResourceSystem_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceSystem : public RestResourceMemberHandler
@@ -34,6 +32,4 @@ public:
 	RestResourceSystem(FaceRest *faceRest, HandlerFunc handler);
 	void handlerSystemInfo(void);
 };
-
-#endif // RestResourceSystem_h
 

--- a/server/src/RestResourceUser.h
+++ b/server/src/RestResourceUser.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceUser_h
-#define RestResourceUser_h
-
+#pragma once
 #include "FaceRestPrivate.h"
 
 struct RestResourceUser : public RestResourceMemberHandler
@@ -72,4 +70,3 @@ struct RestResourceUser : public RestResourceMemberHandler
 	static const std::string pathForUserMe;
 };
 
-#endif // RestResourceUser_h

--- a/server/src/RestResourceUtils.h
+++ b/server/src/RestResourceUtils.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RestResourceUtils_h
-#define RestResourceUtils_h
+#pragma once
 
 class RestResourceUtils {
 public:
@@ -41,4 +40,3 @@ public:
 	  GHashTable *query);
 };
 
-#endif // RestResourceUtils_h

--- a/server/src/SQLProcessorTypes.h
+++ b/server/src/SQLProcessorTypes.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SQLProcessorTypes_h
-#define SQLProcessorTypes_h
-
+#pragma once
 #include <list>
 #include "ItemTablePtr.h"
 
@@ -69,4 +67,3 @@ typedef std::list<ColumnDef>          ColumnDefList;
 typedef ColumnDefList::iterator       ColumnDefListIterator;
 typedef ColumnDefList::const_iterator ColumnDefListConstIterator;
 
-#endif // SQLProcessorTypes_h

--- a/server/src/SQLUtils.h
+++ b/server/src/SQLUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SQLUtils_h
-#define SQLUtils_h
-
+#pragma once
 #include "ItemDataPtr.h"
 #include "SQLProcessorTypes.h"
 
@@ -28,6 +26,4 @@ public:
 	static ItemDataPtr createFromString(const char *str,
 	                                    SQLColumnType type);
 };
-
-#endif // SQLUtils_h
 

--- a/server/src/SelfMonitor.h
+++ b/server/src/SelfMonitor.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SelfMonitor_h
-#define SelfMonitor_h
-
+#pragma once
 #include <list>
 #include <memory>
 #include <UsedCountable.h>
@@ -141,4 +139,3 @@ private:
 
 typedef std::list<SelfMonitorWeakPtr> SelfMonitorWeakPtrList;
 
-#endif // SelfMonitor_h

--- a/server/src/SessionManager.h
+++ b/server/src/SessionManager.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SessionManager_h
-#define SessionManager_h
-
+#pragma once
 #include <string>
 #include <memory>
 #include <map>
@@ -133,4 +131,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // SessionManager_h

--- a/server/src/StatisticsCounter.h
+++ b/server/src/StatisticsCounter.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef StatisticsCounter_h
-#define StatisticsCounter_h
-
+#pragma once
 #include <memory>
 #include <SmartTime.h>
 
@@ -56,6 +54,4 @@ private:
 	struct Impl;
 	std::unique_ptr<Impl> m_impl;
 };
-
-#endif // StatisticsCounter_h
 

--- a/server/src/ThreadLocalDBCache.h
+++ b/server/src/ThreadLocalDBCache.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ThreadLocalDBCache_h
-#define ThreadLocalDBCache_h
-
+#pragma once
 #include "DBTablesMonitoring.h"
 #include "DBTablesUser.h"
 #include "DBTablesConfig.h"
@@ -60,4 +58,3 @@ private:
 	struct Impl;
 };
 
-#endif // ThreadLocalDBCache_h

--- a/server/src/TriggerFetchWorker.h
+++ b/server/src/TriggerFetchWorker.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TriggerFetchWorker_h
-#define TriggerFetchWorker_h
-
+#pragma once
 #include <deque>
 #include <memory>
 #include "Params.h"
@@ -47,4 +45,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // TriggerFetchWorker_h

--- a/server/src/UnifiedDataStore.h
+++ b/server/src/UnifiedDataStore.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef UnifiedDataStore_h
-#define UnifiedDataStore_h
-
+#pragma once
 #include <memory>
 #include "ArmBase.h"
 #include "DBTablesMonitoring.h"
@@ -371,4 +369,3 @@ private:
 	std::unique_ptr<Impl> m_impl;
 };
 
-#endif // UnifiedDataStore_h

--- a/server/test/ActionTp.h
+++ b/server/test/ActionTp.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ActionTp_h
-#define ActionTp_h
-
+#pragma once
 #include <stdint.h>
 
 enum {
@@ -37,6 +35,4 @@ static const size_t ACTTP_SESSION_ID_LEN = 36;
 
 #define OPTION_CRASH_SOON "--crash-soon"
 #define OPTION_STALL      "--stall"
-
-#endif // ActionTp_h
 

--- a/server/test/AssertJoin.h
+++ b/server/test/AssertJoin.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef AssertJoin_h
-#define AssertJoin_h
-
+#pragma once
 #include "Helpers.h"
 
 template <typename RefDataType0, typename RefDataType1>
@@ -163,4 +161,3 @@ public:
 
 #undef BASE
 
-#endif // AssertJoin_h

--- a/server/test/DBAgentTest.h
+++ b/server/test/DBAgentTest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBAgentTestCommon_h
-#define DBAgentTestCommon_h
-
+#pragma once
 #include <cppcutter.h>
 #include "SQLProcessorTypes.h"
 #include "DBAgent.h"
@@ -132,4 +130,3 @@ void dbAgentGetLastInsertId(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentGetNumberOfAffectedRows(DBAgent &dbAgent, DBAgentChecker &checker);
 void dbAgentUpsertBySameData(DBAgent &dbAgent, DBAgentChecker &checker);
 
-#endif // DBAgentTestCommon_h

--- a/server/test/DBTablesTest.h
+++ b/server/test/DBTablesTest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBClientTest_h
-#define DBClientTest_h
-
+#pragma once
 #include <map>
 #include <set>
 #include <SmartTime.h>
@@ -293,4 +291,3 @@ void loadTestDBSeverityRankInfo(void);
 void loadTestDBCustomIncidentStatusInfo(void);
 void loadTestDBIncidentHistory(void);
 
-#endif // DBClientTest_h

--- a/server/test/DBTest.h
+++ b/server/test/DBTest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DBTest_h
-#define DBTest_h
-
+#pragma once
 #include "DB.h"
 
 class TestDB : public DB {
@@ -31,8 +29,4 @@ public:
 private:
 	static SetupContext m_setupCtx;
 };
-
-
-#endif // DBTest_h
-
 

--- a/server/test/DataSamples.h
+++ b/server/test/DataSamples.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DataSamples_h
-#define DataSamples_h
+#pragma once
 
 void addDataSamplesForGCutBool(void);
 void addDataSamplesForGCutInt(void);
@@ -26,4 +25,3 @@ void addDataSamplesForGCutUint64(void);
 void addDataSamplesForGCutDouble(void);
 void addDataSamplesForGCutString(void);
 
-#endif // DataSamples_h

--- a/server/test/ExceptionTestUtils.h
+++ b/server/test/ExceptionTestUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ExceptionTestUtils_h
-#define ExceptionTestUtils_h
-
+#pragma once
 #include <cppcutter.h>
 
 template<class ThrowExceptionType, class CaughtExceptionType>
@@ -42,4 +40,3 @@ void _assertThrow(void (*catchCb)(const CaughtExceptionType &e) = NULL)
 }
 #define assertThrow(T,C,...) cut_trace((_assertThrow<T,C>(__VA_ARGS__)))
 
-#endif // ExceptionTestUtils_h

--- a/server/test/FaceRestTestUtils.h
+++ b/server/test/FaceRestTestUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef FaceRestTestUtils_h
-#define FaceRestTestUtils_h
-
+#pragma once
 #include <string>
 #include "StringUtils.h"
 #include "Params.h"
@@ -108,4 +106,3 @@ void _assertUpdateRecord(const StringMap &params, const std::string &baseUrl,
 
 void assertServersIdNameHashInParser(JSONParser *parser);
 
-#endif // FaceRestTestUtils_h

--- a/server/test/HatoholArmPluginGateTest.h
+++ b/server/test/HatoholArmPluginGateTest.h
@@ -17,8 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholArmPluginGateTest_h
-#define HatoholArmPluginGateTest_h
+#pragma once
 #include <string>
 #include <exception>
 #include <qpid/messaging/Session.h>
@@ -114,4 +113,3 @@ private:
 
 typedef UsedCountablePtr<HatoholArmPluginGateTest> HatoholArmPluginGateTestPtr;
 
-#endif // HatoholArmPluginGateTest_h

--- a/server/test/HatoholArmPluginInterfaceTest.h
+++ b/server/test/HatoholArmPluginInterfaceTest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HatoholArmPluginInterfaces_h
-#define HatoholArmPluginInterfaces_h
-
+#pragma once
 #include <string>
 #include <SimpleSemaphore.h>
 #include <SmartBuffer.h>
@@ -117,4 +115,3 @@ private:
 	mlpl::AtomicValue<bool> m_msgIntercept;
 };
 
-#endif // HatoholArmPluginInterfaces_h

--- a/server/test/Helpers.h
+++ b/server/test/Helpers.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Helpers_h
-#define Helpers_h
-
+#pragma once
 #include <cppcutter.h>
 #include <StringUtils.h>
 #include <Mutex.h>
@@ -450,4 +448,3 @@ private:
 	bool        m_hasOrigValue;
 };
 
-#endif // Helpers_h

--- a/server/test/HttpServerStub.h
+++ b/server/test/HttpServerStub.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef HttpServer_h
-#define HttpServer_h
-
+#pragma once
 #include <string>
 #include <libsoup/soup.h>
 #include "JSONParser.h"
@@ -48,4 +46,3 @@ private:
 	PrivateContext *m_ctx;
 };
 
-#endif // HttpServer_h

--- a/server/test/MultiLangTest.h
+++ b/server/test/MultiLangTest.h
@@ -17,10 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MultiLangTest_h
-#define MultiLangTest_h
+#pragma once
 
 #define COMMAND_EX_JP "/usr/bin/紅蓮・憂鬱／葡萄 -l 'キノコ たけのこ'"
-
-#endif // MultiLangTest_h
 

--- a/server/test/RedmineAPIEmulator.h
+++ b/server/test/RedmineAPIEmulator.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef RedmineAPIEmulator_h
-#define RedmineAPIEmulator_h
-
+#pragma once
 #include "HttpServerStub.h"
 
 struct RedmineIssue {
@@ -85,6 +83,4 @@ private:
 
 extern const guint EMULATOR_PORT;
 extern RedmineAPIEmulator g_redmineEmulator;
-
-#endif // ZabbixAPIEmulator_h
 

--- a/server/test/Synchronizer.h
+++ b/server/test/Synchronizer.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef Synchronizer_h
-#define Synchronizer_h
-
+#pragma once
 #include <glib.h>
 #include <Mutex.h>
 
@@ -36,4 +34,3 @@ public:
 	void wait(void);
 };
 
-#endif // Synchronizer_h

--- a/server/test/TestHostResourceQueryOption.h
+++ b/server/test/TestHostResourceQueryOption.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TestHostResourceQueryOption_h
-#define TestHostResourceQueryOption_h
-
+#pragma once
 #include <string>
 #include <HostResourceQueryOption.h>
 
@@ -40,4 +38,3 @@ public:
 	void callSetValidServerIdSet(const ServerIdSet *set);
 };
 
-#endif // TestHostResourceQueryOption_h

--- a/server/test/ZabbixAPIEmulator.h
+++ b/server/test/ZabbixAPIEmulator.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZabbixAPIEmulator_h
-#define ZabbixAPIEmulator_h
-
+#pragma once
 #include <map>
 #include <glib.h>
 #include <libsoup/soup.h>
@@ -105,4 +103,3 @@ private:
 	PrivateContext *m_ctx;
 };
 
-#endif // ZabbixAPIEmulator_h

--- a/server/test/ZabbixAPITestUtils.h
+++ b/server/test/ZabbixAPITestUtils.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ZabbixAPITestUtils_h
-#define ZabbixAPITestUtils_h
-
+#pragma once
 #include <string>
 #include <cppcutter.h>
 #include "ZabbixAPI.h"
@@ -97,4 +95,3 @@ void _assertCheckAPIVersion(bool expected, int major, int minor , int micro);
 #define assertCheckAPIVersion(EXPECTED,MAJOR,MINOR,MICRO) \
   cut_trace(_assertCheckAPIVersion(EXPECTED,MAJOR,MINOR,MICRO))
 
-#endif // ZabbixAPITestUtils_h

--- a/server/test/residentTest.h
+++ b/server/test/residentTest.h
@@ -17,9 +17,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#ifndef residentTest_h
-#define residentTest_h
-
+#pragma once
 #include "ResidentProtocol.h"
 
 enum ResidentTestCmdType {
@@ -36,4 +34,3 @@ const char *TEST_HOST_ID_REPLY_MAGIC_CODE = (const char *)0x12345678;
 const char *TEST_TRIGGER_ID_REPLY_MAGIC_CODE = (const char *)0x122333;
 const char *TEST_EVENT_ID_REPLY_MAGIC_CODE   = (const char *)0x76543210;
 
-#endif // residentTest_h


### PR DESCRIPTION
インクルードガードを#pragma onceに置き換えました.
#pragma onceは標準化されていませんが, 実装していないコンパイラのほうが少ないので問題ないと思います.