### PR TITLE
Remove Utils::getCurrTimeAsMicroSecond

### DIFF
--- a/server/common/Utils.cc
+++ b/server/common/Utils.cc
@@ -92,18 +92,6 @@ string Utils::demangle(const string &str)
 	return demangledStr;
 }
 
-uint64_t Utils::getCurrTimeAsMicroSecond(void)
-{
-	struct timeval tv;
-	if (gettimeofday(&tv, NULL) == -1) {
-		MLPL_ERR("Failed to call gettimeofday: %d\n", errno);
-		return 0;
-	}
-	uint64_t currTime = tv.tv_usec;
-	currTime += 1000 * 1000 * tv.tv_sec;
-	return currTime;
-}
-
 bool Utils::isValidPort(int port, bool showErrorMsg)
 {
 	if (port < 0 || port >= 65536) {

--- a/server/common/Utils.h
+++ b/server/common/Utils.h
@@ -58,7 +58,6 @@ public:
 	static std::string makeDemangledStackTraceLines(void **trace, int num);
 	static void assertNotNull(const void *ptr);
 	static std::string demangle(const std::string &str);
-	static uint64_t getCurrTimeAsMicroSecond(void);
 	static bool isValidPort(int port, bool showErrorMsg = true);
 	static std::string getExtension(const std::string &path);
 	static bool validateJSMethodName(const std::string &name,

--- a/server/test/testUtils.cc
+++ b/server/test/testUtils.cc
@@ -127,21 +127,6 @@ void cut_teardown(void)
 // ---------------------------------------------------------------------------
 // Test cases
 // ---------------------------------------------------------------------------
-void test_getCurrTimeAsMicroSecond(void)
-{
-	const size_t allowedErrorInMicroSec = 100 * 1000; // 100 ms
-	struct timeval tv;
-	cppcut_assert_equal(0, gettimeofday(&tv, NULL),
-	                    cut_message("errno: %d", errno));
-	uint64_t currTime = Utils::getCurrTimeAsMicroSecond();
-	uint64_t timeError = currTime;
-	timeError -= tv.tv_sec * 1000 * 1000;
-	timeError -= tv.tv_usec;
-	cppcut_assert_equal(true, timeError < allowedErrorInMicroSec);
-	if (isVerboseMode())
-		cut_notify("timeError: %" PRIu64 " [us]", timeError);
-}
-
 void test_validateJSMethodName(void)
 {
 	assertValidateJSMethodName("IYHoooo_21", true);


### PR DESCRIPTION
もしかしてデバッグで使ってたりしますか?