### PR TITLE
Disabled host name and host group name filter when select server

### DIFF
--- a/client/static/js/events_view.js
+++ b/client/static/js/events_view.js
@@ -632,6 +632,10 @@ var EventsView = function(userProfile, options) {
     if (serverId) {
       removeUnselectableFilterCandidates(filterConfig, "hostgroup", serverId);
       removeUnselectableFilterCandidates(filterConfig, "host", serverId);
+      $("#select-hostname").val("");
+      $("#select-host-group-name").val("");
+      $("#select-hostname").prop("disabled", true);
+      $("#select-host-group-name").prop("disabled", true);
     }
 
     refreshSelectPickers();
@@ -1625,7 +1629,7 @@ var EventsView = function(userProfile, options) {
         ++commentCount;
     }
     $tr.find(".userCommentCount").text(commentCount);
-    
+
     // TODO: Should we also update self.rawData?
   }
 


### PR DESCRIPTION
#2524 の修正です.
イベント, トリガー画面において"監視サーバー"を選択した際に"ホスト名", "ホストグループ名"がDisabledになるように修正しました.